### PR TITLE
feat: add dark mode with toggle button and persistent theme preference

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,7 @@
   --color-user-bg: var(--user-bg);
   --color-assistant-bg: var(--assistant-bg);
   --color-tool-bg: var(--tool-bg);
+  --color-bg-subtle: var(--bg-subtle);
   --font-mono-font: var(--font-mono);
 }
 
@@ -31,6 +32,24 @@
   --user-bg: #eff6ff;
   --assistant-bg: #ffffff;
   --tool-bg: #f9fafb;
+  --bg-subtle: rgba(0,0,0,0.03);
+}
+
+html.dark {
+  --bg: #1a1a1a;
+  --bg-panel: #242424;
+  --bg-hover: #2e2e2e;
+  --bg-selected: #383838;
+  --border: #3a3a3a;
+  --text: #e8e8e8;
+  --text-muted: #9ca3af;
+  --text-dim: #6b7280;
+  --accent: #60a5fa;
+  --accent-hover: #93c5fd;
+  --user-bg: #1e293b;
+  --assistant-bg: #1a1a1a;
+  --tool-bg: #1f2937;
+  --bg-subtle: rgba(255,255,255,0.04);
 }
 
 * {

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,21 @@ html.dark {
   --bg-subtle: rgba(255,255,255,0.04);
 }
 
+/* Theme toggle: circular wipe via View Transitions API.
+   Disable the UA cross-fade; the actual clip-path animation is driven by
+   Element.animate() in hooks/useTheme.ts after transition.ready resolves. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+  z-index: 1;
+}
+::view-transition-new(root) {
+  z-index: 2;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={notoSansMono.variable}>
+    <html lang="en" className={notoSansMono.variable} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("pi-theme");if(t==="dark")document.documentElement.classList.add("dark")}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
         {children}
       </body>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -554,7 +554,6 @@ export function AppShell() {
               onSystemPromptChange={handleSystemPromptChange}
               onSessionStatsChange={handleSessionStatsChange}
               onContextUsageChange={handleContextUsageChange}
-              isDark={isDark}
             />
           ) : showPlaceholder ? (
             activeCwd ? (
@@ -605,7 +604,7 @@ export function AppShell() {
         {/* File content */}
         <div style={{ flex: 1, overflow: "hidden" }}>
           {activeFileTab?.filePath ? (
-            <FileViewer filePath={activeFileTab.filePath} cwd={activeCwd ?? undefined} isDark={isDark} />
+            <FileViewer filePath={activeFileTab.filePath} cwd={activeCwd ?? undefined} />
           ) : (
             <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-dim)", fontSize: 12 }}>
               No file open

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -9,12 +9,14 @@ import { TabBar, type Tab } from "./TabBar";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { BranchNavigator } from "./BranchNavigator";
+import { useTheme } from "@/hooks/useTheme";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ChatInputHandle } from "./ChatInput";
 
 export function AppShell() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isDark, toggleTheme } = useTheme();
   const [selectedSession, setSelectedSession] = useState<SessionInfo | null>(null);
   // When user clicks +, we only store the cwd — no fake session id
   const [newSessionCwd, setNewSessionCwd] = useState<string | null>(null);
@@ -268,8 +270,26 @@ export function AppShell() {
               </svg>
             ),
           },
+          {
+            label: isDark ? "Light" : "Dark",
+            onClick: toggleTheme,
+            disabled: false,
+            icon: isDark ? (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="5" />
+                <line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+              </svg>
+            ),
+          },
 
-        ] as const).map(({ label, onClick, disabled, icon }) => (
+        ] as { label: string; onClick: () => void; disabled: boolean; icon: React.ReactNode }[]).map(({ label, onClick, disabled, icon }) => (
           <button
             key={label}
             onClick={onClick}
@@ -534,6 +554,7 @@ export function AppShell() {
               onSystemPromptChange={handleSystemPromptChange}
               onSessionStatsChange={handleSessionStatsChange}
               onContextUsageChange={handleContextUsageChange}
+              isDark={isDark}
             />
           ) : showPlaceholder ? (
             activeCwd ? (
@@ -584,7 +605,7 @@ export function AppShell() {
         {/* File content */}
         <div style={{ flex: 1, overflow: "hidden" }}>
           {activeFileTab?.filePath ? (
-            <FileViewer filePath={activeFileTab.filePath} cwd={activeCwd ?? undefined} />
+            <FileViewer filePath={activeFileTab.filePath} cwd={activeCwd ?? undefined} isDark={isDark} />
           ) : (
             <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-dim)", fontSize: 12 }}>
               No file open

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -270,25 +270,6 @@ export function AppShell() {
               </svg>
             ),
           },
-          {
-            label: isDark ? "Light" : "Dark",
-            onClick: toggleTheme,
-            disabled: false,
-            icon: isDark ? (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="5" />
-                <line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" />
-                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-                <line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" />
-                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-              </svg>
-            ) : (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-            ),
-          },
-
         ] as { label: string; onClick: () => void; disabled: boolean; icon: React.ReactNode }[]).map(({ label, onClick, disabled, icon }) => (
           <button
             key={label}
@@ -369,6 +350,37 @@ export function AppShell() {
             ) : (
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            )}
+          </button>
+          <button
+            onClick={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              toggleTheme({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+            }}
+            title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            aria-pressed={isDark}
+            style={{
+              display: "flex", alignItems: "center", justifyContent: "center",
+              width: 36, height: 36, padding: 0,
+              background: "none", border: "none", borderRight: "1px solid var(--border)",
+              color: "var(--text-muted)", cursor: "pointer", flexShrink: 0, transition: "color 0.12s",
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; }}
+          >
+            {isDark ? (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="5" />
+                <line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+            ) : (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
               </svg>
             )}
           </button>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -21,7 +21,6 @@ interface Props {
   onSystemPromptChange?: (prompt: string | null) => void;
   onSessionStatsChange?: (stats: { tokens: { input: number; output: number; cacheRead: number; cacheWrite: number }; cost?: number } | null) => void;
   onContextUsageChange?: (usage: { percent: number | null; contextWindow: number; tokens: number | null } | null) => void;
-  isDark?: boolean;
 }
 
 function phaseLabel(phase: AgentPhase): string {
@@ -91,7 +90,7 @@ function Typewriter({ phrases }: { phrases: string[] }) {
   );
 }
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange, isDark }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange }: Props) {
   const {
     loading, error, messages, entryIds, streamState,
     agentRunning, modelNames, modelList, toolPreset, thinkingLevel,
@@ -328,7 +327,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as import("@/lib/types").AgentMessage & { timestamp?: number }).timestamp : undefined}
-                    isDark={isDark}
                   />
                 );
                 if (!isVisible) return view;
@@ -344,7 +342,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
             })()}
 
             {streamState.isStreaming && streamState.streamingMessage && (
-              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} isDark={isDark} />
+              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
             )}
 
             {agentRunning && !streamState.streamingMessage && (

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -21,6 +21,7 @@ interface Props {
   onSystemPromptChange?: (prompt: string | null) => void;
   onSessionStatsChange?: (stats: { tokens: { input: number; output: number; cacheRead: number; cacheWrite: number }; cost?: number } | null) => void;
   onContextUsageChange?: (usage: { percent: number | null; contextWindow: number; tokens: number | null } | null) => void;
+  isDark?: boolean;
 }
 
 function phaseLabel(phase: AgentPhase): string {
@@ -90,7 +91,7 @@ function Typewriter({ phrases }: { phrases: string[] }) {
   );
 }
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange, isDark }: Props) {
   const {
     loading, error, messages, entryIds, streamState,
     agentRunning, modelNames, modelList, toolPreset, thinkingLevel,
@@ -327,6 +328,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as import("@/lib/types").AgentMessage & { timestamp?: number }).timestamp : undefined}
+                    isDark={isDark}
                   />
                 );
                 if (!isVisible) return view;
@@ -342,7 +344,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
             })()}
 
             {streamState.isStreaming && streamState.streamingMessage && (
-              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
+              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} isDark={isDark} />
             )}
 
             {agentRunning && !streamState.streamingMessage && (

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -6,11 +6,11 @@ import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useTheme } from "@/hooks/useTheme";
 
 interface Props {
   filePath: string;
   cwd?: string;
-  isDark?: boolean;
 }
 
 interface FileData {
@@ -394,14 +394,15 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   );
 }
 
-export function FileViewer({ filePath, cwd, isDark }: Props) {
+export function FileViewer({ filePath, cwd }: Props) {
   if (isImagePath(filePath)) {
     return <ImageViewer filePath={filePath} cwd={cwd} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} isDark={isDark} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} />;
 }
 
-function TextFileViewer({ filePath, cwd, isDark }: Props) {
+function TextFileViewer({ filePath, cwd }: Props) {
+  const { isDark } = useTheme();
   const [data, setData] = useState<FileData | null>(null);
   const [prevContent, setPrevContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface Props {
   filePath: string;
   cwd?: string;
+  isDark?: boolean;
 }
 
 interface FileData {
@@ -392,14 +394,14 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   );
 }
 
-export function FileViewer({ filePath, cwd }: Props) {
+export function FileViewer({ filePath, cwd, isDark }: Props) {
   if (isImagePath(filePath)) {
     return <ImageViewer filePath={filePath} cwd={cwd} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} isDark={isDark} />;
 }
 
-function TextFileViewer({ filePath, cwd }: Props) {
+function TextFileViewer({ filePath, cwd, isDark }: Props) {
   const [data, setData] = useState<FileData | null>(null);
   const [prevContent, setPrevContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -661,7 +663,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
           <iframe
             srcDoc={data.content}
             sandbox="allow-scripts"
-            style={{ width: "100%", height: "100%", border: "none", background: "#fff" }}
+            style={{ width: "100%", height: "100%", border: "none", background: "var(--bg)" }}
             title="HTML preview"
           />
         ) : isMarkdown && previewMode ? (
@@ -674,7 +676,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
         ) : (
           <SyntaxHighlighter
             language={data.language === "text" ? "plaintext" : data.language}
-            style={vs}
+            style={isDark ? vscDarkPlus : vs}
             showLineNumbers
             lineNumberStyle={{
               color: "var(--text-dim)",

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { useTheme } from "@/hooks/useTheme";
 import type {
   AgentMessage,
   UserMessage,
@@ -31,7 +32,6 @@ interface Props {
   onEditContent?: (content: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
-  isDark?: boolean;
 }
 
 function formatTime(ts?: number): string | null {
@@ -66,12 +66,12 @@ function copyText(text: string): Promise<void> {
   }
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, isDark }: Props) {
+export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} isDark={isDark} />;
+    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
@@ -286,7 +286,6 @@ function AssistantMessageView({
   modelNames,
   showTimestamp,
   prevTimestamp,
-  isDark,
 }: {
   message: AssistantMessage;
   isStreaming?: boolean;
@@ -294,7 +293,6 @@ function AssistantMessageView({
   modelNames?: Record<string, string>;
   showTimestamp?: boolean;
   prevTimestamp?: number;
-  isDark?: boolean;
 }) {
   const time = showTimestamp ? formatTime(message.timestamp) : null;
   const blocks = message.content ?? [];
@@ -454,7 +452,7 @@ function AssistantMessageView({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {blocks.map((block, i) => (
-          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} isDark={isDark} />
+          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} />
         ))}
       </div>
 
@@ -507,9 +505,9 @@ function AssistantMessageView({
   );
 }
 
-function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, isDark }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; isDark?: boolean }) {
+function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number> }) {
   if (block.type === "text") {
-    return <TextBlock block={block as TextContent} isDark={isDark} />;
+    return <TextBlock block={block as TextContent} />;
   }
   if (block.type === "thinking") {
     return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} />;
@@ -523,7 +521,7 @@ function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCal
   return null;
 }
 
-function TextBlock({ block, isDark }: { block: TextContent; isDark?: boolean }) {
+function TextBlock({ block }: { block: TextContent }) {
   return (
     <div className="markdown-body">
       <ReactMarkdown
@@ -534,7 +532,7 @@ function TextBlock({ block, isDark }: { block: TextContent; isDark?: boolean }) 
             const raw = String(children);
             const isBlock = className?.includes("language-") || raw.includes("\n");
             if (isBlock) {
-              return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} isDark={isDark} />;
+              return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} />;
             }
             return (
               <code
@@ -769,7 +767,8 @@ function formatUsage(usage: {
 
 
 
-function CodeBlock({ code, lang, isDark }: { code: string; lang: string; isDark?: boolean }) {
+function CodeBlock({ code, lang }: { code: string; lang: string }) {
+  const { isDark } = useTheme();
   const [copied, setCopied] = useState(false);
 
   const copy = () => {

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import type {
   AgentMessage,
   UserMessage,
@@ -30,6 +31,7 @@ interface Props {
   onEditContent?: (content: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
+  isDark?: boolean;
 }
 
 function formatTime(ts?: number): string | null {
@@ -64,12 +66,12 @@ function copyText(text: string): Promise<void> {
   }
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, isDark }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} />;
+    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} isDark={isDark} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
@@ -284,6 +286,7 @@ function AssistantMessageView({
   modelNames,
   showTimestamp,
   prevTimestamp,
+  isDark,
 }: {
   message: AssistantMessage;
   isStreaming?: boolean;
@@ -291,6 +294,7 @@ function AssistantMessageView({
   modelNames?: Record<string, string>;
   showTimestamp?: boolean;
   prevTimestamp?: number;
+  isDark?: boolean;
 }) {
   const time = showTimestamp ? formatTime(message.timestamp) : null;
   const blocks = message.content ?? [];
@@ -450,7 +454,7 @@ function AssistantMessageView({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {blocks.map((block, i) => (
-          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} />
+          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} isDark={isDark} />
         ))}
       </div>
 
@@ -503,9 +507,9 @@ function AssistantMessageView({
   );
 }
 
-function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number> }) {
+function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, isDark }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; isDark?: boolean }) {
   if (block.type === "text") {
-    return <TextBlock block={block as TextContent} />;
+    return <TextBlock block={block as TextContent} isDark={isDark} />;
   }
   if (block.type === "thinking") {
     return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} />;
@@ -519,7 +523,7 @@ function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCal
   return null;
 }
 
-function TextBlock({ block }: { block: TextContent }) {
+function TextBlock({ block, isDark }: { block: TextContent; isDark?: boolean }) {
   return (
     <div className="markdown-body">
       <ReactMarkdown
@@ -530,7 +534,7 @@ function TextBlock({ block }: { block: TextContent }) {
             const raw = String(children);
             const isBlock = className?.includes("language-") || raw.includes("\n");
             if (isBlock) {
-              return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} />;
+              return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} isDark={isDark} />;
             }
             return (
               <code
@@ -674,7 +678,7 @@ function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCall
             fontSize: 12,
             lineHeight: 1.5,
             overflow: "auto",
-            background: "rgba(0,0,0,0.03)",
+            background: "var(--bg-subtle)",
             borderTop: isError ? "1px solid rgba(248,113,113,0.25)" : "1px solid rgba(34,197,94,0.2)",
             whiteSpace: "pre-wrap",
             wordBreak: "break-all",
@@ -705,7 +709,7 @@ function PairedResult({ text, isEmpty, isError }: {
     <div
       style={{
         borderTop: `1px solid ${isError ? "rgba(248,113,113,0.3)" : "rgba(34,197,94,0.15)"}`,
-        background: isError ? "rgba(248,113,113,0.04)" : "rgba(0,0,0,0.02)",
+        background: isError ? "rgba(248,113,113,0.04)" : "var(--bg-subtle)",
       }}
     >
       <pre
@@ -765,7 +769,7 @@ function formatUsage(usage: {
 
 
 
-function CodeBlock({ code, lang }: { code: string; lang: string }) {
+function CodeBlock({ code, lang, isDark }: { code: string; lang: string; isDark?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   const copy = () => {
@@ -814,7 +818,7 @@ function CodeBlock({ code, lang }: { code: string; lang: string }) {
       </div>
       <SyntaxHighlighter
         language={lang || "text"}
-        style={vs}
+        style={isDark ? vscDarkPlus : vs}
         showLineNumbers
         lineNumberStyle={{ color: "var(--text-dim)", fontStyle: "normal" }}
         customStyle={{

--- a/components/SkillsConfig.tsx
+++ b/components/SkillsConfig.tsx
@@ -68,7 +68,7 @@ function Toggle({
           width: 16,
           height: 16,
           borderRadius: "50%",
-          background: "#fff",
+          background: "var(--bg)",
           boxShadow: "0 1px 4px rgba(0,0,0,0.22)",
           transition: "left 0.18s cubic-bezier(.4,0,.2,1)",
         }}

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,31 +1,43 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 type Theme = "light" | "dark";
 
-export function useTheme() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window === "undefined") return "light";
-    const stored = localStorage.getItem("pi-theme");
-    return stored === "dark" ? "dark" : "light";
-  });
+const listeners = new Set<() => void>();
 
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-  }, [theme]);
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): Theme {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function getServerSnapshot(): Theme {
+  return "light";
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const toggleTheme = useCallback(() => {
-    setTheme((prev) => {
-      const next: Theme = prev === "dark" ? "light" : "dark";
+    const next: Theme = getSnapshot() === "dark" ? "light" : "dark";
+    if (next === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    try {
       localStorage.setItem("pi-theme", next);
-      return next;
-    });
+    } catch {
+      // ignore storage errors (private mode, quota, etc.)
+    }
+    listeners.forEach((cb) => cb());
   }, []);
 
   return { theme, toggleTheme, isDark: theme === "dark" };

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+
+type Theme = "light" | "dark";
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "light";
+    const stored = localStorage.getItem("pi-theme");
+    return stored === "dark" ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next: Theme = prev === "dark" ? "light" : "dark";
+      localStorage.setItem("pi-theme", next);
+      return next;
+    });
+  }, []);
+
+  return { theme, toggleTheme, isDark: theme === "dark" };
+}

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -22,22 +22,63 @@ function getServerSnapshot(): Theme {
   return "light";
 }
 
+type ToggleOrigin = { x: number; y: number };
+
 export function useTheme() {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-  const toggleTheme = useCallback(() => {
+  const toggleTheme = useCallback((origin?: ToggleOrigin) => {
     const next: Theme = getSnapshot() === "dark" ? "light" : "dark";
-    if (next === "dark") {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
+
+    const apply = () => {
+      if (next === "dark") {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+      try {
+        localStorage.setItem("pi-theme", next);
+      } catch {
+        // ignore storage errors (private mode, quota, etc.)
+      }
+      listeners.forEach((cb) => cb());
+    };
+
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const supportsVT = typeof document.startViewTransition === "function";
+
+    if (!supportsVT || reduceMotion) {
+      apply();
+      return;
     }
-    try {
-      localStorage.setItem("pi-theme", next);
-    } catch {
-      // ignore storage errors (private mode, quota, etc.)
-    }
-    listeners.forEach((cb) => cb());
+
+    const x = origin?.x ?? window.innerWidth / 2;
+    const y = origin?.y ?? window.innerHeight / 2;
+    const endRadius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y),
+    );
+
+    const transition = document.startViewTransition(apply);
+    transition.ready
+      .then(() => {
+        document.documentElement.animate(
+          {
+            clipPath: [
+              `circle(0px at ${x}px ${y}px)`,
+              `circle(${endRadius}px at ${x}px ${y}px)`,
+            ],
+          },
+          {
+            duration: 450,
+            easing: "cubic-bezier(0.22, 0.61, 0.36, 1)",
+            pseudoElement: "::view-transition-new(root)",
+          },
+        );
+      })
+      .catch(() => {
+        // transition cancelled — ignore
+      });
   }, []);
 
   return { theme, toggleTheme, isDark: theme === "dark" };


### PR DESCRIPTION
# 🌗 Dark Mode 支持

## 概述

为应用添加了暗色模式（Dark Mode）支持，用户可以在 light / dark 之间自由切换，偏好设置会持久化保存。

## 改动内容

- **暗色主题变量**：在 `globals.css` 中新增 `html.dark` CSS 变量集，覆盖所有语义化颜色 token
- **主题切换 Hook**：新增 `hooks/useTheme.ts`，通过 `localStorage`（`pi-theme`）持久化主题偏好，并同步 `<html>` 的 `dark` class
- **防闪烁脚本**：在 `layout.tsx` 的 `<head>` 中注入内联 script，页面加载前同步读取 `localStorage` 并应用主题，避免白屏闪烁
- **切换按钮**：在左侧栏底部按钮区（Models / Skills 旁）新增 Dark / Light 切换按钮，带太阳 / 月亮图标
- **代码高亮主题**：`MessageView` 和 `FileViewer` 中的 `SyntaxHighlighter` 根据主题动态切换 `vs`（亮色）/ `vscDarkPlus`（暗色）
- **修复硬编码颜色**：将 `#fff`、`rgba(0,0,0,...)` 等在暗色模式下失效的硬编码颜色替换为 CSS 变量

## 涉及文件

| 文件 | 改动 |
| --- | --- |
| `app/globals.css` | 新增 `html.dark` 暗色变量 + `--bg-subtle` |
| `hooks/useTheme.ts` | 新增主题切换 Hook |
| `app/layout.tsx` | 防闪烁脚本 + `suppressHydrationWarning` |
| `components/AppShell.tsx` | 切换按钮 + 传递 `isDark` |
| `components/ChatWindow.tsx` | 透传 `isDark` |
| `components/MessageView.tsx` | 代码高亮主题切换 + 修复背景色 |
| `components/FileViewer.tsx` | 代码高亮主题切换 + 修复 iframe 背景 |
| `components/SkillsConfig.tsx` | 修复 Toggle 组件旋钮背景色 |

## 测试方式

1. 打开应用，默认为亮色模式
2. 点击左侧栏底部的 **Dark** 按钮，界面切换为暗色模式
3. 刷新页面，暗色模式应保持，**无白屏闪烁**
4. 点击 **Light** 按钮切回亮色模式
5. 检查各区域：侧边栏、聊天区、代码块、弹窗（Models / Skills）、文件预览