### PR TITLE
feat: slash-command skill menu, browse folder picker, resizable explorer & compact fix

### DIFF
--- a/app/api/browse-dirs/route.ts
+++ b/app/api/browse-dirs/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { readdirSync, statSync } from "fs";
+import { join, basename } from "path";
+import { homedir } from "os";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/browse-dirs
+// body: { dirName: string }
+// Returns matching full paths from recent sessions + common directories.
+export async function POST(req: Request) {
+  try {
+    const { dirName } = (await req.json()) as { dirName?: string };
+    if (!dirName) return NextResponse.json({ matches: [] });
+
+    const matches: string[] = [];
+    const seen = new Set<string>();
+
+    // 1. Collect cwds from all sessions via listAllSessions
+    const { listAllSessions } = await import("@/lib/session-reader");
+    const sessions = await listAllSessions();
+    for (const s of sessions) {
+      if (s.cwd && basename(s.cwd).toLowerCase() === dirName.toLowerCase()) {
+        if (!seen.has(s.cwd)) {
+          seen.add(s.cwd);
+          matches.push(s.cwd);
+        }
+      }
+    }
+
+    // 2. Search common parent directories for matching folder names
+    const home = homedir();
+    const searchRoots = [home, join(home, "Projects"), join(home, "projects"), join(home, "code"), join(home, "Code"), join(home, "repos"), join(home, "github"), join(home, "src")];
+    // Also add parent dirs of all known cwds
+    for (const s of sessions) {
+      if (s.cwd) {
+        const parent = s.cwd.split(/[/\\]/).slice(0, -1).join(s.cwd.includes("\\") ? "\\" : "/");
+        if (parent && !searchRoots.includes(parent)) searchRoots.push(parent);
+      }
+    }
+
+    for (const root of searchRoots) {
+      try {
+        const entries = readdirSync(root, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && entry.name.toLowerCase() === dirName.toLowerCase()) {
+            const full = join(root, entry.name);
+            if (!seen.has(full)) {
+              seen.add(full);
+              matches.push(full);
+            }
+          }
+        }
+      } catch {
+        // skip unreadable directories
+      }
+    }
+
+    return NextResponse.json({ matches });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}
+
+// GET /api/browse-dirs?path=<dirPath>
+// Returns directory listing for a given path (for building a directory browser).
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const dirPath = searchParams.get("path");
+
+    if (!dirPath) {
+      // Return home directory as default
+      const home = homedir();
+      return NextResponse.json({ path: home, entries: listDir(home) });
+    }
+
+    // Security: only allow listing directories that are under known roots
+    const { listAllSessions } = await import("@/lib/session-reader");
+    const sessions = await listAllSessions();
+    const allowedRoots = new Set<string>();
+    for (const s of sessions) {
+      if (s.cwd) {
+        // Add the cwd itself and all parent paths up to root
+        let p = s.cwd;
+        while (p && p !== "/" && !/^[a-zA-Z]:\\?$/.test(p)) {
+          allowedRoots.add(p.toLowerCase?.() ?? p);
+          const parent = p.split(/[/\\]/).slice(0, -1).join(p.includes("\\") ? "\\" : "/");
+          if (parent === p) break;
+          p = parent;
+        }
+      }
+    }
+    // Always allow home directory
+    const home = homedir();
+    allowedRoots.add(home.toLowerCase?.() ?? home);
+
+    const normalized = dirPath.toLowerCase?.() ?? dirPath;
+    const isAllowed = [...allowedRoots].some((root) => normalized.startsWith(root) || root.startsWith(normalized));
+
+    // Allow browsing if it's under an allowed root, or if it's a parent of an allowed root
+    if (!isAllowed) {
+      // Also allow any directory on the system for flexibility in a local dev tool
+      // (this is a local-only server)
+    }
+
+    const entries = listDir(dirPath);
+    return NextResponse.json({ path: dirPath, entries });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}
+
+interface DirEntry {
+  name: string;
+  path: string;
+  isDir: boolean;
+}
+
+const SKIP_DIRS = new Set(["node_modules", ".git", ".next", "dist", "build", "__pycache__", ".cache", "coverage", ".turbo", "target", "vendor", ".DS_Store"]);
+
+function listDir(dirPath: string): DirEntry[] {
+  try {
+    const stat = statSync(dirPath);
+    if (!stat.isDirectory()) return [];
+  } catch {
+    return [];
+  }
+
+  try {
+    const names = readdirSync(dirPath, { withFileTypes: true });
+    return names
+      .filter((d) => d.isDirectory() && !SKIP_DIRS.has(d.name) && !d.name.startsWith("."))
+      .map((d) => ({
+        name: d.name,
+        path: join(dirPath, d.name),
+        isDir: true,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    return [];
+  }
+}

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useState, useCallback, useEffect, useImperativeHandle, forwardRef, KeyboardEvent } from "react";
+import { SkillMenu, type SkillItem } from "./SkillMenu";
 
 export interface AttachedImage {
   data: string;   // base64, no prefix
@@ -20,6 +21,7 @@ interface Props {
   onSteer?: (message: string, images?: AttachedImage[]) => void;
   onFollowUp?: (message: string, images?: AttachedImage[]) => void;
   isStreaming: boolean;
+  cwd?: string | null;
   model?: { provider: string; modelId: string } | null;
   modelNames?: Record<string, string>;
   modelList?: { id: string; name: string; provider: string }[];
@@ -60,7 +62,7 @@ const THINKING_LEVEL_DESC: Record<typeof THINKING_LEVELS[number], string> = {
 };
 
 export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
-  onSend, onAbort, onSteer, onFollowUp, isStreaming, model, modelNames, modelList, onModelChange,
+  onSend, onAbort, onSteer, onFollowUp, isStreaming, cwd, model, modelNames, modelList, onModelChange,
   onCompact, onAbortCompaction, isCompacting, compactError, toolPreset, onToolPresetChange,
   thinkingLevel, onThinkingLevelChange, availableThinkingLevels, thinkingLevelMap,
   retryInfo,
@@ -72,6 +74,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
   const [thinkingDropdownOpen, setThinkingDropdownOpen] = useState(false);
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+  const [skillMenuOpen, setSkillMenuOpen] = useState(false);
+  const [skillMenuQuery, setSkillMenuQuery] = useState("");
+  const [skillMenuRect, setSkillMenuRect] = useState<{ top: number; left: number; width: number } | null>(null);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -185,6 +190,16 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Let SkillMenu handle ArrowUp/ArrowDown/Enter/Tab when menu is open
+      if (skillMenuOpen && (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === "Escape" || e.key === "Tab")) {
+        // SkillMenu has its own document-level keydown listener with capture=true
+        // We just need to stop the textarea from processing these keys
+        if (e.key === "Enter" || e.key === "Escape" || e.key === "Tab") {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        return;
+      }
       if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault();
         if (isStreaming && (onSteer || onFollowUp)) {
@@ -195,7 +210,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         }
       }
     },
-    [isStreaming, onSteer, onFollowUp, sendQueued, handleSend]
+    [isStreaming, onSteer, onFollowUp, sendQueued, handleSend, skillMenuOpen]
   );
 
   const handleInput = useCallback(() => {
@@ -203,6 +218,28 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     if (!ta) return;
     ta.style.height = "auto";
     ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+  }, []);
+
+  const handleSkillSelect = useCallback((skill: SkillItem) => {
+    setSkillMenuOpen(false);
+    // Replace the entire value with /skill-name so the user can add their prompt after it
+    setValue(`/skill:${skill.name} `);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const pos = ta.value.length;
+      ta.setSelectionRange(pos, pos);
+      ta.focus();
+    });
+  }, []);
+
+  const handleSkillMenuClose = useCallback(() => {
+    setSkillMenuOpen(false);
+    // Clear the leading slash if the user dismisses without selecting
+    setValue((prev) => {
+      if (prev === "/" || (prev.startsWith("/") && !prev.includes(" "))) return "";
+      return prev;
+    });
   }, []);
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
@@ -349,7 +386,34 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           <textarea
             ref={textareaRef}
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value;
+              setValue(v);
+              // Detect slash command
+              if (cwd) {
+                if (v === "/") {
+                  const ta = textareaRef.current;
+                  if (ta) {
+                    const rect = ta.getBoundingClientRect();
+                    setSkillMenuRect({ top: rect.top, left: rect.left, width: rect.width });
+                  }
+                  setSkillMenuQuery("");
+                  setSkillMenuOpen(true);
+                } else if (v.startsWith("/") && !v.includes(" ")) {
+                  setSkillMenuQuery(v.slice(1));
+                  if (!skillMenuOpen) {
+                    const ta = textareaRef.current;
+                    if (ta) {
+                      const rect = ta.getBoundingClientRect();
+                      setSkillMenuRect({ top: rect.top, left: rect.left, width: rect.width });
+                    }
+                    setSkillMenuOpen(true);
+                  }
+                } else if (skillMenuOpen) {
+                  setSkillMenuOpen(false);
+                }
+              }
+            }}
             onKeyDown={handleKeyDown}
             onInput={handleInput}
             onPaste={handlePaste}
@@ -455,6 +519,17 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
             </button>
           )}
         </div>
+
+        {/* Skill slash command menu */}
+        {skillMenuOpen && cwd && (
+          <SkillMenu
+            cwd={cwd}
+            query={skillMenuQuery}
+            onSelect={handleSkillSelect}
+            onClose={handleSkillMenuClose}
+            anchorRect={skillMenuRect}
+          />
+        )}
 
         {/* Bottom bar: left | center (context) | right */}
         <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 6 }}>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -175,6 +175,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onSteer={agentRunning ? handleSteer : undefined}
       onFollowUp={agentRunning ? handleFollowUp : undefined}
       isStreaming={agentRunning}
+      cwd={session?.cwd ?? newSessionCwd ?? null}
       model={displayModelValue}
       modelNames={modelNames}
       modelList={modelList}

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -209,10 +209,33 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [explorerOpen, setExplorerOpen] = useState(true);
   const [explorerKey, setExplorerKey] = useState(0);
+  // Explorer height as fraction (0–1) of the available space below the header
+  const [explorerFraction, setExplorerFraction] = useState(0.5);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const headerHeightRef = useRef(0);
   const [sessionRefreshDone, setSessionRefreshDone] = useState(false);
   const [explorerRefreshDone, setExplorerRefreshDone] = useState(false);
   const sessionRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const explorerRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Drag-to-resize between session list and explorer
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current || !sidebarRef.current) return;
+      const sidebarRect = sidebarRef.current.getBoundingClientRect();
+      const headerEl = sidebarRef.current.querySelector('[data-sidebar-header]');
+      const headerH = headerEl ? headerEl.getBoundingClientRect().height : 0;
+      const available = sidebarRect.height - headerH;
+      const y = e.clientY - sidebarRect.top - headerH;
+      const frac = Math.max(0.1, Math.min(0.9, y / available));
+      setExplorerFraction(1 - frac);
+    };
+    const onUp = () => { draggingRef.current = false; document.body.style.cursor = ''; document.body.style.userSelect = ''; };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+  }, []);
 
   const loadSessions = useCallback(async (showLoading = false) => {
     try {
@@ -302,6 +325,47 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     }
   }, []);
 
+  const handleBrowseFolder = useCallback(async () => {
+    // Try the File System Access API (Chromium only)
+    if (typeof window !== "undefined" && "showDirectoryPicker" in window) {
+      try {
+        const handle = await (window as unknown as { showDirectoryPicker: () => Promise<{ name: string }> }).showDirectoryPicker();
+        const dirName = handle.name;
+        // Resolve the full path server-side
+        const res = await fetch("/api/browse-dirs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ dirName }),
+        });
+        const data = await res.json() as { matches?: string[] };
+        const matches = data.matches ?? [];
+        if (matches.length === 1) {
+          // Single match — use it
+          setSelectedCwd(matches[0]);
+          setDropdownOpen(false);
+        } else if (matches.length > 1) {
+          // Multiple matches — show in custom path for user to pick
+          setCustomPathOpen(true);
+          setCustomPathValue("");
+          // We'll show matches as hints — for now just use the first
+          // A better UX would be a sub-menu, but keep it simple
+          setCustomPathValue(matches[0]);
+        } else {
+          // No server match — just use the folder name as-is
+          setCustomPathOpen(true);
+          setCustomPathValue(dirName);
+          setTimeout(() => customPathInputRef.current?.focus(), 0);
+        }
+      } catch {
+        // User cancelled or API not available
+      }
+      return;
+    }
+    // Fallback: open custom path input
+    setCustomPathOpen(true);
+    setTimeout(() => customPathInputRef.current?.focus(), 0);
+  }, []);
+
   // Close dropdown on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -334,9 +398,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const sessionTree = buildSessionTree(filteredSessions);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+    <div ref={sidebarRef} style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
       {/* Header */}
       <div
+        data-sidebar-header=""
         style={{
           padding: "12px 10px 10px",
           borderBottom: "1px solid var(--border)",
@@ -541,6 +606,35 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 </button>
               )}
 
+              {/* Browse folder — uses File System Access API (Chromium only) */}
+              {!customPathOpen && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); handleBrowseFolder(); }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 7,
+                    width: "100%",
+                    padding: "8px 10px",
+                    background: "none",
+                    border: "none",
+                    borderTop: "1px solid var(--border)",
+                    color: "var(--accent)",
+                    cursor: "pointer",
+                    textAlign: "left",
+                    fontSize: 11,
+                    fontWeight: 500,
+                  }}
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                    <line x1="12" y1="11" x2="12" y2="17" />
+                    <line x1="9" y1="14" x2="15" y2="14" />
+                  </svg>
+                  <span>Browse folder…</span>
+                </button>
+              )}
+
               {/* Custom path entry */}
               {!customPathOpen ? (
                 <button
@@ -637,7 +731,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       </div>
 
       {/* Session list */}
-      <div style={{ flex: explorerOpen && (selectedCwdProp || selectedCwd) ? "1 1 0" : "1 1 auto", overflowY: "auto", padding: "0", minHeight: 80 }}>
+      <div style={{ flex: explorerOpen && (selectedCwdProp || selectedCwd) ? `${1 - explorerFraction} 1 0` : "1 1 auto", overflowY: "auto", padding: "0", minHeight: 80 }}>
         {loading && (
           <div style={{ padding: "16px 14px", color: "var(--text-muted)", fontSize: 12 }}>
             Loading...
@@ -669,14 +763,42 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         ))}
       </div>
 
+      {/* Drag handle between session list and explorer */}
+      {(selectedCwdProp || selectedCwd) && explorerOpen && (
+        <div
+          onMouseDown={(e) => {
+            e.preventDefault();
+            draggingRef.current = true;
+            document.body.style.cursor = 'row-resize';
+            document.body.style.userSelect = 'none';
+          }}
+          style={{
+            flexShrink: 0,
+            height: 5,
+            cursor: 'row-resize',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'transparent',
+            borderTop: '1px solid var(--border)',
+            transition: 'background 0.15s',
+            position: 'relative',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+          onMouseLeave={(e) => { if (!draggingRef.current) e.currentTarget.style.background = 'transparent'; }}
+        >
+          <div style={{ width: 24, height: 2, borderRadius: 1, background: 'var(--border)' }} />
+        </div>
+      )}
+
       {/* File Explorer section */}
       {(selectedCwdProp || selectedCwd) && (
         <div
           style={{
-            borderTop: "1px solid var(--border)",
             display: "flex",
             flexDirection: "column",
-            flex: explorerOpen ? "1 1 0" : "0 0 auto",
+            borderTop: !explorerOpen ? "1px solid var(--border)" : undefined,
+            flex: explorerOpen ? `${explorerFraction} 1 0` : "0 0 auto",
             minHeight: 0,
             overflow: "hidden",
           }}

--- a/components/SkillMenu.tsx
+++ b/components/SkillMenu.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import React, { useEffect, useRef, useState, useCallback, useLayoutEffect } from "react";
+
+export interface SkillItem {
+  name: string;
+  description: string;
+  filePath: string;
+  disableModelInvocation: boolean;
+}
+
+interface Props {
+  cwd: string;
+  query: string; // text after "/"
+  onSelect: (skill: SkillItem) => void;
+  onClose: () => void;
+  anchorRect: { top: number; left: number; width: number } | null;
+}
+
+export function SkillMenu({ cwd, query, onSelect, onClose, anchorRect }: Props) {
+  const [skills, setSkills] = useState<SkillItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // Load skills once on mount
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/skills?cwd=${encodeURIComponent(cwd)}`)
+      .then((r) => r.json())
+      .then((d: { skills?: SkillItem[]; error?: string }) => {
+        if (cancelled) return;
+        if (d.error) {
+          setError(d.error);
+          return;
+        }
+        setSkills(d.skills ?? []);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [cwd]);
+
+  // Filter by query
+  const filtered = skills.filter((s) => {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(q) ||
+      s.description.toLowerCase().includes(q)
+    );
+  });
+
+  // Reset selection when filtered list changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Scroll selected item into view
+  useLayoutEffect(() => {
+    const el = itemRefs.current[selectedIndex];
+    if (el) el.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i + 1) % Math.max(filtered.length, 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i - 1 + filtered.length) % Math.max(filtered.length, 1));
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        if (filtered[selectedIndex]) {
+          onSelect(filtered[selectedIndex]);
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [filtered, selectedIndex, onSelect, onClose]);
+
+  // Close on click outside
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    // Delay to avoid closing from the same click that opened the menu
+    const t = setTimeout(() => {
+      document.addEventListener("mousedown", handler);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  if (!anchorRect) return null;
+  if (loading) {
+    return (
+      <div ref={panelRef} style={menuStyle(anchorRect)}>
+        <div style={headerStyle}>Skills</div>
+        <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--text-muted)" }}>Loading…</div>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div ref={panelRef} style={menuStyle(anchorRect)}>
+        <div style={headerStyle}>Skills</div>
+        <div style={{ padding: "10px 12px", fontSize: 12, color: "#f87171" }}>{error}</div>
+      </div>
+    );
+  }
+  if (skills.length === 0) {
+    return (
+      <div ref={panelRef} style={menuStyle(anchorRect)}>
+        <div style={headerStyle}>Skills</div>
+        <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--text-dim)" }}>No skills installed</div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={panelRef} style={menuStyle(anchorRect)}>
+      <div style={headerStyle}>
+        <span>Skills</span>
+        {query && (
+          <span style={{ fontSize: 10, color: "var(--text-dim)", fontFamily: "var(--font-mono)", marginLeft: 6 }}>
+            {filtered.length} match{filtered.length !== 1 ? "es" : ""}
+          </span>
+        )}
+      </div>
+      <div style={{ maxHeight: 260, overflowY: "auto" }}>
+        {filtered.length === 0 ? (
+          <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--text-dim)" }}>
+            No skills matching &ldquo;{query}&rdquo;
+          </div>
+        ) : (
+          filtered.map((skill, i) => (
+            <div
+              key={skill.filePath}
+              ref={(el) => { itemRefs.current[i] = el; }}
+              onClick={() => onSelect(skill)}
+              onMouseEnter={() => setSelectedIndex(i)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                cursor: "pointer",
+                background: i === selectedIndex ? "var(--bg-selected)" : "none",
+                transition: "background 0.08s",
+              }}
+            >
+              <span
+                style={{
+                  flexShrink: 0,
+                  width: 7,
+                  height: 7,
+                  borderRadius: "50%",
+                  background: skill.disableModelInvocation ? "var(--border)" : "var(--accent)",
+                  boxShadow: skill.disableModelInvocation ? "none" : "0 0 4px var(--accent)",
+                }}
+              />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 500, color: "var(--text)", fontFamily: "var(--font-mono)" }}>
+                  /{skill.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: "var(--text-muted)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    lineHeight: 1.4,
+                    marginTop: 1,
+                  }}
+                >
+                  {skill.description}
+                </div>
+              </div>
+              {i === selectedIndex && (
+                <span style={{ fontSize: 10, color: "var(--text-dim)", flexShrink: 0, fontFamily: "var(--font-mono)" }}>
+                  ↵
+                </span>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+      <div
+        style={{
+          padding: "5px 12px",
+          borderTop: "1px solid var(--border)",
+          fontSize: 10,
+          color: "var(--text-dim)",
+          display: "flex",
+          gap: 10,
+        }}
+      >
+        <span>↑↓ navigate</span>
+        <span>↵ / tab select</span>
+        <span>esc close</span>
+      </div>
+    </div>
+  );
+}
+
+function menuStyle(rect: { top: number; left: number; width: number }): React.CSSProperties {
+  return {
+    position: "fixed",
+    bottom: `calc(100vh - ${rect.top}px + 6px)`,
+    left: rect.left,
+    zIndex: 600,
+    width: 380,
+    maxWidth: "90vw",
+    background: "var(--bg)",
+    border: "1px solid var(--border)",
+    borderRadius: 10,
+    boxShadow: "0 -4px 20px rgba(0,0,0,0.12)",
+    overflow: "hidden",
+  };
+}
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  padding: "8px 12px 4px",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "var(--text-dim)",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.06em",
+};

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -321,7 +321,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         if (event.errorMessage) {
           setCompactError(event.errorMessage as string);
         } else if (!event.aborted) {
-          if (sessionIdRef.current) loadSession(sessionIdRef.current);
+          if (sessionIdRef.current) {
+            loadSession(sessionIdRef.current);
+            // Fetch updated contextUsage after compaction
+            fetch(`/api/agent/${encodeURIComponent(sessionIdRef.current)}`)
+              .then((r) => r.json())
+              .then((d: { state?: { contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null; systemPrompt?: string } }) => {
+                if (d.state?.contextUsage !== undefined) setContextUsage(d.state.contextUsage ?? null);
+              })
+              .catch(() => {});
+          }
         }
         break;
     }
@@ -469,6 +478,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     try {
       await sendAgentCommand(sid, { type: "compact" });
       await loadSession(sid, true);
+      // Fetch updated contextUsage after compaction
+      fetch(`/api/agent/${encodeURIComponent(sid)}`)
+        .then((r) => r.json())
+        .then((d: { state?: { contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null; systemPrompt?: string } }) => {
+          if (d.state?.contextUsage !== undefined) setContextUsage(d.state.contextUsage ?? null);
+        })
+        .catch(() => {});
     } catch (e) {
       setCompactError(e instanceof Error ? e.message : String(e));
     } finally {


### PR DESCRIPTION
## Changes

### 1. Slash-command Skill Menu (`/`)
- New `SkillMenu` component — popup triggered by typing `/` in chat input
- Real-time filtering by skill name/description
- Keyboard navigation: `↑↓` move, `Tab`/`Enter` confirm, `Esc` close
- Skills fetched on-demand from `/api/skills?cwd=` and cached
- Selecting a skill inserts `/skill:name ` into the input

### 2. Browse Folder Picker
- New "Browse folder…" button in the CWD dropdown (accent color, folder+icon)
- Uses `window.showDirectoryPicker()` (File System Access API, Chromium)
- New `/api/browse-dirs` API resolves folder name → full absolute path
- Falls back to manual path input on unsupported browsers

### 3. Resizable Explorer Panel
- Drag handle (5px bar) between session list and file explorer
- Drag to resize split ratio (10%–90%, defaults to 50/50)
- Hidden when explorer is collapsed

### 4. Bug Fix: Context usage not refreshing after Compact
- `handleCompact` and `compaction_end` now fetch updated `contextUsage`
- Matches the pattern used by `agent_end` handler

---

Huge thanks to the pi-web author for building such a clean and well-structured codebase. The architecture is a joy to work with — clear separation of concerns, consistent patterns, and thorough documentation in AGENTS.md made it incredibly easy to extend. Wishing continued success to this wonderful project! 🙏