### PR TITLE
feat: add KaTeX math rendering support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -180,6 +180,9 @@ pre, code {
   padding: 0;
 }
 
+.katex { color: var(--text); }
+.katex-display { color: var(--text); }
+
 /* syntax highlighter line numbers */
 .markdown-body span.linenumber,
 span.linenumber {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_Mono } from "next/font/google";
+import "katex/dist/katex.min.css";
 import "./globals.css";
 
 const notoSansMono = Noto_Sans_Mono({

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -6,6 +6,8 @@ import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import { useTheme } from "@/hooks/useTheme";
 import { encodeFilePathForApi, getFileName, getRelativeFilePath } from "@/lib/file-paths";
 
@@ -800,7 +802,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
             className="markdown-body markdown-file-preview"
             style={{ padding: "24px 32px", maxWidth: 800 }}
           >
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>{data.content}</ReactMarkdown>
           </div>
         ) : (
           <SyntaxHighlighter

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
@@ -525,7 +527,8 @@ function TextBlock({ block }: { block: TextContent }) {
   return (
     <div className="markdown-body">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
         components={{
           code({ className, children, ...props }) {
             const lang = className?.replace("language-", "") ?? "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,15 @@
         "@earendil-works/pi-coding-agent": "^0.75.5",
         "@lobehub/icons": "^5.6.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "katex": "^0.16.47",
         "next": "16.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
-        "remark-gfm": "^4.0.1"
+        "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
       },
       "bin": {
         "pi-web": "bin/pi-web.js"
@@ -11781,9 +11784,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.45",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
-      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"

--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
     "@earendil-works/pi-coding-agent": "^0.75.5",
     "@lobehub/icons": "^5.6.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "katex": "^0.16.47",
     "next": "16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
-    "remark-gfm": "^4.0.1"
+    "rehype-katex": "^7.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",


### PR DESCRIPTION
## 摘要

  为聊天消息和 Markdown 文件预览添加 KaTeX 数学公式渲染支持，使用 `remark-math` + `rehype-katex`插件。

  ## 改动

  - 新增 3 个依赖：`katex`、`remark-math`、`rehype-katex`
  - `MessageView.tsx` — TextBlock 的 ReactMarkdown
  添加数学插件
  - `FileViewer.tsx` — Markdown 文件预览同样添加
  - `globals.css` — 两条 CSS 规则，主题色适配亮/暗模式
  - `layout.tsx` — KaTeX CSS 导入

  ## 测试

  - 构建通过，无 TypeScript/Webpack 错误
  - 公式 `$E=mc^2$` 和 `$$\int_0^\infty e^{-x^2}dx$$`均正确渲染
  - 亮/暗模式切换公式颜色自适应