### PR TITLE
fix: auto-create cwd directory if it does not exist

### DIFF
--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
-import { existsSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
+import { homedir } from "os";
 import { startRpcSession } from "@/lib/rpc-manager";
+
+function expandHome(filePath: string): string {
+  if (filePath.startsWith("~/") || filePath === "~") {
+    return filePath.replace(/^~/, homedir());
+  }
+  return filePath;
+}
 
 // POST /api/agent/new  body: { cwd: string; type: string; message: string; ... }
 // Spawns a brand-new pi session and immediately sends the first command.
@@ -8,13 +16,15 @@ import { startRpcSession } from "@/lib/rpc-manager";
 export async function POST(req: Request) {
   try {
     const body = await req.json() as { cwd?: string; [key: string]: unknown };
-    const { cwd, ...command } = body;
+    const { cwd: rawCwd, ...command } = body;
 
-    if (!cwd || typeof cwd !== "string") {
+    if (!rawCwd || typeof rawCwd !== "string") {
       return NextResponse.json({ error: "cwd is required" }, { status: 400 });
     }
+
+    const cwd = expandHome(rawCwd);
     if (!existsSync(cwd)) {
-      return NextResponse.json({ error: `Directory does not exist: ${cwd}` }, { status: 400 });
+      mkdirSync(cwd, { recursive: true });
     }
 
     // Use a one-time key so startRpcSession's lock doesn't conflict with real session ids


### PR DESCRIPTION
## Fix: auto-create cwd directory if it does not exist

### Problem

When a user sets a custom workspace path (e.g., `~/pi-workspace`) for a directory that doesn't yet exist on disk and attempts to start a chat, the API returns:

```
400: {"error":"Directory does not exist: ~/pi-workspace"}
```

Additionally, the tilde (`~`) in the path was not being expanded to the user's home directory, so even existing directories like `~/project` would fail.

### Root Cause

1. `POST /api/agent/new` checked if `cwd` exists and returned 400 if not — no automatic creation
2. `~` home directory expansion was missing

### Solution

1. Added `expandHome()` function to expand `~` and `~/...` paths to the user's actual home directory
2. Changed the `existsSync` check to call `mkdirSync(cwd, { recursive: true })` instead of returning a 400 error — if the directory doesn't exist, it is created automatically

### Testing

1. Create a new session with a custom path `~/pi-workspace-test` (directory does not exist)
2. Verify the directory is created automatically
3. Verify chat starts without errors
