### PR TITLE
fix: expand tilde in file path for ~/pi-workspace paths

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
+import os from "os";
 import { listAllSessions } from "@/lib/session-reader";
 
 const IGNORED_NAMES = new Set([
@@ -98,6 +99,10 @@ function isWindowsAbsolutePath(filePath: string): boolean {
 function filePathFromSegments(segments: string[]): string {
   const joined = segments.join("/");
   const slashJoined = normalizeSlashes(joined);
+  // Expand ~ to user's home directory
+  if (slashJoined === "~" || slashJoined.startsWith("~/")) {
+    return slashJoined.replace(/^~/, os.homedir());
+  }
   if (isWindowsAbsolutePath(slashJoined)) return slashJoined;
   return "/" + joined.replace(/^\/+/, "");
 }


### PR DESCRIPTION
## Fix: expand tilde in file path for ~/pi-workspace paths

### Problem

When a user sets a custom workspace path like `~/pi-workspace` in the UI, the FileExplorer fails to load with:

```
GET /api/files/root/pi-workspace?type=list
{"error":"Not found"}
```

The issue is that `filePathFromSegments()` in `app/api/files/[...path]/route.ts` does not expand the tilde (`~`) to the user's home directory. The path `~/pi-workspace` is passed as a literal string to `fs.statSync()`, which looks for a directory literally named `~` instead of `/home/user`.

### Root Cause

In `filePathFromSegments()`, the function joins URL-encoded path segments but never handles the tilde prefix. Since URLs encode `~` as `%7E`, the final path becomes `/%7E/pi-workspace` or similar, which doesn't exist.

### Solution

Added tilde expansion in `filePathFromSegments()`:

```typescript
if (slashJoined === "~" || slashJoined.startsWith("~/")) {
  return slashJoined.replace(/^~/, os.homedir());
}
```

This expands `~` and `~/...` paths to the user's actual home directory before performing filesystem operations.

### Testing

1. Create a new directory manually: `mkdir -p ~/pi-workspace`
2. Set the custom workspace path to `~/pi-workspace` in pi-web
3. Verify the FileExplorer loads correctly and shows the directory contents
