### PR TITLE
fix: strip line numbers when copying code blocks

### DIFF
--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -767,12 +767,25 @@ function formatUsage(usage: {
 
 
 
+// 去除行号前缀（如 "1. " 开头的行）
+function stripLineNumbers(code: string): string {
+  return code.split('\n').map(line => {
+    // 匹配 行号. 开头的前缀（最多 5 位数字）
+    const match = line.match(/^\s*\d{1,5}\.\s+/);
+    if (match) {
+      return line.slice(match[0].length);
+    }
+    return line;
+  }).join('\n');
+}
+
 function CodeBlock({ code, lang }: { code: string; lang: string }) {
   const { isDark } = useTheme();
   const [copied, setCopied] = useState(false);
 
   const copy = () => {
-    copyText(code).then(() => {
+    const cleanCode = stripLineNumbers(code);
+    copyText(cleanCode).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });


### PR DESCRIPTION
## Summary
Remove line number prefixes (e.g. '1. ', '2. ') from code content when user clicks the copy button. This prevents unwanted line numbers from being pasted.

## Changes
- Added `stripLineNumbers()` function in `components/MessageView.tsx`
- Modified `CodeBlock` copy handler to clean code before copying

## Before/After
**Before:** Copied text contained line numbers like:
```
1. git clone https://github.com/agegr/pi-web.git
2. npm install
```

**After:** Copy produces clean text without line numbers:
```
git clone https://github.com/agegr/pi-web.git
npm install
```

Fixes issue where clicking 'copy' on code blocks would include line number prefixes.