### PR TITLE
feat: add command copy button to tool call blocks

### DIFF
--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from "next/server";
+import { existsSync } from "fs";
 import { listAllSessions } from "@/lib/session-reader";
 
 export async function GET() {
   try {
     const sessions = await listAllSessions();
-    return NextResponse.json({ sessions });
+    return NextResponse.json({
+      sessions: sessions.map((session) => ({
+        ...session,
+        cwdExists: session.cwd ? existsSync(session.cwd) : false,
+      })),
+    });
   } catch (error) {
     return NextResponse.json(
       { error: String(error) },

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -615,7 +615,19 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
 
 function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCallContent; result?: ToolResultMessage; isRunning?: boolean; duration?: number }) {
   const [expanded, setExpanded] = useState(false);
+  const [copiedCommand, setCopiedCommand] = useState(false);
   const inputStr = JSON.stringify(block.input, null, 2);
+  // Extract command string for tools that accept a "command" input field
+  const command = typeof block.input?.command === "string" ? block.input.command : null;
+
+  // Copy the command to clipboard and briefly show a checkmark
+  const copyCommand = () => {
+    if (!command) return;
+    copyText(command).then(() => {
+      setCopiedCommand(true);
+      setTimeout(() => setCopiedCommand(false), 1500);
+    });
+  };
 
   // Result display
   const resultText = result
@@ -635,36 +647,100 @@ function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCall
       }}
     >
       {/* ── Tool call header ── */}
-      <button
-        onClick={() => setExpanded((v) => !v)}
+      <div
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 7,
           width: "100%",
-          padding: "6px 10px",
           background: "none",
           border: "none",
-          color: "var(--text-muted)",
-          cursor: "pointer",
-          fontSize: 12,
-          textAlign: "left",
           minWidth: 0,
         }}
       >
-        <span style={{ color: isError ? "#f87171" : "#16a34a", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 11, flexShrink: 0 }}>
-          {block.toolName}
-        </span>
-        <span style={{ color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 }}>
-          {getToolPreview(block)}
-        </span>
-        {duration !== undefined && (
-          <span style={{ fontSize: 11, color: "var(--text-dim)", flexShrink: 0, fontVariantNumeric: "tabular-nums" }}>{duration}s</span>
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 7,
+            flex: 1,
+            minWidth: 0,
+            padding: "6px 4px 6px 10px",
+            background: "none",
+            border: "none",
+            color: "var(--text-muted)",
+            cursor: "pointer",
+            fontSize: 12,
+            textAlign: "left",
+          }}
+        >
+          <span style={{ color: isError ? "#f87171" : "#16a34a", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 11, flexShrink: 0 }}>
+            {block.toolName}
+          </span>
+          <span style={{ color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 }}>
+            {getToolPreview(block)}
+          </span>
+        </button>
+        {command && (
+          <button
+            type="button"
+            onClick={copyCommand}
+            aria-label={copiedCommand ? "Command copied" : "Copy command"}
+            title={copiedCommand ? "Copied" : "Copy command"}
+            style={{
+              width: 26,
+              height: 26,
+              padding: 0,
+              marginRight: 2,
+              display: "grid",
+              placeItems: "center",
+              flexShrink: 0,
+              border: "none",
+              borderRadius: 5,
+              background: copiedCommand ? "rgba(34,197,94,0.14)" : "transparent",
+              color: copiedCommand ? "#16a34a" : "var(--text-dim)",
+              cursor: "pointer",
+            }}
+          >
+            {copiedCommand ? (
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polyline points="3.25 8.5 6.25 11.5 12.75 4.5" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="5.25" y="2.75" width="7.5" height="9.5" rx="1.25" />
+                <path d="M3.25 5.25v7.25c0 .69.56 1.25 1.25 1.25h5.25" />
+              </svg>
+            )}
+          </button>
         )}
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="var(--text-dim)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, transform: expanded ? "rotate(180deg)" : "none", transition: "transform 0.15s" }}>
-          <polyline points="2 3.5 5 6.5 8 3.5" />
-        </svg>
-      </button>
+        {duration !== undefined && (
+          <span style={{ fontSize: 11, color: "var(--text-dim)", flexShrink: 0, fontVariantNumeric: "tabular-nums", padding: "0 6px" }}>{duration}s</span>
+        )}
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? "Collapse tool call" : "Expand tool call"}
+          style={{
+            width: 24,
+            height: 26,
+            padding: 0,
+            marginRight: 6,
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            border: "none",
+            borderRadius: 5,
+            background: "transparent",
+            color: "var(--text-dim)",
+            cursor: "pointer",
+          }}
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" style={{ transform: expanded ? "rotate(180deg)" : "none", transition: "transform 0.15s" }} aria-hidden="true">
+            <polyline points="2 3.5 5 6.5 8 3.5" />
+          </svg>
+        </button>
+      </div>
 
       {/* ── Expanded: input args ── */}
       {expanded && (
@@ -835,5 +911,4 @@ function CodeBlock({ code, lang }: { code: string; lang: string }) {
     </div>
   );
 }
-
 

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -47,22 +47,30 @@ function formatTime(ts?: number): string | null {
   return `${date} ${time}`;
 }
 
-function copyText(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    return navigator.clipboard.writeText(text);
-  }
+async function copyText(text: string): Promise<boolean> {
   try {
-    const ta = document.createElement("textarea");
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall back below when browser clipboard permissions reject writeText().
+  }
+
+  let ta: HTMLTextAreaElement | null = null;
+  try {
+    ta = document.createElement("textarea");
     ta.value = text;
     ta.style.position = "fixed";
     ta.style.opacity = "0";
     document.body.appendChild(ta);
+    ta.focus();
     ta.select();
-    document.execCommand("copy");
-    document.body.removeChild(ta);
-    return Promise.resolve();
+    return document.execCommand("copy");
   } catch {
-    return Promise.reject();
+    return false;
+  } finally {
+    if (ta) document.body.removeChild(ta);
   }
 }
 
@@ -110,7 +118,8 @@ function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAs
   const canNavigate = !!prevAssistantEntryId && !!onNavigate;
 
   const copyContent = () => {
-    copyText(content).then(() => {
+    copyText(content).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -336,7 +345,8 @@ function AssistantMessageView({
     .join("\n");
 
   const copyContent = () => {
-    copyText(textContent).then(() => {
+    copyText(textContent).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -615,17 +625,16 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
 
 function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCallContent; result?: ToolResultMessage; isRunning?: boolean; duration?: number }) {
   const [expanded, setExpanded] = useState(false);
-  const [copiedCommand, setCopiedCommand] = useState(false);
+  const [copiedToolInput, setCopiedToolInput] = useState(false);
   const inputStr = JSON.stringify(block.input, null, 2);
-  // Extract command string for tools that accept a "command" input field
-  const command = typeof block.input?.command === "string" ? block.input.command : null;
+  const copyableToolInput = getToolCopyText(block);
 
-  // Copy the command to clipboard and briefly show a checkmark
-  const copyCommand = () => {
-    if (!command) return;
-    copyText(command).then(() => {
-      setCopiedCommand(true);
-      setTimeout(() => setCopiedCommand(false), 1500);
+  const copyToolInput = () => {
+    if (!copyableToolInput) return;
+    copyText(copyableToolInput).then((ok) => {
+      if (!ok) return;
+      setCopiedToolInput(true);
+      setTimeout(() => setCopiedToolInput(false), 1500);
     });
   };
 
@@ -681,12 +690,12 @@ function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCall
             {getToolPreview(block)}
           </span>
         </button>
-        {command && (
+        {copyableToolInput && (
           <button
             type="button"
-            onClick={copyCommand}
-            aria-label={copiedCommand ? "Command copied" : "Copy command"}
-            title={copiedCommand ? "Copied" : "Copy command"}
+            onClick={copyToolInput}
+            aria-label={copiedToolInput ? "Tool input copied" : "Copy tool input"}
+            title={copiedToolInput ? "Copied" : "Copy tool input"}
             style={{
               width: 26,
               height: 26,
@@ -697,12 +706,12 @@ function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCall
               flexShrink: 0,
               border: "none",
               borderRadius: 5,
-              background: copiedCommand ? "rgba(34,197,94,0.14)" : "transparent",
-              color: copiedCommand ? "#16a34a" : "var(--text-dim)",
+              background: copiedToolInput ? "rgba(34,197,94,0.14)" : "transparent",
+              color: copiedToolInput ? "#16a34a" : "var(--text-dim)",
               cursor: "pointer",
             }}
           >
-            {copiedCommand ? (
+            {copiedToolInput ? (
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <polyline points="3.25 8.5 6.25 11.5 12.75 4.5" />
               </svg>
@@ -826,6 +835,22 @@ function getToolPreview(block: ToolCallContent): string {
   return String(first).slice(0, 120);
 }
 
+function getToolCopyText(block: ToolCallContent): string | null {
+  const input = block.input;
+  if (!input || typeof input !== "object") return null;
+
+  const priorityKeys = ["command", "path", "file_path", "pattern", "query"];
+  for (const key of priorityKeys) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+
+  const firstKey = Object.keys(input)[0];
+  if (!firstKey) return null;
+  const first = input[firstKey];
+  return typeof first === "string" && first.length > 0 ? first : null;
+}
+
 function formatUsage(usage: {
   input: number;
   output: number;
@@ -848,7 +873,8 @@ function CodeBlock({ code, lang }: { code: string; lang: string }) {
   const [copied, setCopied] = useState(false);
 
   const copy = () => {
-    copyText(code).then(() => {
+    copyText(code).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -911,4 +937,3 @@ function CodeBlock({ code, lang }: { code: string; lang: string }) {
     </div>
   );
 }
-

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -38,6 +38,7 @@ function getRecentCwds(sessions: SessionInfo[]): string[] {
   const latestByCwd = new Map<string, string>(); // cwd -> most recent modified
   for (const s of sessions) {
     if (!s.cwd) continue;
+    if (s.cwdExists === false) continue;
     const prev = latestByCwd.get(s.cwd);
     if (!prev || s.modified > prev) {
       latestByCwd.set(s.cwd, s.modified);
@@ -261,6 +262,13 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   useEffect(() => {
     if (allSessions.length === 0) return;
 
+    const cwds = getRecentCwds(allSessions);
+
+    if (selectedCwd && !cwds.includes(selectedCwd) && allSessions.some((s) => s.cwd === selectedCwd && s.cwdExists === false)) {
+      setSelectedCwd(cwds[0] ?? null);
+      return;
+    }
+
     if (selectedCwd === null) {
       // If restoring a session, set cwd to match that session
       if (initialSessionId && !restoredRef.current) {
@@ -274,7 +282,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         // Session not found — notify parent so it can show the placeholder
         onInitialRestoreDone?.();
       }
-      const cwds = getRecentCwds(allSessions);
       if (cwds.length > 0) setSelectedCwd(cwds[0]);
     }
   }, [allSessions, selectedCwd, initialSessionId, onSelectSession, onInitialRestoreDone]);

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -341,6 +341,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       timestamp: Date.now(),
     };
     setMessages((prev) => [...prev, userMsg]);
+    setError(null);
     setAgentRunning(true);
     setAgentPhase({ kind: "waiting_model" });
     dispatch({ type: "start" });
@@ -367,7 +368,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             ...(thinkingLevel !== "auto" ? { thinkingLevel } : {}),
           }),
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          let detail = `HTTP ${res.status}`;
+          try {
+            const errorBody = await res.json() as { error?: string };
+            if (errorBody.error) detail = errorBody.error;
+          } catch {
+            // Keep the status-only error if the response is not JSON.
+          }
+          throw new Error(detail);
+        }
         const result = await res.json() as { sessionId: string };
         const realId = result.sessionId;
         sessionIdRef.current = realId;
@@ -392,6 +402,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       }
     } catch (e) {
       console.error("Failed to send message:", e);
+      setError(e instanceof Error ? e.message : String(e));
       setAgentRunning(false);
       setAgentPhase(null);
       dispatch({ type: "end" });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -175,6 +175,7 @@ export interface SessionInfo {
   path: string;
   id: string;
   cwd: string;
+  cwdExists?: boolean;
   name?: string;
   created: string;
   modified: string;


### PR DESCRIPTION
- Show a copy icon next to tool call headers when the tool input contains a command string
- Add cwdExists flag to session list API and filter out sessions with deleted cwd in sidebar
- Improve error handling in useAgentSession (clear previous errors, parse error response body)