### PR TITLE
feat: add ToolsConfig panel with individual tool toggles

### DIFF
--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import {
+  getAgentDir,
+  createAgentSession,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+
+const SETTINGS_FILE = "settings.json";
+const ACTIVE_TOOLS_KEY = "activeTools";
+
+function getSettingsPath(): string {
+  return join(getAgentDir(), SETTINGS_FILE);
+}
+
+function readActiveTools(): string[] | null {
+  const path = getSettingsPath();
+  if (!existsSync(path)) return null;
+  try {
+    const settings = JSON.parse(readFileSync(path, "utf8"));
+    const tools = settings[ACTIVE_TOOLS_KEY];
+    return Array.isArray(tools) && tools.length > 0 ? tools : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeActiveTools(activeTools: string[]): void {
+  const path = getSettingsPath();
+  let settings: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      settings = JSON.parse(readFileSync(path, "utf8"));
+    } catch {}
+  }
+  if (activeTools.length > 0) {
+    settings[ACTIVE_TOOLS_KEY] = activeTools;
+  } else {
+    delete settings[ACTIVE_TOOLS_KEY];
+  }
+  writeFileSync(path, JSON.stringify(settings, null, 2) + "\n", "utf8");
+}
+
+// Enumerate all available tools (built-in + extensions) by creating a temp session
+async function enumerateTools(cwd: string) {
+  if (!cwd || !existsSync(cwd)) return [];
+
+  const agentDir = getAgentDir();
+  const sessionManager = SessionManager.create(cwd, undefined);
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir,
+    sessionManager,
+  });
+
+  const allTools: { name: string; description: string; active: boolean }[] = [];
+  const toolEntries = session.getAllTools?.() ?? [];
+  const savedActive = readActiveTools();
+  const activeSet = savedActive
+    ? new Set(savedActive)
+    : new Set(session.getActiveToolNames?.() ?? []);
+
+  for (const t of toolEntries) {
+    allTools.push({
+      name: t.name,
+      description: t.description ?? "",
+      active: activeSet.has(t.name),
+    });
+  }
+
+  session.dispose?.();
+  return allTools;
+}
+
+// GET /api/tools?cwd=xxx — returns saved config + tool list
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const cwd = searchParams.get("cwd");
+
+  const activeTools = readActiveTools();
+  let tools: { name: string; description: string; active: boolean }[] = [];
+
+  if (cwd) {
+    try {
+      tools = await enumerateTools(cwd);
+    } catch (e) {
+      console.error("Failed to enumerate tools:", e);
+    }
+  }
+
+  return NextResponse.json({ config: { activeTools }, tools });
+}
+
+// POST /api/tools — saves active tools to settings.json
+// body: { activeTools: string[] }
+export async function POST(req: Request) {
+  try {
+    const body = await req.json() as { activeTools: string[] };
+    const { activeTools } = body;
+    if (!Array.isArray(activeTools)) {
+      return NextResponse.json(
+        { error: "activeTools must be an array" },
+        { status: 400 }
+      );
+    }
+    writeActiveTools(activeTools);
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { FileViewer } from "./FileViewer";
 import { TabBar, type Tab } from "./TabBar";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
+import { ToolsConfig } from "./ToolsConfig";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
@@ -26,6 +27,7 @@ export function AppShell() {
   const [modelsConfigOpen, setModelsConfigOpen] = useState(false);
   const [modelsRefreshKey, setModelsRefreshKey] = useState(0);
   const [skillsConfigOpen, setSkillsConfigOpen] = useState(false);
+  const [toolsConfigOpen, setToolsConfigOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const chatInputRef = useRef<ChatInputHandle | null>(null);
   const topBarRef = useRef<HTMLDivElement>(null);
@@ -267,6 +269,16 @@ export function AppShell() {
                 <path d="M12 2L2 7l10 5 10-5-10-5z" />
                 <path d="M2 17l10 5 10-5" />
                 <path d="M2 12l10 5 10-5" />
+              </svg>
+            ),
+          },
+          {
+            label: "Tools",
+            onClick: () => setToolsConfigOpen(true),
+            disabled: false,
+            icon: (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
               </svg>
             ),
           },
@@ -647,6 +659,12 @@ export function AppShell() {
     {modelsConfigOpen && <ModelsConfig onClose={() => { setModelsConfigOpen(false); setModelsRefreshKey((k) => k + 1); }} />}
     {skillsConfigOpen && (activeCwd ?? selectedSession?.cwd ?? newSessionCwd) && (
       <SkillsConfig cwd={(activeCwd ?? selectedSession?.cwd ?? newSessionCwd)!} onClose={() => setSkillsConfigOpen(false)} />
+    )}
+    {toolsConfigOpen && (
+      <ToolsConfig
+        cwd={selectedSession?.cwd ?? newSessionCwd ?? activeCwd ?? null}
+        onClose={() => setToolsConfigOpen(false)}
+      />
     )}
     </>
   );

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -69,14 +69,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const [value, setValue] = useState("");
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [modelDropdownRect, setModelDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
-  const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
   const [thinkingDropdownOpen, setThinkingDropdownOpen] = useState(false);
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const modelDropdownPanelRef = useRef<HTMLDivElement>(null);
-  const toolDropdownRef = useRef<HTMLDivElement>(null);
   const thinkingDropdownRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -248,9 +246,6 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         modelDropdownPanelRef.current && !modelDropdownPanelRef.current.contains(e.target as Node)
       ) {
         setModelDropdownOpen(false);
-      }
-      if (toolDropdownRef.current && !toolDropdownRef.current.contains(e.target as Node)) {
-        setToolDropdownOpen(false);
       }
       if (thinkingDropdownRef.current && !thinkingDropdownRef.current.contains(e.target as Node)) {
         setThinkingDropdownOpen(false);
@@ -689,80 +684,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 )}
               </div>
             )}
-            {!isStreaming && onToolPresetChange && (
-              <div ref={toolDropdownRef} style={{ position: "relative" }}>
-                <button
-                  onClick={() => !isStreaming && setToolDropdownOpen((v) => !v)}
-                  disabled={isStreaming}
-                  title="切换工具预设"
-                  style={{
-                    display: "flex", alignItems: "center", gap: 5,
-                    padding: "8px 12px",
-                    height: 32,
-                    background: toolDropdownOpen ? "var(--bg-hover)" : "none",
-                    border: "none",
-                    borderRadius: 9,
-                    color: "var(--text-muted)",
-                    cursor: isStreaming ? "not-allowed" : "pointer",
-                    fontSize: 12,
-                    opacity: isStreaming ? 0.5 : 1,
-                    transition: "background 0.12s, color 0.12s",
-                  }}
-                  onMouseEnter={(e) => {
-                    if (isStreaming) return;
-                    e.currentTarget.style.background = "var(--bg-hover)";
-                    e.currentTarget.style.color = "var(--text)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = toolDropdownOpen ? "var(--bg-hover)" : "none";
-                    e.currentTarget.style.color = "var(--text-muted)";
-                  }}
-                >
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
-                  </svg>
-                  <span>{Object.entries(TOOL_PRESET_MAP).find(([, v]) => v === (toolPreset ?? "default"))?.[0] ?? "default"}</span>
-                </button>
-                {toolDropdownOpen && (
-                  <div style={{
-                    position: "absolute", bottom: "calc(100% + 6px)", right: 0,
-                    zIndex: 100, background: "var(--bg)", border: "1px solid var(--border)",
-                    borderRadius: 8, boxShadow: "0 -4px 16px rgba(0,0,0,0.10)",
-                    overflow: "hidden", minWidth: 120,
-                  }}>
-                    {TOOL_PRESETS.map((lvl) => {
-                      const preset = TOOL_PRESET_MAP[lvl];
-                      const isActive = (toolPreset ?? "default") === preset;
-                      const desc = lvl === "off" ? "无工具，纯聊天" : lvl === "default" ? "4 项内置工具" : "全部内置工具";
-                      return (
-                        <button
-                          key={lvl}
-                          onClick={() => { setToolDropdownOpen(false); if (!isActive) onToolPresetChange(preset); }}
-                          style={{
-                            display: "flex", alignItems: "center", gap: 8,
-                            width: "100%", padding: "7px 12px",
-                            background: isActive ? "var(--bg-selected)" : "none",
-                            border: "none",
-                            color: isActive ? "var(--text)" : "var(--text-muted)",
-                            cursor: "pointer", fontSize: 12, textAlign: "left",
-                            fontWeight: isActive ? 600 : 400,
-                            whiteSpace: "nowrap",
-                          }}
-                          onMouseEnter={(e) => { if (!isActive) e.currentTarget.style.background = "var(--bg-hover)"; }}
-                          onMouseLeave={(e) => { if (!isActive) e.currentTarget.style.background = "none"; }}
-                        >
-                          {isActive
-                            ? <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><polyline points="1.5 5 4 7.5 8.5 2.5" /></svg>
-                            : <span style={{ width: 10, flexShrink: 0 }} />}
-                          <span style={{ flex: 1 }}>{lvl}</span>
-                          <span style={{ fontSize: 11, color: "var(--text-dim)", marginLeft: 8 }}>{desc}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            )}
+            {/* Tool preset removed — use sidebar Tools button instead */}
 
             {!isStreaming && onCompact && (
               <div style={{ position: "relative" }}>

--- a/components/ToolPanel.tsx
+++ b/components/ToolPanel.tsx
@@ -14,11 +14,13 @@ export const PRESET_DEFAULT: string[] = ["read", "bash", "edit", "write"];
 export const PRESET_FULL: string[] = ["bash", "read", "edit", "write", "grep", "find", "ls"];
 
 export function getPresetFromTools(tools: ToolEntry[]): ToolPreset {
-  const active = tools.filter(t => t.active).map(t => t.name).sort().join(",");
-  if (active === "") return "none";
-  if (active === [...PRESET_DEFAULT].sort().join(",")) return "default";
-  if (active === [...PRESET_FULL].sort().join(",")) return "full";
-  return "default"; // closest match
+  const active = new Set(tools.filter(t => t.active).map(t => t.name));
+  if (active.size === 0) return "none";
+  // Check superset: all "full" tools active -> High
+  if (PRESET_FULL.every(t => active.has(t))) return "full";
+  // All "default" tools active (but not all "full") -> Low
+  if (PRESET_DEFAULT.every(t => active.has(t))) return "default";
+  return "none";
 }
 
 interface Props {

--- a/components/ToolsConfig.tsx
+++ b/components/ToolsConfig.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { ToolEntry } from "./ToolPanel";
+
+interface Props {
+  cwd: string | null;
+  onClose: () => void;
+}
+
+export function ToolsConfig({ cwd, onClose }: Props) {
+  const [tools, setTools] = useState<ToolEntry[]>([]);
+  const [active, setActive] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Fetch tools via the tools API (doesn't need active session)
+  useEffect(() => {
+    if (!cwd) {
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetch(`/api/tools?cwd=${encodeURIComponent(cwd)}`);
+        const d = await res.json();
+        if (d.tools && Array.isArray(d.tools) && d.tools.length > 0) {
+          setTools(d.tools);
+          setActive(new Set(d.tools.filter((t: ToolEntry) => t.active).map((t: ToolEntry) => t.name)));
+        }
+      } catch (e) {
+        console.error("Failed to fetch tools:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [cwd]);
+
+  // Group tools by category
+  const builtinTools = tools.filter(t => ["read", "bash", "edit", "write", "grep", "find", "ls"].includes(t.name));
+  const extensionTools = tools.filter(t => !["read", "bash", "edit", "write", "grep", "find", "ls"].includes(t.name));
+
+  const toggle = (name: string) => {
+    setActive(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const setAll = (enabled: boolean) => {
+    if (enabled) {
+      setActive(new Set(tools.map(t => t.name)));
+    } else {
+      setActive(new Set());
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const names = [...active];
+      // Save to server config
+      await fetch("/api/tools", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ activeTools: names }),
+      });
+      // Note: tools take effect on the NEXT new session.
+      // The saved config is read by startRpcSession on session creation.
+      onClose();
+    } catch (e) {
+      console.error("Failed to save tools config:", e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          width: 480,
+          maxHeight: "78vh",
+          background: "var(--bg)",
+          border: "1px solid var(--border)",
+          borderRadius: 10,
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "12px 18px",
+            borderBottom: "1px solid var(--border)",
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: 15, fontWeight: 700, color: "var(--text)" }}>
+            Tools
+          </span>
+          {tools.length > 0 && (
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                onClick={() => setAll(true)}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "none",
+                  color: "var(--text-muted)",
+                  cursor: "pointer",
+                  fontSize: 11,
+                }}
+              >
+                Enable all
+              </button>
+              <button
+                onClick={() => setAll(false)}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "none",
+                  color: "var(--text-muted)",
+                  cursor: "pointer",
+                  fontSize: 11,
+                }}
+              >
+                Disable all
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Tool list */}
+        <div style={{ flex: 1, overflow: "auto", padding: "8px 0" }}>
+          {loading ? (
+            <div style={{ padding: "40px 18px", textAlign: "center", fontSize: 12, color: "var(--text-dim)" }}>
+              Loading tools...
+            </div>
+          ) : tools.length === 0 ? (
+            <div style={{ padding: "40px 18px", textAlign: "center", fontSize: 12, color: "var(--text-dim)" }}>
+              No tools available. Select a workspace directory first.
+            </div>
+          ) : (
+            <>
+              {builtinTools.length > 0 && (
+                <>
+                  <div style={{ padding: "4px 18px", fontSize: 11, color: "var(--text-dim)", fontWeight: 600 }}>
+                    Built-in
+                  </div>
+                  {builtinTools.map(tool => (
+                    <ToolRow key={tool.name} tool={tool} active={active.has(tool.name)} onToggle={toggle} />
+                  ))}
+                </>
+              )}
+              {extensionTools.length > 0 && (
+                <>
+                  <div style={{ padding: "12px 18px 4px", fontSize: 11, color: "var(--text-dim)", fontWeight: 600 }}>
+                    Extensions
+                  </div>
+                  {extensionTools.map(tool => (
+                    <ToolRow key={tool.name} tool={tool} active={active.has(tool.name)} onToggle={toggle} />
+                  ))}
+                </>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "10px 18px",
+            borderTop: "1px solid var(--border)",
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: 10, color: "var(--text-dim)" }}>
+            Takes effect on next new session
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              padding: "6px 16px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "none",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              fontSize: 12,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || loading || tools.length === 0}
+            style={{
+              padding: "6px 16px",
+              borderRadius: 8,
+              border: "none",
+              background: "var(--accent)",
+              color: "#fff",
+              cursor: saving || loading || tools.length === 0 ? "default" : "pointer",
+              fontSize: 12,
+              opacity: saving || loading || tools.length === 0 ? 0.6 : 1,
+            }}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToolRow({ tool, active, onToggle }: { tool: ToolEntry; active: boolean; onToggle: (name: string) => void }) {
+  return (
+    <div
+      onClick={() => onToggle(tool.name)}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "6px 18px",
+        cursor: "pointer",
+        transition: "background 0.1s",
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
+    >
+      {/* Toggle switch */}
+      <div
+        style={{
+          width: 32,
+          height: 18,
+          borderRadius: 10,
+          background: active ? "var(--accent)" : "var(--border)",
+          position: "relative",
+          transition: "background 0.15s",
+          flexShrink: 0,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 2,
+            left: active ? 15 : 2,
+            width: 14,
+            height: 14,
+            borderRadius: 7,
+            background: "#fff",
+            transition: "left 0.15s",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.2)",
+          }}
+        />
+      </div>
+      {/* Name */}
+      <span style={{ fontSize: 13, color: active ? "var(--text)" : "var(--text-muted)", fontWeight: active ? 500 : 400 }}>
+        {tool.name}
+      </span>
+      {/* Description */}
+      <span style={{ fontSize: 11, color: "var(--text-dim)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {tool.description}
+      </span>
+    </div>
+  );
+}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -352,8 +352,20 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       if (isNew && newSessionCwd) {
         const selectedModel = newSessionModel;
         if (selectedModel) setPendingModel(selectedModel);
-        const { PRESET_NONE, PRESET_DEFAULT, PRESET_FULL } = await import("@/components/ToolPanel");
-        const toolNames = toolPreset === "none" ? PRESET_NONE : toolPreset === "default" ? PRESET_DEFAULT : PRESET_FULL;
+        // Read saved tool config if available, otherwise use preset
+        let toolNames: string[];
+        try {
+          const savedRes = await fetch("/api/tools");
+          const saved = await savedRes.json() as { config?: { activeTools?: string[] } };
+          if (saved.config?.activeTools && saved.config.activeTools.length > 0) {
+            toolNames = saved.config.activeTools;
+          } else {
+            throw new Error("no saved config");
+          }
+        } catch {
+          const { PRESET_NONE, PRESET_DEFAULT, PRESET_FULL } = await import("@/components/ToolPanel");
+          toolNames = toolPreset === "none" ? PRESET_NONE : toolPreset === "default" ? PRESET_DEFAULT : PRESET_FULL;
+        }
         const res = await fetch("/api/agent/new", {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,5 +1,7 @@
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { cacheSessionPath } from "./session-reader";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import type { AgentSessionLike, ToolInfo } from "./pi-types";
 
 // ============================================================================
@@ -208,7 +210,21 @@ export class AgentSessionWrapper {
       }
 
       case "set_tools": {
-        this.inner.setActiveToolsByName(command.toolNames as string[]);
+        const names = command.toolNames as string[];
+        const exact = command.exact as boolean | undefined;
+        if (names.length === 0) {
+          // Disable all tools
+          this.inner.setActiveToolsByName([]);
+        } else if (exact) {
+          // From ToolsConfig: set EXACTLY these tools (user's explicit choice)
+          this.inner.setActiveToolsByName(names);
+        } else {
+          // From old preset: preserve all registered tools (extensions + built-in)
+          const allTools = this.inner.getAllTools();
+          const activeNames = new Set(names);
+          for (const t of allTools) activeNames.add(t.name);
+          this.inner.setActiveToolsByName([...activeNames]);
+        }
         return null;
       }
 
@@ -293,13 +309,25 @@ export async function startRpcSession(
       ? SessionManager.open(sessionFile, undefined)
       : SessionManager.create(cwd, undefined);
 
-    // Determine which tools to pass based on requested toolNames.
-    // Since v0.68.0, createAgentSession expects string[] tool names instead of Tool[] instances.
-    // Pass all built-in coding tool names by default; for "all off", pass empty array.
-    const allCodingToolNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+    // Determine which tools to pass based on requested toolNames or saved config.
+    // Priority:
+    // 1. Frontend explicitly passed toolNames — use it
+    // 2. Saved activeTools in settings.json — use that (persisted across sessions)
+    // 3. Default: let core's includeAllExtensionTools handle it (all tools active)
     let toolsOption: string[] | undefined;
     if (toolNames !== undefined) {
-      toolsOption = toolNames.length === 0 ? [] : allCodingToolNames;
+      toolsOption = toolNames.length === 0 ? [] : toolNames;
+    } else {
+      // Read saved activeTools from settings.json
+      try {
+        const settingsPath = join(agentDir, "settings.json");
+        if (existsSync(settingsPath)) {
+          const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+          if (Array.isArray(settings.activeTools) && settings.activeTools.length > 0) {
+            toolsOption = settings.activeTools;
+          }
+        }
+      } catch {}
     }
 
     const { session: inner } = await createAgentSession({
@@ -309,16 +337,14 @@ export async function startRpcSession(
       ...(toolsOption !== undefined ? { tools: toolsOption } : {}),
     });
 
-    // If specific tool names were requested (non-empty), narrow active tools now
-    if (toolNames && toolNames.length > 0) {
-      inner.setActiveToolsByName(toolNames);
-    }
-
-    // When all tools are disabled, clear the system prompt entirely.
-    // pi's buildSystemPrompt always produces a non-empty prompt even with no tools;
-    // the only way to truly clear it is to call agent.setSystemPrompt directly.
-    if (toolNames?.length === 0) {
-      inner.agent.state.systemPrompt = "";
+    // Apply exact tool list after creation, overriding includeAllExtensionTools.
+    if (toolsOption !== undefined) {
+      if (toolsOption.length === 0) {
+        inner.setActiveToolsByName([]);
+        inner.agent.state.systemPrompt = "";
+      } else {
+        inner.setActiveToolsByName(toolsOption);
+      }
     }
 
     const wrapper = new AgentSessionWrapper(inner);


### PR DESCRIPTION
## 概述 / Summary

新增 ToolsConfig 面板，每个工具（内置 + 扩展）可单独开关，替代旧的 Low/High/Off 预设下拉菜单。配置持久化到 `settings.json` 的 `activeTools` 字段，pi-cli 也可共享。

Replace the old wrench-icon Low/High/Off preset dropdown with a ToolsConfig modal panel where each tool (built-in + extension) can be individually toggled. Config is persisted to `settings.json` under `activeTools`, shared with pi-cli.

## 改动 / Changes

| File | Change |
|------|--------|
| `app/api/tools/route.ts` | **New** — tool enumeration via temp session + read/write `activeTools` in `settings.json` |
| `components/ToolsConfig.tsx` | **New** — modal panel with per-tool toggles, grouped by Built-in / Extensions |
| `lib/rpc-manager.ts` | `startRpcSession` reads `activeTools` from `settings.json`; `set_tools` supports `exact` flag |
| `components/AppShell.tsx` | Added **Tools** button in left sidebar |
| `components/ChatInput.tsx` | Removed old wrench-icon Low/High/Off preset dropdown |
| `hooks/useAgentSession.ts` | New sessions read saved config from `/api/tools`, fall back to old presets |
| `components/ToolPanel.tsx` | `getPresetFromTools` uses superset matching for extension compatibility |

## 向后兼容 / Backward Compatibility

- 旧预设下拉菜单已移除，但 `set_tools` 不加 `exact: true` 时仍保留所有已注册工具（含扩展）
- `settings.json` 中的 `activeTools` 字段对旧版 pi-cli 无影响（忽略未知字段）
- The old preset dropdown is removed, but `set_tools` without `exact: true` still preserves all registered tools (including extensions)
- `activeTools` in `settings.json` is ignored by older pi-cli versions