### PR TITLE
feat: 会话完成后自动生成摘要标题

### DIFF
--- a/app/api/sessions/[id]/generate-title/route.ts
+++ b/app/api/sessions/[id]/generate-title/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { SessionManager, AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { completeSimple } from "@earendil-works/pi-ai";
+import { resolveSessionPath, buildSessionContext } from "@/lib/session-reader";
+
+const TITLE_PROMPT = `Summarize the following conversation in 3-8 words. Output ONLY the summary title, nothing else. No quotes, no punctuation at the end. Use the same language as the conversation.`;
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  try {
+    const filePath = await resolveSessionPath(id);
+    if (!filePath) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const sm = SessionManager.open(filePath);
+
+    // Don't regenerate if the session already has a custom name
+    const existingName = sm.getSessionName();
+    if (existingName) {
+      return NextResponse.json({ title: existingName, skipped: true });
+    }
+
+    const entries = sm.getEntries() as never;
+    const leafId = sm.getLeafId();
+    const context = buildSessionContext(entries, leafId);
+
+    // Need at least one user message and one assistant response
+    if (!context.messages.some((m) => m.role === "user") || !context.messages.some((m) => m.role === "assistant")) {
+      return NextResponse.json({ error: "Not enough messages to generate title" }, { status: 400 });
+    }
+
+    // Build a compact text summary of the conversation for the LLM
+    const conversationText = context.messages
+      .filter((m) => m.role === "user" || m.role === "assistant")
+      .map((m) => {
+        const content = m.content;
+        if (typeof content === "string") {
+          return `${m.role === "user" ? "User" : "Assistant"}: ${content}`;
+        }
+        if (Array.isArray(content)) {
+          const textParts = content
+            .filter((b): b is { type: "text"; text: string } => b.type === "text")
+            .map((b) => b.text)
+            .join("\n");
+          return `${m.role === "user" ? "User" : "Assistant"}: ${textParts}`;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n\n");
+
+    // Truncate to avoid using too many tokens
+    const MAX_CHARS = 3000;
+    const truncated = conversationText.length > MAX_CHARS
+      ? conversationText.slice(0, MAX_CHARS) + "\n\n[... conversation truncated]"
+      : conversationText;
+
+    // Resolve the model to use — prefer the session's current model, fall back to default
+    const authStorage = AuthStorage.create();
+    const registry = ModelRegistry.create(authStorage);
+    const available = registry.getAvailable();
+
+    if (available.length === 0) {
+      return NextResponse.json({ error: "No models available" }, { status: 400 });
+    }
+
+    // Try to use the session's current model
+    let model = context.model
+      ? registry.find(context.model.provider, context.model.modelId)
+      : undefined;
+
+    // Fall back to first available model
+    if (!model) {
+      model = available[0];
+    }
+
+    // Resolve API key through pi's ModelRegistry (handles AuthStorage, env vars, OAuth, etc.)
+    const auth = await registry.getApiKeyAndHeaders(model);
+    if (!auth.ok) {
+      return NextResponse.json({ error: auth.error }, { status: 400 });
+    }
+
+    // Use completeSimple for a non-streaming call
+    const result = await completeSimple(
+      model as never,
+      {
+        systemPrompt: TITLE_PROMPT,
+        messages: [
+          {
+            role: "user" as const,
+            content: truncated,
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        maxTokens: 60,
+        temperature: 0.3,
+        apiKey: auth.apiKey,
+        ...(auth.headers ? { headers: auth.headers } : {}),
+      }
+    );
+
+    // Extract text from response
+    if (result.stopReason === "error" || result.stopReason === "aborted") {
+      return NextResponse.json(
+        { error: result.errorMessage ?? "LLM call failed" },
+        { status: 500 }
+      );
+    }
+
+    let title = "";
+    if (result.content && Array.isArray(result.content)) {
+      const textParts = result.content
+        .filter((b: { type: string }) => b.type === "text")
+        .map((b: { text: string }) => b.text);
+      title = textParts.join("").trim();
+    }
+
+    if (!title) {
+      return NextResponse.json({ error: "Failed to generate title" }, { status: 500 });
+    }
+
+    // Clean up the title — remove quotes, trailing punctuation
+    title = title
+      .replace(/^["'`]+|["'`]+$/g, "")
+      .replace(/[.!?。！？]+$/, "")
+      .trim()
+      .slice(0, 80); // Hard limit
+
+    if (!title) {
+      return NextResponse.json({ error: "Generated empty title" }, { status: 500 });
+    }
+
+    // Save the title via session manager
+    sm.appendSessionInfo(title);
+
+    return NextResponse.json({ title, skipped: false });
+  } catch (error) {
+    return NextResponse.json(
+      { error: String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -165,6 +165,18 @@ export function AppShell() {
     setExplorerRefreshKey((k) => k + 1);
   }, []);
 
+  const handleTitleGenerated = useCallback((sessionId: string, title: string) => {
+    // Refresh sidebar to pick up the new title
+    setRefreshKey((k) => k + 1);
+    // Update the selected session's name locally for immediate feedback
+    setSelectedSession((prev) => {
+      if (prev?.id === sessionId) {
+        return { ...prev, name: title };
+      }
+      return prev;
+    });
+  }, []);
+
   const handleSessionForked = useCallback((newSessionId: string) => {
     setRefreshKey((k) => k + 1);
     setSessionKey((k) => k + 1);
@@ -566,6 +578,7 @@ export function AppShell() {
               onSystemPromptChange={handleSystemPromptChange}
               onSessionStatsChange={handleSessionStatsChange}
               onContextUsageChange={handleContextUsageChange}
+              onTitleGenerated={handleTitleGenerated}
             />
           ) : showPlaceholder ? (
             activeCwd ? (

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -21,6 +21,7 @@ interface Props {
   onSystemPromptChange?: (prompt: string | null) => void;
   onSessionStatsChange?: (stats: { tokens: { input: number; output: number; cacheRead: number; cacheWrite: number }; cost?: number } | null) => void;
   onContextUsageChange?: (usage: { percent: number | null; contextWindow: number; tokens: number | null } | null) => void;
+  onTitleGenerated?: (sessionId: string, title: string) => void;
 }
 
 function phaseLabel(phase: AgentPhase): string {
@@ -90,7 +91,7 @@ function Typewriter({ phrases }: { phrases: string[] }) {
   );
 }
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onContextUsageChange, onTitleGenerated }: Props) {
   const {
     loading, error, messages, entryIds, streamState,
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
@@ -105,7 +106,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     handleToolPresetChange, handleThinkingLevelChange, handleAgentEventRef,
   } = useAgentSession({
     session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked,
-    modelsRefreshKey, onBranchDataChange, onSystemPromptChange,
+    modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onTitleGenerated,
   });
 
   const { soundEnabled, onSoundToggle, playDoneSound } = useAudio();

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -66,6 +66,8 @@ export interface UseAgentSessionOptions {
   onSystemPromptChange?: (prompt: string | null) => void;
   setNewSessionModel?: (model: { provider: string; modelId: string } | null) => void;
   setToolPreset?: (preset: "none" | "default" | "full") => void;
+  /** Called when a session title is auto-generated after agent ends */
+  onTitleGenerated?: (sessionId: string, title: string) => void;
 }
 
 export type ThinkingLevelOption = "auto" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -85,7 +87,7 @@ export interface AttachedImage {
 export function useAgentSession(opts: UseAgentSessionOptions) {
   const {
     session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked,
-    modelsRefreshKey, onBranchDataChange, onSystemPromptChange,
+    modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onTitleGenerated,
   } = opts;
 
   const isNew = session === null && newSessionCwd !== null;
@@ -263,6 +265,19 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
               if (d.state?.systemPrompt !== undefined) setSystemPrompt(d.state.systemPrompt ?? null);
             })
             .catch(() => {});
+          // Auto-generate title if session doesn't have a custom name
+          const currentSessionId = sessionIdRef.current;
+          const sessionHasName = !!session?.name;
+          if (!sessionHasName) {
+            fetch(`/api/sessions/${encodeURIComponent(currentSessionId)}/generate-title`, { method: "POST" })
+              .then((r) => r.json())
+              .then((data: { title?: string; skipped?: boolean; error?: string }) => {
+                if (data.title && !data.skipped) {
+                  onTitleGenerated?.(currentSessionId, data.title);
+                }
+              })
+              .catch(() => {}); // Silently ignore title generation failures
+          }
         }
         onAgentEnd?.();
         break;
@@ -325,7 +340,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         }
         break;
     }
-  }, [loadSession, onAgentEnd]);
+  }, [loadSession, onAgentEnd, onTitleGenerated, session?.name]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {


### PR DESCRIPTION
## 功能描述

**ASIS（当前状态）：**
左边栏 session 的标题直接取用户首轮 query 的内容（截断到50字符），当对话较长或任务较复杂时，标题往往不能直观反映会话的实际内容。

**TOBE（目标状态）：**
当一个会话的对话或 agent 任务完成后（`agent_end` 事件），自动调用 LLM 总结当前对话/任务内容，为 session 生成简短的摘要标题，显示在左边栏。

## 实现方案

### 新增 API 路由
`POST /api/sessions/[id]/generate-title`
- 读取会话的所有消息内容
- 使用会话当前 LLM 模型发送总结 prompt（3-8 个词的简短标题）
- 通过 `SessionManager.appendSessionInfo()` 将标题持久化到 `.jsonl` 文件
- 如果 session 已有自定义名称则跳过
- 通过 `ModelRegistry.getApiKeyAndHeaders()` 解析 API key（支持 AuthStorage / 环境变量 / OAuth 等方式）
- 对话文本截断为 3000 字符以节省 token

### 前端改动
- `useAgentSession` hook：在 `agent_end` 事件触发时，检查 session 是否已有名称，若无则异步调用标题生成接口，失败时静默忽略
- `ChatWindow` / `AppShell`：通过 `onTitleGenerated` 回调逐层传递，收到生成结果后立即更新本地 session 状态并刷新侧边栏

## 文件变更

| 文件 | 说明 |
|------|------|
| `app/api/sessions/[id]/generate-title/route.ts` | 新增：标题生成 API 路由 |
| `hooks/useAgentSession.ts` | 修改：agent_end 时触发标题生成 |
| `components/ChatWindow.tsx` | 修改：传递 onTitleGenerated prop |
| `components/AppShell.tsx` | 修改：处理标题生成回调，刷新侧边栏 |