### PR TITLE
fix: compress linear tree chains instead of removing tree field to prevent JSON.stringify stack overflow

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -10,6 +10,22 @@ import {
 } from "@/lib/session-reader";
 import { getRpcSession } from "@/lib/rpc-manager";
 
+/**
+ * Collapse consecutive single-child nodes into their parent to avoid
+ * JSON.stringify call stack overflow on 2000+ message linear sessions.
+ */
+function compressTree<T extends { children: T[] }>(nodes: T[]): T[] {
+  function walk(node: T): T {
+    if (node.children.length === 0) return node;
+    if (node.children.length === 1) {
+      const collapsed = walk(node.children[0]);
+      return { ...node, children: collapsed.children };
+    }
+    return { ...node, children: node.children.map(walk) };
+  }
+  return nodes.map(walk);
+}
+
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -23,8 +39,8 @@ export async function GET(
 
     const sm = SessionManager.open(filePath);
     const entries = sm.getEntries() as never;
-    const tree = sm.getTree();
     const leafId = sm.getLeafId();
+    const tree = compressTree(sm.getTree());
     const context = buildSessionContext(entries, leafId);
 
     const header = sm.getHeader();
@@ -66,8 +82,8 @@ export async function GET(
       sessionId: id,
       filePath,
       info,
-      tree,
       leafId,
+      tree,
       context,
       ...(agentState !== undefined ? { agentState } : {}),
     });


### PR DESCRIPTION
**Title:**

fix: compress linear tree chains instead of removing tree field to prevent JSON.stringify stack overflow

**Description:**

Previous PR (#38) removed the `tree` field entirely, which broke `BranchNavigator` — branched sessions lost in-session branch navigation.

This PR takes a different approach: instead of removing `tree`, it applies a **linear chain compression** before serialization.

## How it works

- A recursive `walk` function traverses the tree
- **Single-child chains** (e.g., `A → B → C → D` where each node has exactly one child) are collapsed — each node adopts its grandchild's children, effectively flattening the chain
- **Branching points** (nodes with >1 children) are preserved as-is

## Result

- A 2000+ message **linear** session: depth goes from 2000+ → 1 (root node only, no overhead)
- A **branched** session `root → A → [branch1, branch2]`: preserved as-is, only the linear prefix before the first branch is collapsed
- `JSON.stringify` stays well within V8's ~3000 recursion limit
- `BranchNavigator` receives a valid (compressed) tree and renders correctly

## Testing

- Verified with a 3400-message linear session: opens without error, ChatMinimap and branch navigation working
- Branched session creation and navigation tested and working