### PR TITLE
refactor: use relative API paths to support basePath

### DIFF
--- a/app/api/agent/[id]/events/route.ts
+++ b/app/api/agent/[id]/events/route.ts
@@ -4,7 +4,7 @@ import { SessionManager } from "@earendil-works/pi-coding-agent";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/agent/[id]/events - SSE stream of agent events
+// GET api/agent/[id]/events - SSE stream of agent events
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/app/api/agent/[id]/route.ts
+++ b/app/api/agent/[id]/route.ts
@@ -3,7 +3,7 @@ import { resolveSessionPath } from "@/lib/session-reader";
 import { startRpcSession, getRpcSession } from "@/lib/rpc-manager";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 
-// POST /api/agent/[id] - Send a command to an existing session
+// POST api/agent/[id] - Send a command to an existing session
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -36,7 +36,7 @@ export async function POST(
   }
 }
 
-// GET /api/agent/[id] - Get current agent state
+// GET api/agent/[id] - Get current agent state
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { existsSync } from "fs";
 import { startRpcSession } from "@/lib/rpc-manager";
 
-// POST /api/agent/new  body: { cwd: string; type: string; message: string; ... }
+// POST api/agent/new  body: { cwd: string; type: string; message: string; ... }
 // Spawns a brand-new pi session and immediately sends the first command.
 // Returns { sessionId, data } where sessionId is pi's real session id.
 export async function POST(req: Request) {
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     const { session, realSessionId } = await startRpcSession(tempKey, "", cwd, toolNames);
 
     // Keep the files-route allowed-roots cache (see app/api/files/[...path]/route.ts)
-    // in sync so the new cwd is immediately readable via /api/files. Without this,
+    // in sync so the new cwd is immediately readable via api/files. Without this,
     // a file request under a brand-new cwd would 403 for up to the cache TTL.
     globalThis.__piAllowedRootsCache?.roots.add(cwd);
 

--- a/app/api/auth/all-providers/route.ts
+++ b/app/api/auth/all-providers/route.ts
@@ -2,7 +2,7 @@ import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 export const dynamic = "force-dynamic";
 
-// Providers that use OAuth — handled separately via /api/auth/providers
+// Providers that use OAuth — handled separately via api/auth/providers
 const OAUTH_PROVIDER_IDS = new Set(["anthropic", "github-copilot", "openai-codex"]);
 
 export async function GET() {

--- a/app/api/auth/api-key/[provider]/route.ts
+++ b/app/api/auth/api-key/[provider]/route.ts
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ provider: string }> };
 
-// GET /api/auth/api-key/[provider] — returns auth status (never returns the actual key)
+// GET api/auth/api-key/[provider] — returns auth status (never returns the actual key)
 export async function GET(_req: Request, { params }: Params) {
   const { provider } = await params;
   const authStorage = AuthStorage.create();
@@ -16,7 +16,7 @@ export async function GET(_req: Request, { params }: Params) {
   return NextResponse.json({ provider, displayName, configured: status.configured, source: status.source, models });
 }
 
-// POST /api/auth/api-key/[provider]  body: { apiKey: string }
+// POST api/auth/api-key/[provider]  body: { apiKey: string }
 export async function POST(req: Request, { params }: Params) {
   const { provider } = await params;
   try {
@@ -32,7 +32,7 @@ export async function POST(req: Request, { params }: Params) {
   }
 }
 
-// DELETE /api/auth/api-key/[provider] — removes stored API key
+// DELETE api/auth/api-key/[provider] — removes stored API key
 export async function DELETE(_req: Request, { params }: Params) {
   const { provider } = await params;
   try {

--- a/app/api/auth/login/[provider]/route.ts
+++ b/app/api/auth/login/[provider]/route.ts
@@ -12,7 +12,7 @@ function getCallbackRegistry() {
   return globalThis.__piLoginCallbacks;
 }
 
-// POST /api/auth/login/[provider] — frontend sends redirect URL or auth code
+// POST api/auth/login/[provider] — frontend sends redirect URL or auth code
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ provider: string }> }
@@ -39,7 +39,7 @@ export async function POST(
   return Response.json({ ok: true, provider });
 }
 
-// GET /api/auth/login/[provider] — SSE stream for OAuth flow
+// GET api/auth/login/[provider] — SSE stream for OAuth flow
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ provider: string }> }

--- a/app/api/cwd/validate/route.ts
+++ b/app/api/cwd/validate/route.ts
@@ -9,7 +9,7 @@ function normalizeCwd(cwd: string): string {
   return isAbsolute(cwd) ? cwd : resolve(cwd);
 }
 
-// POST /api/cwd/validate  body: { cwd: string }
+// POST api/cwd/validate  body: { cwd: string }
 // Validates a candidate workspace before the UI selects it.
 export async function POST(req: Request) {
   try {

--- a/app/api/default-cwd/route.ts
+++ b/app/api/default-cwd/route.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
-// POST /api/default-cwd
+// POST api/default-cwd
 // Creates ~/pi-cwd-<YYYYMMDD> if it doesn't exist and returns the path.
 export async function POST() {
   try {

--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -34,7 +34,7 @@ export async function PUT(req: Request) {
   try {
     const body = await req.json() as Record<string, unknown>;
     writeModelsJson(body);
-    // Model registry refreshes on each /api/models request (no local cache to invalidate)
+    // Model registry refreshes on each api/models request (no local cache to invalidate)
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -76,7 +76,7 @@ export async function GET(
   }
 }
 
-// PATCH /api/sessions/[id]  body: { name: string }
+// PATCH api/sessions/[id]  body: { name: string }
 export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -99,7 +99,7 @@ export async function PATCH(
   }
 }
 
-// DELETE /api/sessions/[id]
+// DELETE api/sessions/[id]
 export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/app/api/skills/install/route.ts
+++ b/app/api/skills/install/route.ts
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 
 const ANSI_RE = /\x1B\[[0-9;]*m/g;
 
-// POST /api/skills/install  body: { package: string; scope: "global" | "project"; cwd?: string }
+// POST api/skills/install  body: { package: string; scope: "global" | "project"; cwd?: string }
 export async function POST(req: Request) {
   try {
     const { package: pkg, scope, cwd } = await req.json() as { package?: string; scope?: string; cwd?: string };

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -4,7 +4,7 @@ import { DefaultResourceLoader, getAgentDir, parseFrontmatter } from "@earendil-
 
 export const dynamic = "force-dynamic";
 
-// GET /api/skills?cwd=<path>
+// GET api/skills?cwd=<path>
 // Uses DefaultResourceLoader (same logic as AgentSession startup) so settings.json
 // skill paths, package skills, and .agents/skills directories are all included.
 export async function GET(req: Request) {
@@ -22,7 +22,7 @@ export async function GET(req: Request) {
   }
 }
 
-// PATCH /api/skills — toggle disable-model-invocation on a SKILL.md file
+// PATCH api/skills — toggle disable-model-invocation on a SKILL.md file
 export async function PATCH(req: Request) {
   try {
     const body = await req.json() as { filePath: string; disableModelInvocation: boolean };

--- a/app/api/skills/search/route.ts
+++ b/app/api/skills/search/route.ts
@@ -92,7 +92,7 @@ function parseInstallCount(installs: string): number {
   return value * multiplier;
 }
 
-// POST /api/skills/search  body: { query: string, limit?: number }
+// POST api/skills/search  body: { query: string, limit?: number }
 export async function POST(req: Request) {
   try {
     const { query, limit: rawLimit } = await req.json() as { query?: string; limit?: unknown };

--- a/components/FileExplorer.tsx
+++ b/components/FileExplorer.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 async function fetchEntries(dirPath: string): Promise<FileNode[]> {
   const encoded = encodeFilePathForApi(dirPath);
-  const res = await fetch(`/api/files/${encoded}?type=list`);
+  const res = await fetch(`api/files/${encoded}?type=list`);
   if (!res.ok) return [];
   const data = await res.json() as { entries?: FileEntry[] };
   return (data.entries ?? []).map((e) => ({

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -49,7 +49,7 @@ function DownloadLink({ filePath, label = "Download" }: { filePath: string; labe
   const encoded = encodeFilePathForApi(filePath);
   return (
     <a
-      href={`/api/files/${encoded}?type=read`}
+      href={`api/files/${encoded}?type=read`}
       download={getFileName(filePath)}
       style={{
         color: "var(--text-muted)",
@@ -326,7 +326,7 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
     }
 
     const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(`api/files/${encoded}?type=watch`);
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -347,7 +347,7 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   }, [filePath]);
 
   const encoded = encodeFilePathForApi(filePath);
-  const src = `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
+  const src = `api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
 
   const formatSizeStr = size != null ? formatSize(size) : null;
 
@@ -460,7 +460,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
     }
 
     const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(`api/files/${encoded}?type=watch`);
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -483,7 +483,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   }, [filePath]);
 
   const encoded = encodeFilePathForApi(filePath);
-  const src = `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
+  const src = `api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
@@ -565,8 +565,8 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   const encoded = encodeFilePathForApi(filePath);
   const isPdf = ext === "pdf";
   const previewUrl = isPdf
-    ? `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`
-    : `/api/files/${encoded}?type=preview${bust ? `&v=${bust}` : ""}`;
+    ? `api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`
+    : `api/files/${encoded}?type=preview${bust ? `&v=${bust}` : ""}`;
 
   useEffect(() => {
     setBust(0);
@@ -579,7 +579,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       esRef.current = null;
     }
 
-    fetch(`/api/files/${encoded}?type=meta`)
+    fetch(`api/files/${encoded}?type=meta`)
       .then((r) => r.json())
       .then((d: { size?: number; error?: string }) => {
         if (d.error) setError(d.error);
@@ -592,7 +592,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       })
       .catch((e) => setError(String(e)));
 
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(`api/files/${encoded}?type=watch`);
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -704,7 +704,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
 
   const fetchContent = useCallback((filePath: string, isRefresh = false) => {
     const encoded = encodeFilePathForApi(filePath);
-    return fetch(`/api/files/${encoded}?type=read`)
+    return fetch(`api/files/${encoded}?type=read`)
       .then((r) => r.json())
       .then((d: FileData & { error?: string }) => {
         if (d.error) {
@@ -751,7 +751,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
 
     // Set up SSE watch
     const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(`api/files/${encoded}?type=watch`);
     esRef.current = es;
 
     es.addEventListener("connected", () => {

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -526,7 +526,7 @@ function ModelDetail({
     if (!model.id.trim() || testState.phase === "testing") return;
     setTestState({ phase: "testing" });
     try {
-      const res = await fetch("/api/models-config/test", {
+      const res = await fetch("api/models-config/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ providerName, provider, model }),
@@ -718,7 +718,7 @@ function OAuthDetail({ provider, onRefresh }: { provider: OAuthProvider; onRefre
     setLoginState({ phase: "connecting" });
     setInputValue("");
 
-    const es = new EventSource(`/api/auth/login/${encodeURIComponent(provider.id)}`);
+    const es = new EventSource(`api/auth/login/${encodeURIComponent(provider.id)}`);
     eventSourceRef.current = es;
 
     es.onmessage = (e) => {
@@ -765,7 +765,7 @@ function OAuthDetail({ provider, onRefresh }: { provider: OAuthProvider; onRefre
   }, [provider.id, onRefresh]);
 
   const handleLogout = useCallback(async () => {
-    await fetch(`/api/auth/logout/${encodeURIComponent(provider.id)}`, { method: "POST" });
+    await fetch(`api/auth/logout/${encodeURIComponent(provider.id)}`, { method: "POST" });
     setLoginState({ phase: "idle" });
     onRefresh();
   }, [provider.id, onRefresh]);
@@ -774,7 +774,7 @@ function OAuthDetail({ provider, onRefresh }: { provider: OAuthProvider; onRefre
     if (!code.trim()) return;
     setLoginState({ phase: "progress", message: "Verifying…" });
     try {
-      const res = await fetch(`/api/auth/login/${encodeURIComponent(provider.id)}`, {
+      const res = await fetch(`api/auth/login/${encodeURIComponent(provider.id)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, code: code.trim() }),
@@ -794,7 +794,7 @@ function OAuthDetail({ provider, onRefresh }: { provider: OAuthProvider; onRefre
   const submitSelection = useCallback(async (token: string, value: string) => {
     setLoginState({ phase: "progress", message: "Continuing…" });
     try {
-      const res = await fetch(`/api/auth/login/${encodeURIComponent(provider.id)}`, {
+      const res = await fetch(`api/auth/login/${encodeURIComponent(provider.id)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, code: value }),
@@ -968,7 +968,7 @@ function ApiKeyDetail({ provider, onRefresh }: { provider: ApiKeyProvider; onRef
     setError(null);
     setSavedOk(false);
     try {
-      const res = await fetch(`/api/auth/api-key/${encodeURIComponent(provider.id)}`, {
+      const res = await fetch(`api/auth/api-key/${encodeURIComponent(provider.id)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ apiKey: apiKey.trim() }),
@@ -993,7 +993,7 @@ function ApiKeyDetail({ provider, onRefresh }: { provider: ApiKeyProvider; onRef
     setRemoving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/auth/api-key/${encodeURIComponent(provider.id)}`, { method: "DELETE" });
+      const res = await fetch(`api/auth/api-key/${encodeURIComponent(provider.id)}`, { method: "DELETE" });
       const d = await res.json() as { success?: boolean; error?: string };
       if (!res.ok || d.error) setError(d.error ?? `HTTP ${res.status}`);
       else onRefresh();
@@ -1237,21 +1237,21 @@ export function ModelsConfig({ onClose }: { onClose: () => void }) {
   const [pickerOpen, setPickerOpen] = useState(false);
 
   const loadOAuthProviders = useCallback(() => {
-    fetch("/api/auth/providers")
+    fetch("api/auth/providers")
       .then((r) => r.json())
       .then((d: { providers: OAuthProvider[] }) => setOauthProviders(d.providers))
       .catch(() => {});
   }, []);
 
   const loadApiKeyProviders = useCallback(() => {
-    fetch("/api/auth/all-providers")
+    fetch("api/auth/all-providers")
       .then((r) => r.json())
       .then((d: { providers: ApiKeyProvider[] }) => setApiKeyProviders(d.providers))
       .catch(() => {});
   }, []);
 
   useEffect(() => {
-    fetch("/api/models-config")
+    fetch("api/models-config")
       .then((r) => r.json())
       .then((d: ModelsJson) => {
         const normalized = d.providers ? d : { ...d, providers: {} };
@@ -1343,7 +1343,7 @@ export function ModelsConfig({ onClose }: { onClose: () => void }) {
     setSaveError(null);
     setSavedOk(false);
     try {
-      const res = await fetch("/api/models-config", {
+      const res = await fetch("api/models-config", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(config),

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -219,7 +219,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const loadSessions = useCallback(async (showLoading = false) => {
     try {
       if (showLoading) setLoading(true);
-      const res = await fetch("/api/sessions");
+      const res = await fetch("api/sessions");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json() as { sessions: SessionInfo[] };
       setAllSessions(data.sessions);
@@ -248,7 +248,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   }, [explorerRefreshKey]);
 
   useEffect(() => {
-    fetch("/api/home").then((r) => r.json()).then((d: { home?: string }) => {
+    fetch("api/home").then((r) => r.json()).then((d: { home?: string }) => {
       if (d.home) setHomeDir(d.home);
     }).catch(() => {});
   }, []);
@@ -288,7 +288,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     setCustomPathValidating(true);
     setCustomPathError(null);
     try {
-      const res = await fetch("/api/cwd/validate", {
+      const res = await fetch("api/cwd/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ cwd: path }),
@@ -311,7 +311,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
 
   const handleDefaultCwd = useCallback(async () => {
     try {
-      const res = await fetch("/api/default-cwd", { method: "POST" });
+      const res = await fetch("api/default-cwd", { method: "POST" });
       const data = await res.json() as { cwd?: string; error?: string };
       if (data.cwd) {
         setSelectedCwd(data.cwd);
@@ -911,7 +911,7 @@ function SessionItem({
     setRenaming(false);
     if (name === (session.name ?? "")) return;
     try {
-      await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
+      await fetch(`api/sessions/${encodeURIComponent(session.id)}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name }),
@@ -932,7 +932,7 @@ function SessionItem({
     setConfirmDelete(false);
     setDeleting(true);
     try {
-      await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, { method: "DELETE" });
+      await fetch(`api/sessions/${encodeURIComponent(session.id)}`, { method: "DELETE" });
       onDeleted?.(session.id);
     } catch {
       setDeleting(false);

--- a/components/SkillsConfig.tsx
+++ b/components/SkillsConfig.tsx
@@ -206,7 +206,7 @@ function AddSkillPanel({
     setSearchError(null);
     setResults([]);
     try {
-      const res = await fetch("/api/skills/search", {
+      const res = await fetch("api/skills/search", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query: q.trim() }),
@@ -233,7 +233,7 @@ function AddSkillPanel({
       setInstalling(pkg);
       setInstallError(null);
       try {
-        const res = await fetch("/api/skills/install", {
+        const res = await fetch("api/skills/install", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ package: pkg, scope, cwd }),
@@ -524,7 +524,7 @@ export function SkillsConfig({
   const loadSkills = useCallback(() => {
     setLoading(true);
     setError(null);
-    fetch(`/api/skills?cwd=${encodeURIComponent(cwd)}`)
+    fetch(`api/skills?cwd=${encodeURIComponent(cwd)}`)
       .then((r) => r.json())
       .then((d: { skills?: Skill[]; error?: string }) => {
         if (d.error) {
@@ -548,7 +548,7 @@ export function SkillsConfig({
     setToggling((s) => new Set(s).add(skill.filePath));
     setSaveError(null);
     try {
-      const res = await fetch("/api/skills", {
+      const res = await fetch("api/skills", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -152,8 +152,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     try {
       if (showLoading) setLoading(true);
       const url = includeState
-        ? `/api/sessions/${encodeURIComponent(sid)}?includeState`
-        : `/api/sessions/${encodeURIComponent(sid)}`;
+        ? `api/sessions/${encodeURIComponent(sid)}?includeState`
+        : `api/sessions/${encodeURIComponent(sid)}`;
       const res = await fetch(url);
       if (res.status === 404) {
         if (showLoading) {
@@ -188,8 +188,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const loadContext = useCallback(async (sid: string, leafId: string | null) => {
     try {
       const url = leafId
-        ? `/api/sessions/${encodeURIComponent(sid)}/context?leafId=${encodeURIComponent(leafId)}`
-        : `/api/sessions/${encodeURIComponent(sid)}/context`;
+        ? `api/sessions/${encodeURIComponent(sid)}/context?leafId=${encodeURIComponent(leafId)}`
+        : `api/sessions/${encodeURIComponent(sid)}/context`;
       const res = await fetch(url);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const d = await res.json() as { context: { messages: AgentMessage[]; entryIds: string[] } };
@@ -217,7 +217,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       eventSourceRef.current.close();
       eventSourceRef.current = null;
     }
-    const es = new EventSource(`/api/agent/${encodeURIComponent(sid)}/events`);
+    const es = new EventSource(`api/agent/${encodeURIComponent(sid)}/events`);
     eventSourceRef.current = es;
     es.onmessage = (e) => {
       try {
@@ -256,7 +256,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         dispatch({ type: "end" });
         if (sessionIdRef.current) {
           loadSession(sessionIdRef.current);
-          fetch(`/api/agent/${encodeURIComponent(sessionIdRef.current)}`)
+          fetch(`api/agent/${encodeURIComponent(sessionIdRef.current)}`)
             .then((r) => r.json())
             .then((d: { state?: { contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null; systemPrompt?: string } }) => {
               if (d.state?.contextUsage !== undefined) setContextUsage(d.state.contextUsage ?? null);
@@ -357,7 +357,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         if (selectedModel) setPendingModel(selectedModel);
         const { PRESET_NONE, PRESET_DEFAULT, PRESET_FULL } = await import("@/components/ToolPanel");
         const toolNames = toolPreset === "none" ? PRESET_NONE : toolPreset === "default" ? PRESET_DEFAULT : PRESET_FULL;
-        const res = await fetch("/api/agent/new", {
+        const res = await fetch("api/agent/new", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -612,7 +612,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
   // Load model list
   useEffect(() => {
-    fetch("/api/models").then((r) => r.json()).then((d: { models: Record<string, string>; modelList?: { id: string; name: string; provider: string }[]; defaultModel?: { provider: string; modelId: string } | null; thinkingLevels?: Record<string, string[]>; thinkingLevelMaps?: Record<string, Record<string, string | null>> }) => {
+    fetch("api/models").then((r) => r.json()).then((d: { models: Record<string, string>; modelList?: { id: string; name: string; provider: string }[]; defaultModel?: { provider: string; modelId: string } | null; thinkingLevels?: Record<string, string[]>; thinkingLevelMaps?: Record<string, Record<string, string | null>> }) => {
       setModelNames(d.models);
       if (d.thinkingLevels) setModelThinkingLevels(d.thinkingLevels);
       if (d.thinkingLevelMaps) setModelThinkingLevelMaps(d.thinkingLevelMaps);

--- a/lib/agent-client.ts
+++ b/lib/agent-client.ts
@@ -1,6 +1,6 @@
-// Client-side helper for POST /api/agent/[id].
+// Client-side helper for POST api/agent/[id].
 //
-// Every /api/agent/[id] route returns one of:
+// Every api/agent/[id] route returns one of:
 //   { success: true, data: <result> }
 //   { error: string }              (non-2xx)
 //
@@ -11,7 +11,7 @@ export async function sendAgentCommand<T = unknown>(
   sessionId: string,
   command: Record<string, unknown>,
 ): Promise<T> {
-  const res = await fetch(`/api/agent/${encodeURIComponent(sessionId)}`, {
+  const res = await fetch(`api/agent/${encodeURIComponent(sessionId)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(command),


### PR DESCRIPTION
Convert all fetch/EventSource/href/src URLs from /api/* to api/* so they resolve correctly under a configurable Next.js basePath. Also update corresponding comments in API route files. 20 files changed, 64 modifications.