### PR TITLE
[codex] Add math rendering, cwd persistence, and audio attachments

### DIFF
--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
 import { startRpcSession } from "@/lib/rpc-manager";
+import { normalizeCwd } from "@/lib/cwd";
 
 // POST /api/agent/new  body: { cwd: string; type: string; message: string; ... }
 // Spawns a brand-new pi session and immediately sends the first command.
@@ -13,7 +14,8 @@ export async function POST(req: Request) {
     if (!cwd || typeof cwd !== "string") {
       return NextResponse.json({ error: "cwd is required" }, { status: 400 });
     }
-    if (!existsSync(cwd)) {
+    const normalizedCwd = normalizeCwd(cwd);
+    if (!existsSync(normalizedCwd)) {
       return NextResponse.json({ error: `Directory does not exist: ${cwd}` }, { status: 400 });
     }
 
@@ -21,12 +23,12 @@ export async function POST(req: Request) {
     const { provider, modelId, toolNames, thinkingLevel, ...promptCommand } = command as { provider?: string; modelId?: string; toolNames?: string[]; thinkingLevel?: string; [key: string]: unknown };
 
     const tempKey = `__new__${Date.now()}`;
-    const { session, realSessionId } = await startRpcSession(tempKey, "", cwd, toolNames);
+    const { session, realSessionId } = await startRpcSession(tempKey, "", normalizedCwd, toolNames);
 
     // Keep the files-route allowed-roots cache (see app/api/files/[...path]/route.ts)
     // in sync so the new cwd is immediately readable via /api/files. Without this,
     // a file request under a brand-new cwd would 403 for up to the cache TTL.
-    globalThis.__piAllowedRootsCache?.roots.add(cwd);
+    globalThis.__piAllowedRootsCache?.roots.add(normalizedCwd);
 
     // Apply pre-selected model before sending the prompt
     if (provider && modelId) {

--- a/app/api/cwd/validate/route.ts
+++ b/app/api/cwd/validate/route.ts
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
 import { statSync, type Stats } from "fs";
-import { homedir } from "os";
-import { isAbsolute, resolve } from "path";
-
-function normalizeCwd(cwd: string): string {
-  if (cwd === "~") return homedir();
-  if (cwd.startsWith("~/")) return resolve(homedir(), cwd.slice(2));
-  return isAbsolute(cwd) ? cwd : resolve(cwd);
-}
+import { normalizeCwd } from "@/lib/cwd";
 
 // POST /api/cwd/validate  body: { cwd: string }
 // Validates a candidate workspace before the UI selects it.

--- a/app/api/default-cwd/route.ts
+++ b/app/api/default-cwd/route.ts
@@ -4,11 +4,10 @@ import { homedir } from "os";
 import { join } from "path";
 
 // POST /api/default-cwd
-// Creates ~/pi-cwd-<YYYYMMDD> if it doesn't exist and returns the path.
+// Creates ~/dev/pi-cwd if it doesn't exist and returns the path.
 export async function POST() {
   try {
-    const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
-    const dir = join(homedir(), `pi-cwd-${date}`);
+    const dir = join(homedir(), "dev", "pi-cwd");
     mkdirSync(dir, { recursive: true });
     return NextResponse.json({ cwd: dir });
   } catch (error) {

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -10,6 +10,18 @@ import {
 } from "@/lib/session-reader";
 import { getRpcSession } from "@/lib/rpc-manager";
 
+function compressTree<T extends { children: T[] }>(nodes: T[]): T[] {
+  function walk(node: T): T {
+    if (node.children.length === 0) return node;
+    if (node.children.length === 1) {
+      const collapsed = walk(node.children[0]);
+      return { ...node, children: collapsed.children };
+    }
+    return { ...node, children: node.children.map(walk) };
+  }
+  return nodes.map(walk);
+}
+
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -23,7 +35,7 @@ export async function GET(
 
     const sm = SessionManager.open(filePath);
     const entries = sm.getEntries() as never;
-    const tree = sm.getTree();
+    const tree = compressTree(sm.getTree());
     const leafId = sm.getLeafId();
     const context = buildSessionContext(entries, leafId);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_Mono } from "next/font/google";
+import "katex/dist/katex.min.css";
 import "./globals.css";
 
 const notoSansMono = Noto_Sans_Mono({

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -12,6 +12,7 @@ const { parseArgs } = require("util");
 
 const pkgDir = path.join(__dirname, "..");
 const nextDir = path.join(pkgDir, ".next");
+const buildIdFile = path.join(nextDir, "BUILD_ID");
 
 // Resolve next's CLI entry directly to avoid relying on .bin symlinks (which
 // may not exist when installed via npx).
@@ -39,12 +40,8 @@ const { values: cliArgs } = parseArgs({
 const port     = cliArgs.port     ?? process.env.PORT     ?? "30141";
 const hostname = cliArgs.hostname ?? process.env.HOSTNAME ?? null;
 
-if (!fs.existsSync(nextDir)) {
-  console.error("Build artifacts not found. Please report this issue.");
-  process.exit(1);
-}
-
-const nextArgs = ["start", "-p", port];
+const hasBuild = fs.existsSync(buildIdFile);
+const nextArgs = [hasBuild ? "start" : "dev", "-p", port];
 if (hostname) nextArgs.push("-H", hostname);
 
 // Always run next's JS entry with node directly — avoids .bin symlink issues

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -3,9 +3,12 @@
 import React, { useRef, useState, useCallback, useEffect, useImperativeHandle, forwardRef, KeyboardEvent } from "react";
 
 export interface AttachedImage {
+  kind: "image" | "audio";
   data: string;   // base64, no prefix
   mimeType: string;
   previewUrl: string; // object URL for display
+  name: string;
+  size: number;
 }
 
 interface ModelOption {
@@ -119,15 +122,15 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       });
     },
     addImages(files: File[]) {
-      processImageFiles(files);
+      processMediaFiles(files);
     },
   }));
 
-  const processImageFiles = useCallback(async (files: File[]) => {
-    const imageFiles = files.filter((f) => f.type.startsWith("image/"));
-    if (!imageFiles.length) return;
-    const newImages = await Promise.all(
-      imageFiles.map(
+  const processMediaFiles = useCallback(async (files: File[]) => {
+    const mediaFiles = files.filter((f) => f.type.startsWith("image/") || f.type.startsWith("audio/"));
+    if (!mediaFiles.length) return;
+    const newMedia = await Promise.all(
+      mediaFiles.map(
         (file) =>
           new Promise<AttachedImage>((resolve, reject) => {
             const reader = new FileReader();
@@ -135,14 +138,21 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
               const result = reader.result as string;
               // result is "data:<mime>;base64,<data>"
               const base64 = result.split(",")[1];
-              resolve({ data: base64, mimeType: file.type, previewUrl: URL.createObjectURL(file) });
+              resolve({
+                kind: file.type.startsWith("audio/") ? "audio" : "image",
+                data: base64,
+                mimeType: file.type,
+                previewUrl: URL.createObjectURL(file),
+                name: file.name,
+                size: file.size,
+              });
             };
             reader.onerror = reject;
             reader.readAsDataURL(file);
           })
       )
     );
-    setAttachedImages((prev) => [...prev, ...newImages]);
+    setAttachedImages((prev) => [...prev, ...newMedia]);
   }, []);
 
   const removeImage = useCallback((index: number) => {
@@ -226,8 +236,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     if (!imageItems.length) return;
     e.preventDefault();
     const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
-    processImageFiles(files);
-  }, [processImageFiles]);
+    processMediaFiles(files);
+  }, [processMediaFiles]);
 
 
 
@@ -290,12 +300,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       <input
         ref={fileInputRef}
         type="file"
-        accept="image/*"
+        accept="image/*,audio/*"
         multiple
         style={{ display: "none" }}
         onChange={(e) => {
           const files = Array.from(e.target.files ?? []);
-          processImageFiles(files);
+          processMediaFiles(files);
           e.target.value = "";
         }}
       />
@@ -315,17 +325,42 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
             Retrying ({retryInfo.attempt}/{retryInfo.maxAttempts})…{retryInfo.errorMessage && <span style={{ opacity: 0.7, marginLeft: 4 }}>— {retryInfo.errorMessage}</span>}
           </div>
         )}
-        {/* Image previews */}
+        {/* Attachment previews */}
         {attachedImages.length > 0 && (
           <div style={{ display: "flex", gap: 6, marginBottom: 6, flexWrap: "wrap" }}>
             {attachedImages.map((img, i) => (
               <div key={i} style={{ position: "relative", flexShrink: 0 }}>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={img.previewUrl}
-                  alt=""
-                  style={{ width: 56, height: 56, objectFit: "cover", borderRadius: 6, border: "1px solid var(--border)", display: "block" }}
-                />
+                {img.kind === "audio" ? (
+                  <div
+                    title={img.name}
+                    style={{
+                      width: 180,
+                      height: 56,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "0 10px",
+                      borderRadius: 6,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg-panel)",
+                      color: "var(--text-muted)",
+                      fontSize: 12,
+                      minWidth: 0,
+                    }}
+                  >
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                      <path d="M12 3v10.5a3.5 3.5 0 1 1-2-3.15V6l8-2v5" />
+                    </svg>
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{img.name}</span>
+                  </div>
+                ) : (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={img.previewUrl}
+                    alt=""
+                    style={{ width: 56, height: 56, objectFit: "cover", borderRadius: 6, border: "1px solid var(--border)", display: "block" }}
+                  />
+                )}
                 <button
                   onClick={() => removeImage(i)}
                   style={{
@@ -486,7 +521,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
             <button
               onClick={() => fileInputRef.current?.click()}
               disabled={isStreaming}
-              title="Attach image"
+              title="Attach image or audio"
               style={{
                 flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center",
                 width: 32, height: 32, padding: 0,

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -6,6 +6,8 @@ import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import { useTheme } from "@/hooks/useTheme";
 import { encodeFilePathForApi, getFileName, getRelativeFilePath } from "@/lib/file-paths";
 
@@ -958,7 +960,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
             className="markdown-body markdown-file-preview"
             style={{ padding: "24px 32px", maxWidth: 800 }}
           >
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>{data.content}</ReactMarkdown>
           </div>
         ) : (
           <SyntaxHighlighter

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef, useEffect, useMemo, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
@@ -15,6 +17,7 @@ import type {
   AssistantContentBlock,
   TextContent,
   ImageContent,
+  AudioContent,
   ToolCallContent,
   ThinkingContent,
 } from "@/lib/types";
@@ -104,6 +107,10 @@ function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAs
     typeof message.content === "string"
       ? []
       : message.content.filter((b): b is ImageContent => b.type === "image");
+  const audioBlocks: AudioContent[] =
+    typeof message.content === "string"
+      ? []
+      : message.content.filter((b): b is AudioContent => b.type === "audio");
 
   const time = formatTime(message.timestamp);
   const canFork = !!entryId && !!onFork;
@@ -139,7 +146,7 @@ function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAs
           }}
         >
           {imageBlocks.length > 0 && (
-            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: content ? 8 : 0 }}>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: content || audioBlocks.length ? 8 : 0 }}>
               {imageBlocks.map((img, i) => {
                 // lib/types.ts ImageContent uses {source:{type,data,media_type,url}}
                 // pi-ai on-disk format uses flat {data, mimeType} — handle both
@@ -159,6 +166,40 @@ function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAs
                     alt=""
                     style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid rgba(59,130,246,0.15)" }}
                   />
+                );
+              })}
+            </div>
+          )}
+          {audioBlocks.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: content ? 8 : 0 }}>
+              {audioBlocks.map((audio, i) => {
+                const flat = audio as unknown as { data?: string; mimeType?: string; name?: string };
+                const src = audio.source
+                  ? audio.source.type === "base64"
+                    ? `data:${audio.source.media_type};base64,${audio.source.data}`
+                    : audio.source.url ?? ""
+                  : flat.data
+                    ? `data:${flat.mimeType};base64,${flat.data}`
+                    : "";
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      border: "1px solid rgba(59,130,246,0.15)",
+                      borderRadius: 6,
+                      padding: "6px 8px",
+                      background: "rgba(255,255,255,0.35)",
+                      minWidth: 240,
+                    }}
+                  >
+                    <span style={{ fontSize: 12, color: "var(--text-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 160 }}>
+                      {flat.name ?? audio.source?.media_type ?? flat.mimeType ?? "audio"}
+                    </span>
+                    {src && <audio controls src={src} style={{ height: 28, maxWidth: 220 }} />}
+                  </div>
                 );
               })}
             </div>
@@ -516,7 +557,7 @@ function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCal
     const tc = block as ToolCallContent;
     const result = toolResults?.get(tc.toolCallId);
     const duration = toolCallDurations?.get(tc.toolCallId);
-    return <ToolCallBlock block={tc} result={result} isRunning={isStreaming && !result} duration={duration} />;
+    return <ToolCallBlock block={tc} result={result} duration={duration} />;
   }
   return null;
 }
@@ -525,7 +566,8 @@ function TextBlock({ block, isStreaming }: { block: TextContent; isStreaming?: b
   return (
     <div className="markdown-body">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
         components={{
           code({ className, children, ...props }) {
             const lang = className?.replace("language-", "").toLowerCase() ?? "";
@@ -728,7 +770,7 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
 }
 
 
-function ToolCallBlock({ block, result, isRunning, duration }: { block: ToolCallContent; result?: ToolResultMessage; isRunning?: boolean; duration?: number }) {
+function ToolCallBlock({ block, result, duration }: { block: ToolCallContent; result?: ToolResultMessage; duration?: number }) {
   const [expanded, setExpanded] = useState(false);
   const inputStr = JSON.stringify(block.input, null, 2);
 

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -109,6 +109,7 @@ function buildSessionTree(sessions: SessionInfo[]): SessionTreeNode[] {
 }
 
 const SCRAMBLE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+const LAST_CWD_STORAGE_KEY = "pi-web:last-cwd";
 
 function useScramble(target: string, running: boolean): string {
   const [display, setDisplay] = useState(target);
@@ -257,7 +258,24 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
 
   useEffect(() => {
     onCwdChange?.(selectedCwd);
+    if (selectedCwd) {
+      try {
+        localStorage.setItem(LAST_CWD_STORAGE_KEY, selectedCwd);
+      } catch {
+        // ignore
+      }
+    }
   }, [selectedCwd, onCwdChange]);
+
+  useEffect(() => {
+    if (initialSessionId || selectedCwd !== null) return;
+    try {
+      const saved = localStorage.getItem(LAST_CWD_STORAGE_KEY);
+      if (saved) setSelectedCwd(saved);
+    } catch {
+      // ignore
+    }
+  }, [initialSessionId, selectedCwd]);
 
   // Auto-select cwd and restore session from URL on first load
   useEffect(() => {
@@ -277,7 +295,14 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         onInitialRestoreDone?.();
       }
       const cwds = getRecentCwds(allSessions);
-      if (cwds.length > 0) setSelectedCwd(cwds[0]);
+      let saved: string | null = null;
+      try {
+        saved = localStorage.getItem(LAST_CWD_STORAGE_KEY);
+      } catch {
+        saved = null;
+      }
+      if (saved) setSelectedCwd(saved);
+      else if (cwds.length > 0) setSelectedCwd(cwds[0]);
     }
   }, [allSessions, selectedCwd, initialSessionId, onSelectSession, onInitialRestoreDone]);
 

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -77,9 +77,12 @@ export interface ChatInputHandle {
 }
 
 export interface AttachedImage {
+  kind: "image" | "audio";
   data: string;
   mimeType: string;
   previewUrl: string;
+  name: string;
+  size: number;
 }
 
 export function useAgentSession(opts: UseAgentSessionOptions) {
@@ -335,11 +338,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     if (!message.trim() && !images?.length) return;
     if (agentRunning) return;
 
-    const imageBlocks = images?.map((img) => ({ type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } }));
+    const mediaBlocks = images?.map((img) => img.kind === "audio"
+      ? { type: "audio" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data }, name: img.name }
+      : { type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } });
     const userMsg: AgentMessage = {
       role: "user",
-      content: imageBlocks?.length
-        ? [...(message.trim() ? [{ type: "text" as const, text: message }] : []), ...imageBlocks]
+      content: mediaBlocks?.length
+        ? [...(message.trim() ? [{ type: "text" as const, text: message }] : []), ...mediaBlocks]
         : message,
       timestamp: Date.now(),
     };
@@ -349,7 +354,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     dispatch({ type: "start" });
     pendingScrollToUserRef.current = true;
 
-    const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
+    const piImages = images?.map((img) => ({
+      type: img.kind,
+      data: img.data,
+      mimeType: img.mimeType,
+      ...(img.kind === "audio" ? { name: img.name } : {}),
+    }));
 
     try {
       if (isNew && newSessionCwd) {
@@ -483,7 +493,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const sid = sessionIdRef.current;
     if (!sid) return;
     setMessages((prev) => [...prev, { role: "user", content: `[steer] ${message}`, timestamp: Date.now() } as AgentMessage]);
-    const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
+    const piImages = images?.map((img) => ({
+      type: img.kind,
+      data: img.data,
+      mimeType: img.mimeType,
+      ...(img.kind === "audio" ? { name: img.name } : {}),
+    }));
     try {
       await sendAgentCommand(sid, {
         type: "steer",
@@ -499,7 +514,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const sid = sessionIdRef.current;
     if (!sid) return;
     setMessages((prev) => [...prev, { role: "user", content: message, timestamp: Date.now() } as AgentMessage]);
-    const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
+    const piImages = images?.map((img) => ({
+      type: img.kind,
+      data: img.data,
+      mimeType: img.mimeType,
+      ...(img.kind === "audio" ? { name: img.name } : {}),
+    }));
     try {
       await sendAgentCommand(sid, {
         type: "follow_up",

--- a/lib/cwd.ts
+++ b/lib/cwd.ts
@@ -1,0 +1,9 @@
+import { homedir } from "os";
+import { isAbsolute, resolve } from "path";
+
+export function normalizeCwd(cwd: string): string {
+  const trimmed = cwd.trim();
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) return resolve(homedir(), trimmed.slice(2));
+  return isAbsolute(trimmed) ? trimmed : resolve(trimmed);
+}

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -71,8 +71,8 @@ export class AgentSessionWrapper {
     switch (type) {
       case "prompt": {
         // Fire and forget — events come via subscribe
-        const promptImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
-        this.inner.prompt(command.message as string, promptImages?.length ? { images: promptImages } : undefined).catch(() => {});
+        const promptImages = command.images as Array<{ type: "image" | "audio"; data: string; mimeType: string }> | undefined;
+        this.inner.prompt(command.message as string, promptImages?.length ? { images: promptImages as never } : undefined).catch(() => {});
         return null;
       }
 
@@ -186,14 +186,14 @@ export class AgentSessionWrapper {
       }
 
       case "steer": {
-        const steerImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
-        await this.inner.steer(command.message as string, steerImages?.length ? steerImages : undefined);
+        const steerImages = command.images as Array<{ type: "image" | "audio"; data: string; mimeType: string }> | undefined;
+        await this.inner.steer(command.message as string, steerImages?.length ? steerImages as never : undefined);
         return null;
       }
 
       case "follow_up": {
-        const followImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
-        await this.inner.followUp(command.message as string, followImages?.length ? followImages : undefined);
+        const followImages = command.images as Array<{ type: "image" | "audio"; data: string; mimeType: string }> | undefined;
+        await this.inner.followUp(command.message as string, followImages?.length ? followImages as never : undefined);
         return null;
       }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,19 @@ export interface ImageContent {
   };
 }
 
+export interface AudioContent {
+  type: "audio";
+  data?: string;
+  mimeType?: string;
+  name?: string;
+  source?: {
+    type: "base64" | "url";
+    media_type?: string;
+    data?: string;
+    url?: string;
+  };
+}
+
 export interface ThinkingContent {
   type: "thinking";
   thinking: string;
@@ -43,11 +56,13 @@ export interface ToolCallContent {
   input: Record<string, unknown>;
 }
 
+export type UserContentBlock = TextContent | ImageContent | AudioContent;
+
 export type AssistantContentBlock = TextContent | ImageContent | ThinkingContent | ToolCallContent;
 
 export interface UserMessage {
   role: "user";
-  content: string | (TextContent | ImageContent)[];
+  content: string | UserContentBlock[];
   timestamp?: number;
 }
 
@@ -86,7 +101,7 @@ export interface ToolResultMessage {
 export interface CustomMessage {
   role: "custom";
   customType: string;
-  content: string | (TextContent | ImageContent)[];
+  content: string | UserContentBlock[];
   display: boolean;
   details?: unknown;
   timestamp?: number;
@@ -136,7 +151,7 @@ export interface CustomEntry extends SessionEntryBase {
 export interface CustomMessageEntry extends SessionEntryBase {
   type: "custom_message";
   customType: string;
-  content: string | (TextContent | ImageContent)[];
+  content: string | UserContentBlock[];
   details?: unknown;
   display: boolean;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@earendil-works/pi-coding-agent": "^0.78.0",
         "@lobehub/icons": "^5.6.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "katex": "^0.17.0",
         "mammoth": "^1.12.0",
         "mermaid": "^11.14.0",
         "next": "16.2.1",
@@ -20,7 +21,9 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
-        "remark-gfm": "^4.0.1"
+        "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
       },
       "bin": {
         "pi-web": "bin/pi-web.js"
@@ -1532,7 +1535,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4131,6 +4134,23 @@
         "motion": "^12.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@lobehub/ui/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/@lobehub/ui/node_modules/lucide-react": {
@@ -7032,8 +7052,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -9313,7 +9332,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -10846,7 +10864,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
       "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hastscript": "^9.0.0",
@@ -10862,7 +10879,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
       "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.1.0",
@@ -10881,7 +10897,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
       "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-from-dom": "^5.0.0",
@@ -10898,7 +10913,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -10911,7 +10925,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -10932,7 +10945,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -11096,7 +11108,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
       "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -11236,6 +11247,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11970,9 +11982,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.45",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
-      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "version": "0.17.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -12702,7 +12714,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
       "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -12918,6 +12929,22 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -13182,7 +13209,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
       "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/katex": "^0.16.0",
         "devlop": "^1.0.0",
@@ -13195,6 +13221,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -15279,10 +15321,9 @@
     },
     "node_modules/rehype-katex": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/rehype-katex/-/rehype-katex-7.0.1.tgz",
       "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/katex": "^0.16.0",
@@ -15295,6 +15336,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/rehype-raw": {
@@ -15406,10 +15463,9 @@
     },
     "node_modules/remark-math": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/remark-math/-/remark-math-6.0.0.tgz",
       "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-math": "^3.0.0",
@@ -16712,7 +16768,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
       "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -16763,7 +16818,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
       "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
@@ -16944,7 +16998,6 @@
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile": "^6.0.0"
@@ -17002,7 +17055,6 @@
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@earendil-works/pi-coding-agent": "^0.78.0",
     "@lobehub/icons": "^5.6.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "katex": "^0.17.0",
     "mammoth": "^1.12.0",
     "mermaid": "^11.14.0",
     "next": "16.2.1",
@@ -35,7 +36,9 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
-    "remark-gfm": "^4.0.1"
+    "rehype-katex": "^7.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",


### PR DESCRIPTION
## Summary

Adds four UI/runtime improvements:

- Render Markdown math in chat messages and Markdown file previews via `remark-math`, `rehype-katex`, and KaTeX CSS.
- Normalize and persist selected cwd values, including `~` and relative paths, so custom cwd selection survives refresh and new sessions receive absolute paths.
- Change the local default cwd endpoint to use `~/dev/pi-cwd` instead of date-stamped `~/pi-cwd-YYYYMMDD` directories.
- Extend chat attachments from images to images plus audio, forwarding audio media blocks through the existing multimodal prompt path for providers that accept inline audio data.

Also includes the small session tree compression fix from open PR #48 to avoid deep linear tree serialization issues, and lets the local linked `pi-web` binary fall back to `next dev` when no production build exists.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- Browser verified `http://localhost:30141` renders existing math as KaTeX nodes.
- Browser verified custom cwd `~/dev/pi-cwd` normalizes to `/Users/chenmin/dev/pi-cwd` and survives reload.
- Browser verified the file input accepts `image/*,audio/*` and the attach button is labeled for image or audio.
- Local API verified `POST /api/default-cwd` returns `/Users/chenmin/dev/pi-cwd`.

## Notes

The current `@earendil-works/pi-coding-agent` public types only expose image attachments. Audio is forwarded as an inline media block through the same prompt path, which should work for Google/Gemini-style providers that accept inline audio data, but it is not a universal provider capability.
