### PR TITLE
feat: add scroll-to-bottom control for chat sessions

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -96,13 +96,12 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, displayModel: displayModelValue, sessionStats,
-    agentPhase,
+    agentPhase, showScrollToBottom,
     isNew,
     messagesEndRef, scrollContainerRef,
-    lastUserMsgRef,
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handleAbortCompaction,
-    handleToolPresetChange, handleThinkingLevelChange, handleAgentEventRef,
+    handleToolPresetChange, handleThinkingLevelChange, scrollToBottom, handleAgentEventRef,
   } = useAgentSession({
     session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked,
     modelsRefreshKey, onBranchDataChange, onSystemPromptChange,
@@ -298,10 +297,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                   toolResultsMap.set((msg as import("@/lib/types").ToolResultMessage).toolCallId, msg as import("@/lib/types").ToolResultMessage);
                 }
               }
-              let lastUserIdx = -1;
-              for (let i = messages.length - 1; i >= 0; i--) {
-                if (messages[i].role === "user") { lastUserIdx = i; break; }
-              }
               let refIdx = 0;
               return messages.map((msg, idx) => {
                 const prevAssistantEntryId =
@@ -343,7 +338,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 return (
                   <div key={idx} ref={(el) => {
                     messageRefs.current[currentRefIdx] = el;
-                    if (idx === lastUserIdx) { (lastUserMsgRef as { current: HTMLDivElement | null }).current = el; }
                   }}>
                     {view}
                   </div>
@@ -361,10 +355,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
               </div>
             )}
 
-            {agentRunning && (
-              <div style={{ height: scrollContainerRef.current ? scrollContainerRef.current.clientHeight : "80vh" }} />
-            )}
-
             <div ref={messagesEndRef} />
           </div>
         </div>
@@ -374,6 +364,46 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
           scrollContainer={scrollContainerRef}
           messageRefs={messageRefs}
         />
+        {showScrollToBottom && (
+          <button
+            type="button"
+            onClick={() => scrollToBottom("smooth")}
+            title="Scroll to latest message"
+            aria-label="Scroll to latest message"
+            style={{
+              position: "absolute",
+              left: "50%",
+              bottom: 16,
+              transform: "translateX(-50%)",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 38,
+              height: 38,
+              padding: 0,
+              color: "var(--text)",
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: 9999,
+              cursor: "pointer",
+              transition: "background 0.15s ease, border-color 0.15s ease, color 0.15s ease",
+              zIndex: 20,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = "var(--bg-hover)";
+              e.currentTarget.style.borderColor = "var(--text-dim)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = "var(--bg-panel)";
+              e.currentTarget.style.borderColor = "var(--border)";
+            }}
+          >
+            <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M12 4v16" />
+              <path d="m5 13 7 7 7-7" />
+            </svg>
+          </button>
+        )}
       </div>
 
       <div className="relative">

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -70,6 +70,8 @@ export interface UseAgentSessionOptions {
 
 export type ThinkingLevelOption = "auto" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
+const SCROLL_BOTTOM_THRESHOLD_PX = 96;
+
 export interface ChatInputHandle {
   insertText: (text: string) => void;
   insertIfEmpty: (content: string) => void;
@@ -114,14 +116,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [isCompacting, setIsCompacting] = useState(false);
   const [compactError, setCompactError] = useState<string | null>(null);
   const [agentPhase, setAgentPhase] = useState<AgentPhase>(null);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const sessionIdRef = useRef<string | null>(session?.id ?? null);
   const agentRunningRef = useRef(false);
+  const shouldAutoScrollToBottomRef = useRef(true);
   const handleAgentEventRef = useRef<((event: AgentEvent) => void) | null>(null);
   const initialScrollDoneRef = useRef(false);
-  const lastUserMsgRef = useRef<HTMLDivElement | null>(null);
-  const pendingScrollToUserRef = useRef(false);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -347,7 +349,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     setAgentRunning(true);
     setAgentPhase({ kind: "waiting_model" });
     dispatch({ type: "start" });
-    pendingScrollToUserRef.current = true;
+    shouldAutoScrollToBottomRef.current = true;
 
     const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
 
@@ -546,16 +548,31 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [setToolPresetState]);
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    messagesEndRef.current?.scrollIntoView({ behavior });
+  const measureScrollPosition = useCallback((syncAutoFollow: boolean) => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const hiddenBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    const isScrollable = container.scrollHeight - container.clientHeight > SCROLL_BOTTOM_THRESHOLD_PX;
+    const isNearBottom = hiddenBottom <= SCROLL_BOTTOM_THRESHOLD_PX;
+
+    if (syncAutoFollow) {
+      shouldAutoScrollToBottomRef.current = isNearBottom;
+    }
+
+    setShowScrollToBottom(isScrollable && !isNearBottom && !shouldAutoScrollToBottomRef.current);
   }, []);
 
-  const scrollUserMsgToTop = useCallback(() => {
-    const container = scrollContainerRef.current;
-    const el = lastUserMsgRef.current;
-    if (!container || !el) return;
-    const elAbsTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-    container.scrollTo({ top: elAbsTop - 16, behavior: "smooth" });
+  const updateScrollToBottomAffordance = useCallback(() => {
+    measureScrollPosition(false);
+  }, [measureScrollPosition]);
+
+  const handleScrollPositionChange = useCallback(() => {
+    measureScrollPosition(true);
+  }, [measureScrollPosition]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    messagesEndRef.current?.scrollIntoView({ behavior });
+    shouldAutoScrollToBottomRef.current = true;
   }, []);
 
   // Load session on mount
@@ -596,19 +613,40 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [data?.tree, activeLeafId, handleLeafChange, onBranchDataChange]);
 
   useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    updateScrollToBottomAffordance();
+    container.addEventListener("scroll", handleScrollPositionChange, { passive: true });
+    const resizeObserver = new ResizeObserver(updateScrollToBottomAffordance);
+    resizeObserver.observe(container);
+    return () => {
+      container.removeEventListener("scroll", handleScrollPositionChange);
+      resizeObserver.disconnect();
+    };
+  }, [loading, data?.sessionId, handleScrollPositionChange, updateScrollToBottomAffordance]);
+
+  useEffect(() => {
     if (messages.length > 0) {
-      if (pendingScrollToUserRef.current) {
-        pendingScrollToUserRef.current = false;
-        initialScrollDoneRef.current = true;
-        scrollUserMsgToTop();
-      } else if (!initialScrollDoneRef.current) {
+      if (!initialScrollDoneRef.current) {
         initialScrollDoneRef.current = true;
         scrollToBottom("instant");
-      } else if (!agentRunningRef.current) {
-        scrollToBottom("smooth");
+      } else if (shouldAutoScrollToBottomRef.current) {
+        scrollToBottom(agentRunningRef.current ? "instant" : "smooth");
+      } else {
+        requestAnimationFrame(updateScrollToBottomAffordance);
       }
     }
-  }, [messages.length, agentRunning, scrollToBottom, scrollUserMsgToTop]);
+  }, [messages.length, agentRunning, scrollToBottom, updateScrollToBottomAffordance]);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      if (shouldAutoScrollToBottomRef.current) {
+        scrollToBottom("instant");
+      } else {
+        updateScrollToBottomAffordance();
+      }
+    });
+  }, [agentRunning, streamState.streamingMessage, scrollToBottom, updateScrollToBottomAffordance]);
 
   // Load model list
   useEffect(() => {
@@ -643,15 +681,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, newSessionModel, toolPreset, thinkingLevel,
     retryInfo, contextUsage, systemPrompt, forkingEntryId,
     isCompacting, compactError, currentModel, displayModel, sessionStats,
-    agentPhase,
+    agentPhase, showScrollToBottom,
     isNew,
     // Refs
     sessionIdRef, eventSourceRef, messagesEndRef, scrollContainerRef,
-    lastUserMsgRef, pendingScrollToUserRef, initialScrollDoneRef,
+    initialScrollDoneRef,
     // Actions
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handleAbortCompaction,
-    handleToolPresetChange, handleThinkingLevelChange, loadTools, setActiveLeafId, setData, setMessages,
+    handleToolPresetChange, handleThinkingLevelChange, scrollToBottom, loadTools, setActiveLeafId, setData, setMessages,
     dispatch, setAgentRunning, setForkingEntryId,
     // Subscriptions
     handleAgentEventRef,


### PR DESCRIPTION
## Summary

Fixes #59.

This PR updates the chat scroll behavior so the view no longer jumps to the bottom after a response completes when the user has scrolled away from the latest message.

It also keeps the chat pinned to the latest message when new or streaming content arrives while the user is already at the bottom.

It adds a lightweight scroll-to-latest control that appears when the user is away from the bottom of the conversation, and removes the previous running-state bottom spacer that pushed the message list upward while the agent was active.

## Changes

- Track whether the chat viewport is near the bottom before auto-scrolling
- Preserve the user's reading position while an agent response is streaming or completing
- Keep the chat pinned to the latest message when new or streaming content arrives while the user is already at the bottom
- Remove the running-state bottom spacer and last-user-message scroll anchoring
- Add a centered scroll-to-bottom button for returning to the latest message
- Hide the button naturally once the viewport reaches the bottom

## Testing

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- Manually verified the scroll button appears, scrolls smoothly to the latest message, does not flicker on click, and preserves bottom auto-follow for new messages
