### PR TITLE
fix: compress linear tree chains to prevent JSON.stringify stack overflow

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -12,19 +12,36 @@ import { getRpcSession } from "@/lib/rpc-manager";
 
 /**
  * Compress linear single-child chains to prevent JSON.stringify stack overflow.
- * Uses iterative descent for linear chains (no recursion) and preserves
- * terminal leaf nodes so BranchNavigator can still resolve activeLeafId.
+ * Preserves the root node, branch anchors, and terminal leaves while
+ * contracting intermediate chains via iterative descent (no stack growth).
  */
 function compressTree<T extends { children: T[] }>(nodes: T[]): T[] {
   function walk(node: T): T {
-    // Follow linear chain iteratively — no stack growth on long sessions
-    while (node.children.length === 1) {
-      node = node.children[0];
+    // Leaf: return as-is
+    if (node.children.length === 0) {
+      return node;
     }
-    if (node.children.length === 0) return node;
+
+    // Linear single-child chain: skip the middle nodes iteratively
+    if (node.children.length === 1) {
+      let next = node.children[0];
+      while (next.children.length === 1) {
+        next = next.children[0];
+      }
+      // Keep current node (chain head), connect directly to the tail
+      return {
+        ...node,
+        children: [walk(next)],
+      };
+    }
+
     // Branch point: recurse on each child
-    return { ...node, children: node.children.map(walk) };
+    return {
+      ...node,
+      children: node.children.map(walk),
+    };
   }
+
   return nodes.map(walk);
 }
 

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -10,6 +10,22 @@ import {
 } from "@/lib/session-reader";
 import { getRpcSession } from "@/lib/rpc-manager";
 
+/**
+ * Collapse consecutive single-child nodes into their parent to avoid
+ * JSON.stringify call stack overflow on 2000+ message linear sessions.
+ */
+function compressTree<T extends { children: T[] }>(nodes: T[]): T[] {
+  function walk(node: T): T {
+    if (node.children.length === 0) return node;
+    if (node.children.length === 1) {
+      const collapsed = walk(node.children[0]);
+      return { ...node, children: collapsed.children };
+    }
+    return { ...node, children: node.children.map(walk) };
+  }
+  return nodes.map(walk);
+}
+
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -23,8 +39,8 @@ export async function GET(
 
     const sm = SessionManager.open(filePath);
     const entries = sm.getEntries() as never;
-    const tree = sm.getTree();
     const leafId = sm.getLeafId();
+    const tree = compressTree(sm.getTree());
     const context = buildSessionContext(entries, leafId);
 
     const header = sm.getHeader();
@@ -66,8 +82,8 @@ export async function GET(
       sessionId: id,
       filePath,
       info,
-      tree,
       leafId,
+      tree,
       context,
       ...(agentState !== undefined ? { agentState } : {}),
     });

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -11,16 +11,18 @@ import {
 import { getRpcSession } from "@/lib/rpc-manager";
 
 /**
- * Collapse consecutive single-child nodes into their parent to avoid
- * JSON.stringify call stack overflow on 2000+ message linear sessions.
+ * Compress linear single-child chains to prevent JSON.stringify stack overflow.
+ * Uses iterative descent for linear chains (no recursion) and preserves
+ * terminal leaf nodes so BranchNavigator can still resolve activeLeafId.
  */
 function compressTree<T extends { children: T[] }>(nodes: T[]): T[] {
   function walk(node: T): T {
-    if (node.children.length === 0) return node;
-    if (node.children.length === 1) {
-      const collapsed = walk(node.children[0]);
-      return { ...node, children: collapsed.children };
+    // Follow linear chain iteratively — no stack growth on long sessions
+    while (node.children.length === 1) {
+      node = node.children[0];
     }
+    if (node.children.length === 0) return node;
+    // Branch point: recurse on each child
     return { ...node, children: node.children.map(walk) };
   }
   return nodes.map(walk);


### PR DESCRIPTION

 Problem

 On long linear sessions (2000+ messages), JSON.stringify(tree) in the session detail API throws Maximum call stack size exceeded because each message is a single-child node forming a deep linear chain.

 Simply removing the tree field breaks BranchNavigator branch navigation.

 Solution

 Add a generic compressTree<T> function that contracts linear single-child chains while preserving branch points and terminal leaves:

 - Linear chains (node has exactly 1 child): skip intermediate nodes iteratively (while loop, no stack growth) and connect the chain head directly to the tail.
 - Branch points (node has 2+ children): preserve the node and recurse on each child.
 - Leaves (node has 0 children): return as-is.

 Before: Msg_1 → Msg_2 → ... → Msg_3400 (depth 3400 → stack overflow)
 After:  Msg_1 → Msg_3400 (depth 2 → safe)

 Branch tree shape preserved:

 ```
   root → A → [branch1 → leaf1, branch2 → leaf2]
   root → [branch1 → leaf1, branch2 → leaf2]   ✅ leaves preserved
 ```

 Testing

 - Tested with real 3500+ message session containing 5 branch points
 - BranchNavigator navigation works correctly
 - activeLeafId resolves to existing nodes

 Notes

 Supersedes PR #38 and PR #48 following reviewer feedback:
 - v1: remove tree → rejected (breaks BranchNavigator)
 - v2: recursive compress → reviewer noted leaf nodes lost
 - v3: iterative chain descent + leaf preservation → current