### PR TITLE
fix: add rehype-raw plugin to render raw HTML tables in markdown content

### DIFF
--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -6,6 +6,7 @@ import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
 import { useTheme } from "@/hooks/useTheme";
 import { encodeFilePathForApi, getFileName, getRelativeFilePath } from "@/lib/file-paths";
 
@@ -958,7 +959,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
             className="markdown-body markdown-file-preview"
             style={{ padding: "24px 32px", maxWidth: 800 }}
           >
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>{data.content}</ReactMarkdown>
           </div>
         ) : (
           <SyntaxHighlighter

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
+import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -42,7 +43,7 @@ export function MarkdownBody({ children, className, isStreaming }: MarkdownBodyP
     <div className={["markdown-body", className].filter(Boolean).join(" ")}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[[rehypeKatex, { throwOnError: false, strict: false }]]}
+        rehypePlugins={[rehypeRaw, [rehypeKatex, { throwOnError: false, strict: false }]]}
         components={{
           code({ className, children, ...props }) {
             const lang = className?.replace("language-", "").toLowerCase() ?? "";


### PR DESCRIPTION
## Problem

Markdown content containing raw HTML `<table>` elements is not rendered
as tables in two places:

1. **Chat messages** (`MarkdownBody.tsx`): HTML tags are silently stripped
   by react-markdown because `rehype-raw` is not included.
2. **File preview** (`FileViewer.tsx`): Same issue in the markdown file
   preview (Preview mode).

## Fix

Add `rehype-raw` to the `rehypePlugins` array in both components:

- `components/MarkdownBody.tsx` — used for chat message rendering
- `components/FileViewer.tsx` — used for markdown file preview

Both already had `remarkGfm` / `rehype-katex` but were missing
`rehype-raw` for raw HTML passthrough.

## Testing

Confirmed that HTML `<table>` in `.md` files renders correctly in both
chat messages and file preview mode.