### PR TITLE
fix: load extension models in web selector

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,9 +1,20 @@
-import { AuthStorage, ModelRegistry, SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
+function compareModelEntries(
+  a: { id: string; name: string; provider: string },
+  b: { id: string; name: string; provider: string }
+): number {
+  return modelNameCollator.compare(a.name || a.id, b.name || b.id)
+    || modelNameCollator.compare(a.provider, b.provider)
+    || modelNameCollator.compare(a.id, b.id);
+}
+
+export async function GET(req: Request) {
   const nameMap = new Map<string, string>();
   let modelList: { id: string; name: string; provider: string }[] = [];
   let defaultModel: { provider: string; modelId: string } | null = null;
@@ -12,14 +23,15 @@ export async function GET() {
 
   try {
     const agentDir = getAgentDir();
-    const authStorage = AuthStorage.create();
-    const registry = ModelRegistry.create(authStorage);
+    const cwd = new URL(req.url).searchParams.get("cwd") || process.cwd();
+    const services = await createAgentSessionServices({ cwd, agentDir });
+    const registry = services.modelRegistry;
     const available = registry.getAvailable();
     modelList = available.map((m: { id: string; name: string; provider: string }) => ({
       id: m.id,
       name: m.name,
       provider: m.provider,
-    }));
+    })).sort(compareModelEntries);
     for (const m of available) {
       const key = `${m.provider}:${m.id}`;
       nameMap.set(key, m.name);
@@ -27,7 +39,7 @@ export async function GET() {
       if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
     }
 
-    const settings = SettingsManager.create(process.cwd(), agentDir);
+    const settings: SettingsManager = services.settingsManager;
     const provider = settings.getDefaultProvider();
     const modelId = settings.getDefaultModel();
     if (provider) {

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,3 +1,4 @@
+import { stat } from "fs/promises";
 import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 
@@ -20,10 +21,20 @@ export async function GET(req: Request) {
   let defaultModel: { provider: string; modelId: string } | null = null;
   const thinkingLevels: Record<string, string[]> = {};
   const thinkingLevelMaps: Record<string, Record<string, string | null>> = {};
+  const cwd = new URL(req.url).searchParams.get("cwd") || process.cwd();
+
+  let cwdStat;
+  try {
+    cwdStat = await stat(cwd);
+  } catch {
+    return Response.json({ error: `Directory does not exist: ${cwd}` }, { status: 400 });
+  }
+  if (!cwdStat.isDirectory()) {
+    return Response.json({ error: `Not a directory: ${cwd}` }, { status: 400 });
+  }
 
   try {
     const agentDir = getAgentDir();
-    const cwd = new URL(req.url).searchParams.get("cwd") || process.cwd();
     const services = await createAgentSessionServices({ cwd, agentDir });
     const registry = services.modelRegistry;
     const available = registry.getAvailable();
@@ -42,8 +53,8 @@ export async function GET(req: Request) {
     const settings: SettingsManager = services.settingsManager;
     const provider = settings.getDefaultProvider();
     const modelId = settings.getDefaultModel();
-    if (provider) {
-      defaultModel = { provider, modelId: modelId ?? available[0]?.id ?? "" };
+    if (provider && modelId && available.some((m) => m.provider === provider && m.id === modelId)) {
+      defaultModel = { provider, modelId };
     }
   } catch { /* return empty */ }
 

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -48,6 +48,13 @@ export interface ChatInputHandle {
 const TOOL_PRESETS = ["off", "default", "full"] as const;
 const TOOL_PRESET_MAP: Record<"off" | "default" | "full", "none" | "default" | "full"> = { off: "none", default: "default", full: "full" };
 const COMPOSITION_END_ENTER_GRACE_MS = 100;
+const MODEL_OPTION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
+function compareModelOptions(a: ModelOption, b: ModelOption): number {
+  return MODEL_OPTION_COLLATOR.compare(a.name || a.modelId, b.name || b.modelId)
+    || MODEL_OPTION_COLLATOR.compare(a.provider, b.provider)
+    || MODEL_OPTION_COLLATOR.compare(a.modelId, b.modelId);
+}
 
 const THINKING_LEVELS = ["auto", "off", "minimal", "low", "medium", "high", "xhigh"] as const;
 const THINKING_LEVEL_DESC: Record<typeof THINKING_LEVELS[number], string> = {
@@ -234,13 +241,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   // Build model options: prefer modelList (has provider info), fallback to modelNames
   const modelOptions: ModelOption[] = (() => {
     if (modelList && modelList.length > 0) {
-      return modelList.map((m) => ({ provider: m.provider, modelId: m.id, name: m.name }));
+      return modelList.map((m) => ({ provider: m.provider, modelId: m.id, name: m.name })).sort(compareModelOptions);
     }
     return Object.entries(modelNames ?? {}).map(([modelId, name]) => ({
       provider: model?.provider ?? "unknown",
       modelId,
       name,
-    }));
+    })).sort(compareModelOptions);
   })();
 
   // Group options by provider, preserving insertion order

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -21,6 +21,7 @@ interface Props {
   onFollowUp?: (message: string, images?: AttachedImage[]) => void;
   isStreaming: boolean;
   model?: { provider: string; modelId: string } | null;
+  isAutoModelSelection?: boolean;
   modelNames?: Record<string, string>;
   modelList?: { id: string; name: string; provider: string }[];
   onModelChange?: (provider: string, modelId: string) => void;
@@ -68,7 +69,7 @@ const THINKING_LEVEL_DESC: Record<typeof THINKING_LEVELS[number], string> = {
 };
 
 export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
-  onSend, onAbort, onSteer, onFollowUp, isStreaming, model, modelNames, modelList, onModelChange,
+  onSend, onAbort, onSteer, onFollowUp, isStreaming, model, isAutoModelSelection, modelNames, modelList, onModelChange,
   onCompact, onAbortCompaction, isCompacting, compactError, toolPreset, onToolPresetChange,
   thinkingLevel, onThinkingLevelChange, availableThinkingLevels, thinkingLevelMap,
   retryInfo,
@@ -258,9 +259,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     else modelsByProvider.push({ provider: opt.provider, options: [opt] });
   }
 
-  const currentName = model
+  const displayModelName = model
     ? (modelOptions.find((o) => o.modelId === model.modelId && o.provider === model.provider)?.name ?? model.modelId)
-    : modelOptions.length > 0 ? modelOptions[0].name : null;
+    : null;
+  const currentName = displayModelName;
 
   // Close dropdowns on outside click
   useEffect(() => {
@@ -569,13 +571,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                     const bottom = viewportHeight - modelDropdownRect.top + 6;
                     const maxH = Math.max(120, Math.min(modelDropdownRect.top - 8, viewportHeight * 0.6));
                     return (
-                    <div ref={modelDropdownPanelRef} style={{
+                      <div ref={modelDropdownPanelRef} style={{
                       position: "fixed",
                       bottom, left: modelDropdownRect.left,
                       zIndex: 500, background: "var(--bg)", border: "1px solid var(--border)",
                       borderRadius: 8, boxShadow: "0 -4px 16px rgba(0,0,0,0.10)",
                       overflow: "hidden", width: "max-content", minWidth: modelDropdownRect.width, maxHeight: maxH, overflowY: "auto",
-                    }}>
+                      }}>
                       {modelsByProvider.map((group, gi) => (
                         <div key={group.provider}>
                           {(modelsByProvider.length > 1) && (
@@ -593,7 +595,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                             return (
                               <button
                                 key={`${opt.provider}:${opt.modelId}`}
-                                onClick={() => { setModelDropdownOpen(false); if (!isActive) onModelChange(opt.provider, opt.modelId); }}
+                                onClick={() => { setModelDropdownOpen(false); if (!isActive || isAutoModelSelection) onModelChange(opt.provider, opt.modelId); }}
                                 style={{
                                   display: "flex", alignItems: "center", gap: 8,
                                   width: "100%", padding: "7px 12px",

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -96,6 +96,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, displayModel: displayModelValue, sessionStats,
+    isAutoModelSelection,
     agentPhase,
     isNew,
     messagesEndRef, scrollContainerRef,
@@ -176,6 +177,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onFollowUp={agentRunning ? handleFollowUp : undefined}
       isStreaming={agentRunning}
       model={displayModelValue}
+      isAutoModelSelection={isAutoModelSelection}
       modelNames={modelNames}
       modelList={modelList}
       onModelChange={handleModelChange}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -612,7 +612,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
   // Load model list
   useEffect(() => {
-    fetch("/api/models").then((r) => r.json()).then((d: { models: Record<string, string>; modelList?: { id: string; name: string; provider: string }[]; defaultModel?: { provider: string; modelId: string } | null; thinkingLevels?: Record<string, string[]>; thinkingLevelMaps?: Record<string, Record<string, string | null>> }) => {
+    const modelCwd = newSessionCwd ?? session?.cwd ?? "";
+    const modelsUrl = modelCwd ? `/api/models?cwd=${encodeURIComponent(modelCwd)}` : "/api/models";
+    fetch(modelsUrl).then((r) => r.json()).then((d: { models: Record<string, string>; modelList?: { id: string; name: string; provider: string }[]; defaultModel?: { provider: string; modelId: string } | null; thinkingLevels?: Record<string, string[]>; thinkingLevelMaps?: Record<string, Record<string, string | null>> }) => {
       setModelNames(d.models);
       if (d.thinkingLevels) setModelThinkingLevels(d.thinkingLevels);
       if (d.thinkingLevelMaps) setModelThinkingLevelMaps(d.thinkingLevelMaps);
@@ -628,7 +630,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         }
       }
     }).catch(() => {});
-  }, [isNew, modelsRefreshKey, setNewSessionModel]);
+  }, [isNew, modelsRefreshKey, newSessionCwd, session?.cwd, setNewSessionModel]);
 
   // Compact error auto-dismiss
   useEffect(() => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -64,7 +64,6 @@ export interface UseAgentSessionOptions {
   chatInputRef?: React.RefObject<ChatInputHandle | null>;
   onBranchDataChange?: (tree: SessionTreeNode[], activeLeafId: string | null, onLeafChange: (leafId: string | null) => void) => void;
   onSystemPromptChange?: (prompt: string | null) => void;
-  setNewSessionModel?: (model: { provider: string; modelId: string } | null) => void;
   setToolPreset?: (preset: "none" | "default" | "full") => void;
 }
 
@@ -81,6 +80,16 @@ export interface AttachedImage {
   mimeType: string;
   previewUrl: string;
 }
+
+type SelectedModel = { provider: string; modelId: string };
+type ModelEntry = { id: string; name: string; provider: string };
+type ModelsResponse = {
+  models: Record<string, string>;
+  modelList?: ModelEntry[];
+  defaultModel?: SelectedModel | null;
+  thinkingLevels?: Record<string, string[]>;
+  thinkingLevelMaps?: Record<string, Record<string, string | null>>;
+};
 
 export function useAgentSession(opts: UseAgentSessionOptions) {
   const {
@@ -99,10 +108,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [streamState, dispatch] = useReducer(streamReducer, { isStreaming: false, streamingMessage: null });
   const [agentRunning, setAgentRunning] = useState(false);
   const [modelNames, setModelNames] = useState<Record<string, string>>({});
-  const [modelList, setModelList] = useState<{ id: string; name: string; provider: string }[]>([]);
+  const [modelList, setModelList] = useState<ModelEntry[]>([]);
   const [modelThinkingLevels, setModelThinkingLevels] = useState<Record<string, string[]>>({});
   const [modelThinkingLevelMaps, setModelThinkingLevelMaps] = useState<Record<string, Record<string, string | null>>>({});
-  const [newSessionModel, setNewSessionModelState] = useState<{ provider: string; modelId: string } | null>(null);
+  const [newSessionModel, setNewSessionModel] = useState<SelectedModel | null>(null);
+  const [newSessionDefaultModel, setNewSessionDefaultModel] = useState<SelectedModel | null>(null);
   const [toolPreset, setToolPreset] = useState<"none" | "default" | "full">("default");
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevelOption>("auto");
   const [retryInfo, setRetryInfo] = useState<{ attempt: number; maxAttempts: number; errorMessage?: string } | null>(null);
@@ -125,11 +135,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const setNewSessionModel = opts.setNewSessionModel ?? setNewSessionModelState;
   const setToolPresetState = opts.setToolPreset ?? setToolPreset;
 
   const currentModel = currentModelOverride ?? data?.context.model ?? pendingModel ?? null;
-  const displayModel = isNew ? newSessionModel : currentModel;
+  const displayModel = isNew ? (newSessionModel ?? newSessionDefaultModel) : currentModel;
 
   const sessionStats = (() => {
     const tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
@@ -614,23 +623,28 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   useEffect(() => {
     const modelCwd = newSessionCwd ?? session?.cwd ?? "";
     const modelsUrl = modelCwd ? `/api/models?cwd=${encodeURIComponent(modelCwd)}` : "/api/models";
-    fetch(modelsUrl).then((r) => r.json()).then((d: { models: Record<string, string>; modelList?: { id: string; name: string; provider: string }[]; defaultModel?: { provider: string; modelId: string } | null; thinkingLevels?: Record<string, string[]>; thinkingLevelMaps?: Record<string, Record<string, string | null>> }) => {
+    const controller = new AbortController();
+    fetch(modelsUrl, { signal: controller.signal }).then((r) => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.json();
+    }).then((d: ModelsResponse) => {
       setModelNames(d.models);
-      if (d.thinkingLevels) setModelThinkingLevels(d.thinkingLevels);
-      if (d.thinkingLevelMaps) setModelThinkingLevelMaps(d.thinkingLevelMaps);
-      if (d.modelList) {
-        setModelList(d.modelList);
-        if (isNew && d.modelList.length > 0) {
-          const def = d.defaultModel;
-          const match = def && d.modelList.find((m) => m.id === def.modelId && m.provider === def.provider);
-          const selected = match
-            ? { provider: match.provider, modelId: match.id }
-            : { provider: d.modelList[0].provider, modelId: d.modelList[0].id };
-          setNewSessionModel(selected);
-        }
+      setModelThinkingLevels(d.thinkingLevels ?? {});
+      setModelThinkingLevelMaps(d.thinkingLevelMaps ?? {});
+      const nextModelList = d.modelList ?? [];
+      setModelList(nextModelList);
+      if (isNew) {
+        const match = d.defaultModel
+          ? nextModelList.find((m) => m.id === d.defaultModel?.modelId && m.provider === d.defaultModel?.provider)
+          : undefined;
+        const displayModel = match ?? nextModelList[0];
+        setNewSessionDefaultModel(displayModel ? { provider: displayModel.provider, modelId: displayModel.id } : null);
       }
-    }).catch(() => {});
-  }, [isNew, modelsRefreshKey, newSessionCwd, session?.cwd, setNewSessionModel]);
+    }).catch((e) => {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+    });
+    return () => controller.abort();
+  }, [isNew, modelsRefreshKey, newSessionCwd, session?.cwd]);
 
   // Compact error auto-dismiss
   useEffect(() => {
@@ -645,6 +659,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, newSessionModel, toolPreset, thinkingLevel,
     retryInfo, contextUsage, systemPrompt, forkingEntryId,
     isCompacting, compactError, currentModel, displayModel, sessionStats,
+    isAutoModelSelection: isNew && newSessionModel === null,
     agentPhase,
     isNew,
     // Refs


### PR DESCRIPTION
## Summary
- Load `/api/models` through `createAgentSessionServices` so extension-registered providers appear in the web selector
- Pass the active cwd when fetching models so project/user settings are respected
- Sort model options alphabetically with natural, case-insensitive ordering

## Verification
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- Direct `/api/models` route check confirmed 11 CustomProvider models are returned and sorted