### PR TITLE
fix(extensions): dispatch session_start to extension runtime on session creation

### DIFF
--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -52,14 +52,13 @@ export class AgentSessionWrapper {
   private extensionStatuses = new Map<string, string>();
   private extensionWidgets = new Map<string, ExtensionWidgetItem>();
   private promptRunning = false;
+  private extensionsBound = false;
   private unsubscribe: (() => void) | null = null;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private onDestroyCallback: (() => void) | null = null;
   private _alive = true;
 
-  constructor(public readonly inner: AgentSessionLike) {
-    this.inner.extensionRunner.setUIContext?.(this.createExtensionUiContext(), "rpc");
-  }
+  constructor(public readonly inner: AgentSessionLike) {}
 
   get sessionId(): string {
     return this.inner.sessionId;
@@ -79,6 +78,23 @@ export class AgentSessionWrapper {
       this.emit(event);
     });
     this.resetIdleTimer();
+  }
+
+  async bindExtensions(): Promise<void> {
+    if (this.extensionsBound || !this._alive) return;
+    try {
+      const session = this.inner as AgentSessionLike & {
+        bindExtensions(b: { uiContext: ExtensionUiContextLike; mode: "rpc" }): Promise<void>;
+      };
+      await session.bindExtensions({
+        uiContext: this.createExtensionUiContext(),
+        mode: "rpc",
+      });
+      this.extensionsBound = true;
+      console.log(`[pi-web] session_start dispatched to extensions for session ${this.inner.sessionId}`);
+    } catch (err) {
+      console.error(`[pi-web] failed to dispatch session_start to extensions:`, err instanceof Error ? err.message : err);
+    }
   }
 
   private emit(event: AgentEvent): void {
@@ -596,6 +612,7 @@ export async function startRpcSession(
 
     const wrapper = new AgentSessionWrapper(inner);
     wrapper.start();
+    await wrapper.bindExtensions();
 
     const realSessionId = inner.sessionId as string;
     const realSessionFile = inner.sessionFile as string | undefined;


### PR DESCRIPTION
## Problem

Extensions such as `pi-mcp-adapter` rely on the `session_start` event to initialize. They failed with **"MCP not initialized"** because pi-web never dispatched `session_start` to the extension runtime.

## Root Cause

`AgentSessionWrapper`'s constructor only called `extensionRunner.setUIContext()`, which sets the UI context at the runner layer but never triggers `AgentSession.bindExtensions()`. Since `createAgentSession()` does not auto-emit `session_start`, extensions never received the `session_start` (nor `resources_discover`) event.

The `session_start` event is emitted only inside `AgentSession.bindExtensions()` (`agent-session.js: _extensionRunner.emit(this._sessionStartEvent)`), which pi-web never called.

## Fix

- Add `AgentSessionWrapper.bindExtensions()` with a re-entrancy guard (`extensionsBound` flag) and minimal logging
- Call it after `wrapper.start()` inside `startRpcSession`'s start lock, so extensions are ready before the session is usable
- Remove the now-redundant `setUIContext` call — `bindExtensions` applies bindings (including UI context) via `_applyExtensionBindings`

## Verification

- `tsc --noEmit` passes
- `eslint` passes
- Manually tested — `pi-mcp-adapter` initializes correctly after the fix
