### PR TITLE
feat: 保留切换 session 时未发送的输入草稿

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState, useCallback, useEffect, useImperativeHandle, forwardRef, KeyboardEvent } from "react";
 import type { BuiltinSlashCommandResult, CompactResultInfo, SlashCommandInfo } from "@/hooks/useAgentSession";
+import { clearDraft, getDraft, setDraft } from "@/lib/draft-store";
 
 export interface AttachedImage {
   data: string;   // base64, no prefix
@@ -45,6 +46,9 @@ interface Props {
   onBuiltinCommand?: (message: string) => Promise<BuiltinSlashCommandResult>;
   soundEnabled?: boolean;
   onSoundToggle?: () => void;
+  // Stable key used to persist the unsent draft across session switches
+  // (ChatWindow is fully remounted when switching sessions).
+  draftKey?: string;
 }
 
 export interface ChatInputHandle {
@@ -131,8 +135,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   onBuiltinCommand,
   soundEnabled, onSoundToggle,
   onPromptWithStreamingBehavior,
+  draftKey,
 }: Props, ref) {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(() => (draftKey ? getDraft(draftKey) : ""));
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [modelDropdownRect, setModelDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
   const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
@@ -232,11 +237,27 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
   const clearInput = useCallback(() => {
     setValue("");
+    if (draftKey) clearDraft(draftKey);
     clearImages();
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
-  }, [clearImages]);
+  }, [clearImages, draftKey]);
+
+  // Persist the unsent draft so it survives session switches (remounts).
+  useEffect(() => {
+    if (!draftKey) return;
+    setDraft(draftKey, value);
+  }, [draftKey, value]);
+
+  // On mount, size the textarea to fit a restored multi-line draft.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta || !value) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSend = useCallback(async () => {
     const msg = value.trim();

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -225,6 +225,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onBuiltinCommand={handleBuiltinSlashCommand}
       soundEnabled={soundEnabled}
       onSoundToggle={onSoundToggle}
+      draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
     />
   );
 

--- a/lib/draft-store.ts
+++ b/lib/draft-store.ts
@@ -1,0 +1,35 @@
+// Per-session draft store for the chat input.
+//
+// ChatWindow (and its ChatInput) is fully remounted whenever the user switches
+// sessions (AppShell bumps `sessionKey`), which wipes the ChatInput's local
+// `value` state. To avoid losing an unsent draft when the user briefly switches
+// to another session and comes back, we persist the draft text here keyed by a
+// stable draft key derived from the session id (or the new-session cwd).
+//
+// The store lives at module scope so it survives ChatWindow remounts. It is
+// intentionally in-memory only (cleared on page reload).
+
+const drafts = new Map<string, string>();
+
+export function getDraft(key: string): string {
+  return drafts.get(key) ?? "";
+}
+
+export function setDraft(key: string, value: string): void {
+  if (value) drafts.set(key, value);
+  else drafts.delete(key);
+}
+
+export function clearDraft(key: string): void {
+  drafts.delete(key);
+}
+
+// Move a draft from one key to another. Used when a brand-new session gets its
+// real id from pi, so the draft key transitions from "new:<cwd>" to the id.
+export function moveDraft(fromKey: string, toKey: string): void {
+  if (fromKey === toKey) return;
+  const value = drafts.get(fromKey);
+  if (value === undefined) return;
+  drafts.delete(fromKey);
+  if (value) drafts.set(toKey, value);
+}


### PR DESCRIPTION
## 背景 / 问题

当前在一个 session 中输入问题但还没有发送时，如果用户临时切换到其他 session 查看内容，再切回原来的 session，输入框里的内容会消失。

这会导致用户需要重新输入刚才的问题，尤其是输入内容较长、需要参考其他 session 信息时，体验比较差。

造成这个现象的原因是：切换 session 时 `AppShell` 会更新 `sessionKey`，从而让 `ChatWindow` 以及内部的 `ChatInput` 被重新挂载；而输入框内容此前只保存在 `ChatInput` 的本地 React state 中，组件一旦重挂载就会丢失。

## 解决方案

本 PR 为聊天输入框增加了按 session 维度的内存草稿缓存：

- 新增 `lib/draft-store.ts`
  - 使用模块级 `Map` 保存未发送的输入草稿
  - 按稳定的 draft key 隔离不同 session 的草稿
- `ChatInput` 新增 `draftKey` 参数
  - 初始化时从草稿缓存中恢复内容
  - 输入变化时同步写入草稿缓存
  - 发送成功 / 清空输入时删除对应草稿
  - 恢复多行草稿时自动调整 textarea 高度
- `ChatWindow` 为 `ChatInput` 传入稳定的 key
  - 已有 session 使用 `session.id`
  - 新建 session 在还没有真实 session id 前使用 `new:<cwd>`

## 用户侧效果

修复后：

1. 用户在 session A 输入一段问题，但暂不发送
2. 切换到 session B 查看内容
3. 再切回 session A
4. 输入框会恢复刚才未发送的草稿

不同 session 的草稿彼此隔离，不会串到其他会话中。消息发送成功后，对应草稿会被清除。

## 说明

当前实现是内存级缓存，主要解决“临时切换 session 后回来”的体验问题；页面刷新后草稿不会持久化到磁盘或 localStorage。

## 验证

已本地执行：

- `git diff --check`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint components/ChatInput.tsx components/ChatWindow.tsx lib/draft-store.ts`
