### PR TITLE
feat: 侧边栏显示会话运行状态与未读提示

### DIFF
--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -1,0 +1,53 @@
+import { getRunningRpcSessionIds, subscribeRunningSessions } from "@/lib/rpc-manager";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/agent/running/events - SSE stream of the set of currently-running
+// session ids. Pushes an update whenever any session starts or stops working,
+// so the sidebar never has to poll.
+export async function GET(req: Request) {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encode = (data: unknown) => {
+        const text = `data: ${JSON.stringify(data)}\n\n`;
+        controller.enqueue(new TextEncoder().encode(text));
+      };
+
+      // Initial snapshot so the client renders the correct state immediately.
+      encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
+
+      const unsubscribe = subscribeRunningSessions((ids) => {
+        try {
+          encode({ type: "running", runningSessionIds: ids });
+        } catch {
+          // controller already closed
+        }
+      });
+
+      // Heartbeat to keep the connection alive through proxies/timeouts.
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(new TextEncoder().encode(":\n\n"));
+        } catch {
+          // controller already closed
+        }
+      }, 30_000);
+
+      const cleanup = () => {
+        clearInterval(heartbeat);
+        unsubscribe();
+        try { controller.close(); } catch { /* already closed */ }
+      };
+
+      req.signal?.addEventListener("abort", cleanup);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -13,9 +13,8 @@ export async function GET(req: Request) {
         controller.enqueue(new TextEncoder().encode(text));
       };
 
-      // Initial snapshot so the client renders the correct state immediately.
-      encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
-
+      // Subscribe BEFORE taking the initial snapshot so no state change can slip
+      // through the gap between snapshot and subscription.
       const unsubscribe = subscribeRunningSessions((ids) => {
         try {
           encode({ type: "running", runningSessionIds: ids });
@@ -23,6 +22,10 @@ export async function GET(req: Request) {
           // controller already closed
         }
       });
+
+      // Initial snapshot so the client renders the correct state immediately.
+      // (A duplicate frame here is harmless: the client just sets the same set.)
+      encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
 
       // Heartbeat to keep the connection alive through proxies/timeouts.
       const heartbeat = setInterval(() => {

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { listAllSessions } from "@/lib/session-reader";
+import { getRunningRpcSessionIds } from "@/lib/rpc-manager";
 
 export async function GET() {
   try {
     const sessions = await listAllSessions();
-    return NextResponse.json({ sessions });
+    return NextResponse.json({ sessions, runningSessionIds: getRunningRpcSessionIds() });
   } catch (error) {
     return NextResponse.json(
       { error: String(error) },

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -19,6 +19,31 @@ interface Props {
   onAtMention?: (relativePath: string) => void;
 }
 
+const UNREAD_SESSIONS_STORAGE_KEY = "pi-web:unread-session-ids";
+
+function loadUnreadSessionIds(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(UNREAD_SESSIONS_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return new Set(parsed.filter((id): id is string => typeof id === "string"));
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function saveUnreadSessionIds(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (ids.size === 0) window.localStorage.removeItem(UNREAD_SESSIONS_STORAGE_KEY);
+    else window.localStorage.setItem(UNREAD_SESSIONS_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    // ignore storage quota / privacy-mode errors
+  }
+}
+
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();
@@ -213,6 +238,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [explorerKey, setExplorerKey] = useState(0);
   const [sessionRefreshDone, setSessionRefreshDone] = useState(false);
   const [explorerRefreshDone, setExplorerRefreshDone] = useState(false);
+  const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
+  const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(() => loadUnreadSessionIds());
+  const previousRunningSessionIdsRef = useRef<Set<string>>(new Set());
   const sessionRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const explorerRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -221,8 +249,16 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       if (showLoading) setLoading(true);
       const res = await fetch("/api/sessions");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json() as { sessions: SessionInfo[] };
+      const data = await res.json() as { sessions: SessionInfo[]; runningSessionIds?: string[] };
       setAllSessions(data.sessions);
+      setRunningSessionIds(new Set(data.runningSessionIds ?? []));
+      // Drop unread markers for sessions that no longer exist (e.g. deleted).
+      const existingIds = new Set(data.sessions.map((s) => s.id));
+      setUnreadSessionIds((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Set([...prev].filter((id) => existingIds.has(id)));
+        return next.size === prev.size ? prev : next;
+      });
       setError(null);
       if (!showLoading) {
         setSessionRefreshDone(true);
@@ -242,6 +278,59 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     initialLoadDone.current = true;
     loadSessions(isFirst);
   }, [loadSessions, refreshKey]);
+
+  // Persist unread markers so they survive a browser refresh before the user
+  // has actually opened the completed session.
+  useEffect(() => {
+    saveUnreadSessionIds(unreadSessionIds);
+  }, [unreadSessionIds]);
+
+  useEffect(() => {
+    // Live running status via SSE — no polling. The server pushes the current
+    // set of running session ids whenever any session starts/stops working.
+    const source = new EventSource("/api/agent/running/events");
+
+    source.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data) as { type?: string; runningSessionIds?: string[] };
+        if (data.type === "running") {
+          setRunningSessionIds(new Set(data.runningSessionIds ?? []));
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    };
+
+    // On error EventSource auto-reconnects; keep the last known state meanwhile.
+    return () => source.close();
+  }, []);
+
+  useEffect(() => {
+    const previous = previousRunningSessionIdsRef.current;
+    const completedInBackground = [...previous].filter((id) => !runningSessionIds.has(id) && id !== selectedSessionId);
+    const newlyRunning = [...runningSessionIds];
+
+    if (completedInBackground.length > 0 || newlyRunning.length > 0) {
+      setUnreadSessionIds((prev) => {
+        const next = new Set(prev);
+        newlyRunning.forEach((id) => next.delete(id));
+        completedInBackground.forEach((id) => next.add(id));
+        return next;
+      });
+    }
+
+    previousRunningSessionIdsRef.current = runningSessionIds;
+  }, [runningSessionIds, selectedSessionId]);
+
+  useEffect(() => {
+    if (!selectedSessionId) return;
+    setUnreadSessionIds((prev) => {
+      if (!prev.has(selectedSessionId)) return prev;
+      const next = new Set(prev);
+      next.delete(selectedSessionId);
+      return next;
+    });
+  }, [selectedSessionId]);
 
   useEffect(() => {
     if (explorerRefreshKey !== undefined) setExplorerKey((k) => k + 1);
@@ -704,6 +793,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             key={node.session.id}
             node={node}
             selectedSessionId={selectedSessionId}
+            runningSessionIds={runningSessionIds}
+            unreadSessionIds={unreadSessionIds}
             onSelectSession={onSelectSession}
             onRenamed={loadSessions}
             onSessionDeleted={(id) => {
@@ -809,6 +900,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
 function SessionTreeItem({
   node,
   selectedSessionId,
+  runningSessionIds,
+  unreadSessionIds,
   onSelectSession,
   onRenamed,
   onSessionDeleted,
@@ -816,6 +909,8 @@ function SessionTreeItem({
 }: {
   node: SessionTreeNode;
   selectedSessionId: string | null;
+  runningSessionIds: Set<string>;
+  unreadSessionIds: Set<string>;
   onSelectSession: (s: SessionInfo) => void;
   onRenamed?: () => void;
   onSessionDeleted?: (id: string) => void;
@@ -841,6 +936,8 @@ function SessionTreeItem({
         <SessionItem
           session={node.session}
           isSelected={node.session.id === selectedSessionId}
+          isRunning={runningSessionIds.has(node.session.id)}
+          isUnread={unreadSessionIds.has(node.session.id)}
           onClick={() => onSelectSession(node.session)}
           onRenamed={onRenamed}
           onDeleted={(id) => onSessionDeleted?.(id)}
@@ -857,6 +954,8 @@ function SessionTreeItem({
               key={child.session.id}
               node={child}
               selectedSessionId={selectedSessionId}
+              runningSessionIds={runningSessionIds}
+              unreadSessionIds={unreadSessionIds}
               onSelectSession={onSelectSession}
               onRenamed={onRenamed}
               onSessionDeleted={onSessionDeleted}
@@ -869,9 +968,67 @@ function SessionTreeItem({
   );
 }
 
+function RunningSessionIndicator() {
+  return (
+    <span
+      title="Agent running…"
+      aria-label="Agent running"
+      style={{
+        width: 14,
+        height: 14,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        color: "var(--accent)",
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" style={{ display: "block" }}>
+        <circle cx="7" cy="7" r="3" fill="currentColor" opacity="0.25">
+          <animate attributeName="r" values="3;6;3" dur="1.3s" repeatCount="indefinite" />
+          <animate attributeName="opacity" values="0.35;0;0.35" dur="1.3s" repeatCount="indefinite" />
+        </circle>
+        <circle cx="7" cy="7" r="3" fill="currentColor">
+          <animate attributeName="opacity" values="1;0.55;1" dur="1.3s" repeatCount="indefinite" />
+        </circle>
+      </svg>
+    </span>
+  );
+}
+
+function UnreadSessionIndicator() {
+  return (
+    <span
+      title="Completed while you were away"
+      aria-label="Unread completed session"
+      style={{
+        width: 14,
+        height: 14,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        color: "#eab308",
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: "currentColor",
+          boxShadow: "0 0 0 2px rgba(234,179,8,0.14)",
+        }}
+      />
+    </span>
+  );
+}
+
 function SessionItem({
   session,
   isSelected,
+  isRunning,
+  isUnread,
   onClick,
   onRenamed,
   onDeleted,
@@ -882,6 +1039,8 @@ function SessionItem({
 }: {
   session: SessionInfo;
   isSelected: boolean;
+  isRunning?: boolean;
+  isUnread?: boolean;
   onClick: () => void;
   onRenamed?: () => void;
   onDeleted?: (id: string) => void;
@@ -1051,17 +1210,21 @@ function SessionItem({
           <div style={{ flex: 1, minWidth: 0 }}>
             <div
               style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                minWidth: 0,
                 fontSize: 12,
                 fontWeight: isSelected ? 500 : 400,
                 lineHeight: 1.4,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
                 color: "var(--text)",
               }}
-              title={title}
+              title={isRunning ? `${title} · Agent running…` : isUnread ? `${title} · Completed while you were away` : title}
             >
-              {title}
+              {isRunning ? <RunningSessionIndicator /> : isUnread ? <UnreadSessionIndicator /> : null}
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>
+                {title}
+              </span>
             </div>
             <div style={{ marginTop: 2, display: "flex", gap: 8, color: "var(--text-dim)", fontSize: 11 }}>
               <span title={session.modified}>{formatRelativeTime(session.modified)}</span>

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -991,14 +991,23 @@ function RunningSessionIndicator() {
         color: "var(--accent)",
       }}
     >
-      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" style={{ display: "block" }}>
-        <circle cx="7" cy="7" r="3" fill="currentColor" opacity="0.25">
-          <animate attributeName="r" values="3;6;3" dur="1.3s" repeatCount="indefinite" />
-          <animate attributeName="opacity" values="0.35;0;0.35" dur="1.3s" repeatCount="indefinite" />
-        </circle>
-        <circle cx="7" cy="7" r="3" fill="currentColor">
-          <animate attributeName="opacity" values="1;0.55;1" dur="1.3s" repeatCount="indefinite" />
-        </circle>
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true" style={{ display: "block" }}>
+        <g>
+          <path
+            d="M21 12a9 9 0 1 1-3.8-7.4"
+            stroke="currentColor"
+            strokeWidth="2.8"
+            strokeLinecap="round"
+          />
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 12 12"
+            to="360 12 12"
+            dur="0.9s"
+            repeatCount="indefinite"
+          />
+        </g>
       </svg>
     </span>
   );
@@ -1007,8 +1016,8 @@ function RunningSessionIndicator() {
 function UnreadSessionIndicator() {
   return (
     <span
-      title="Completed while you were away"
-      aria-label="Unread completed session"
+      title="New activity"
+      aria-label="New session activity"
       style={{
         width: 14,
         height: 14,
@@ -1016,18 +1025,16 @@ function UnreadSessionIndicator() {
         alignItems: "center",
         justifyContent: "center",
         flexShrink: 0,
-        color: "#eab308",
+        color: "#0891b2",
       }}
     >
-      <span
-        style={{
-          width: 8,
-          height: 8,
-          borderRadius: "50%",
-          background: "currentColor",
-          boxShadow: "0 0 0 2px rgba(234,179,8,0.14)",
-        }}
-      />
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" style={{ display: "block" }}>
+        <circle cx="7" cy="7" r="2.5" fill="currentColor" />
+        <circle cx="7" cy="7" r="3" stroke="currentColor" strokeWidth="1.4" opacity="0.32">
+          <animate attributeName="r" values="3;6;3" dur="1.6s" repeatCount="indefinite" />
+          <animate attributeName="opacity" values="0.32;0;0.32" dur="1.6s" repeatCount="indefinite" />
+        </circle>
+      </svg>
     </span>
   );
 }
@@ -1227,7 +1234,7 @@ function SessionItem({
                 lineHeight: 1.4,
                 color: "var(--text)",
               }}
-              title={isRunning ? `${title} · Agent running…` : isUnread ? `${title} · Completed while you were away` : title}
+              title={isRunning ? `${title} · Agent running…` : isUnread ? `${title} · New activity` : title}
             >
               {isRunning ? <RunningSessionIndicator /> : isUnread ? <UnreadSessionIndicator /> : null}
               <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -241,6 +241,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
   const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(() => loadUnreadSessionIds());
   const previousRunningSessionIdsRef = useRef<Set<string>>(new Set());
+  // Once the SSE stream has delivered a frame it is the source of truth for
+  // running state; late /api/sessions responses must not overwrite it.
+  const sseAuthoritativeRef = useRef(false);
   const sessionRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const explorerRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -251,7 +254,11 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json() as { sessions: SessionInfo[]; runningSessionIds?: string[] };
       setAllSessions(data.sessions);
-      setRunningSessionIds(new Set(data.runningSessionIds ?? []));
+      // Treat the fetched running set as an initial fallback only. Once SSE is
+      // live it owns this state, so a slow fetch can't revive a stale snapshot.
+      if (!sseAuthoritativeRef.current) {
+        setRunningSessionIds(new Set(data.runningSessionIds ?? []));
+      }
       // Drop unread markers for sessions that no longer exist (e.g. deleted).
       const existingIds = new Set(data.sessions.map((s) => s.id));
       setUnreadSessionIds((prev) => {
@@ -294,6 +301,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       try {
         const data = JSON.parse(e.data) as { type?: string; runningSessionIds?: string[] };
         if (data.type === "running") {
+          sseAuthoritativeRef.current = true;
           setRunningSessionIds(new Set(data.runningSessionIds ?? []));
         }
       } catch {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -104,12 +104,20 @@ export class AgentSessionWrapper {
     return this._alive;
   }
 
+  isRunning(): boolean {
+    return this._alive && (this.promptRunning || this.inner.isStreaming || this.inner.isCompacting);
+  }
+
   start(): void {
     this.unsubscribe = this.inner.subscribe((event: AgentEvent) => {
       this.resetIdleTimer();
       this.emit(event);
+      // Streaming / compaction / tool events flow through here; re-broadcast
+      // the running-status snapshot so the sidebar can update live.
+      notifyRunningChange();
     });
     this.resetIdleTimer();
+    notifyRunningChange();
   }
 
   setForceEmptySystemPrompt(force: boolean): void {
@@ -231,6 +239,7 @@ export class AgentSessionWrapper {
         const promptImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
         const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
         this.promptRunning = true;
+        notifyRunningChange();
         this.inner.prompt(command.message as string, {
           ...(promptImages?.length ? { images: promptImages } : {}),
           ...(streamingBehavior ? { streamingBehavior } : {}),
@@ -238,6 +247,7 @@ export class AgentSessionWrapper {
         }).then(() => {
           this.promptRunning = false;
           if (!streamingBehavior) this.emit({ type: "prompt_done" });
+          notifyRunningChange();
         }).catch((error) => {
           this.promptRunning = false;
           this.emit({
@@ -245,6 +255,7 @@ export class AgentSessionWrapper {
             errorMessage: error instanceof Error ? error.message : String(error),
           });
           if (!streamingBehavior) this.emit({ type: "prompt_done" });
+          notifyRunningChange();
         });
         return null;
       }
@@ -470,6 +481,7 @@ export class AgentSessionWrapper {
     this.pendingUiResponses.clear();
     this.pendingUiRequests.clear();
     this.onDestroyCallback?.();
+    notifyRunningChange();
   }
 
   private resolveExtensionUiResponse(response: ExtensionUiResponse): void {
@@ -790,6 +802,7 @@ export class AgentSessionWrapper {
 declare global {
   var __piSessions: Map<string, AgentSessionWrapper> | undefined;
   var __piStartLocks: Map<string, Promise<{ session: AgentSessionWrapper; realSessionId: string }>> | undefined;
+  var __piRunningListeners: Set<(ids: string[]) => void> | undefined;
 }
 
 function getRegistry(): Map<string, AgentSessionWrapper> {
@@ -810,6 +823,51 @@ function getLocks(): Map<string, Promise<{ session: AgentSessionWrapper; realSes
 
 export function getRpcSession(sessionId: string): AgentSessionWrapper | undefined {
   return getRegistry().get(sessionId);
+}
+
+export function getRunningRpcSessionIds(): string[] {
+  const ids = new Set<string>();
+  for (const [sessionId, session] of getRegistry()) {
+    if (session.isRunning()) ids.add(session.sessionId || sessionId);
+  }
+  return [...ids];
+}
+
+// ----------------------------------------------------------------------------
+// Running-status broadcaster
+//
+// Pushes the current set of running session ids to subscribers whenever any
+// session's running state may have changed. This lets the sidebar receive live
+// updates over SSE instead of polling. Listeners live on globalThis so they
+// survive Next.js hot-reload.
+// ----------------------------------------------------------------------------
+
+function getRunningListeners(): Set<(ids: string[]) => void> {
+  if (!globalThis.__piRunningListeners) globalThis.__piRunningListeners = new Set();
+  return globalThis.__piRunningListeners;
+}
+
+/** Subscribe to running-session-id changes. Returns an unsubscribe function. */
+export function subscribeRunningSessions(listener: (ids: string[]) => void): () => void {
+  const listeners = getRunningListeners();
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+let lastRunningSnapshot = "";
+
+/**
+ * Recompute the running-session-id set and, if it changed since the last
+ * notification, broadcast it to subscribers. Cheap to call often.
+ */
+export function notifyRunningChange(): void {
+  const ids = getRunningRpcSessionIds();
+  const snapshot = JSON.stringify([...ids].sort());
+  if (snapshot === lastRunningSnapshot) return;
+  lastRunningSnapshot = snapshot;
+  for (const listener of getRunningListeners()) {
+    try { listener(ids); } catch { /* ignore listener errors */ }
+  }
 }
 
 /**

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -200,6 +200,14 @@ export class AgentSessionWrapper {
     return type === "prompt" || type === "steer" || type === "follow_up" || type === "get_commands";
   }
 
+  private async withFinalRunningNotification<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } finally {
+      notifyRunningChange();
+    }
+  }
+
   private applyForcedEmptySystemPrompt(): void {
     if (this.forceEmptySystemPrompt && this.inner.agent.state) {
       this.inner.agent.state.systemPrompt = "";
@@ -261,7 +269,7 @@ export class AgentSessionWrapper {
       }
 
       case "abort":
-        await this.inner.abort();
+        await this.withFinalRunningNotification(() => this.inner.abort());
         return null;
 
       case "get_state": {
@@ -348,7 +356,9 @@ export class AgentSessionWrapper {
       }
 
       case "compact": {
-        const result = await this.inner.compact(command.customInstructions as string | undefined);
+        const result = await this.withFinalRunningNotification(() =>
+          this.inner.compact(command.customInstructions as string | undefined)
+        );
         return result;
       }
 


### PR DESCRIPTION
## 解决的问题

同时运行多个 session 或切到其他 session 时，用户无法直接感知哪些 session 正在工作；后台完成的 session 也没有任何提醒。

## 改动

- 侧边栏为正在运行的 session 显示动态图标（蓝色脉冲）。
- 后台完成但用户尚未查看的 session 显示未读黄点，点击查看后消失。
- 未读状态持久化到 localStorage，浏览器刷新后不丢失。
- 运行状态通过 SSE（`GET /api/agent/running/events`）实时推送，不使用轮询，空闲时零请求。

## 说明

- `/api/sessions` 仅新增 `runningSessionIds` 字段，向后兼容。
- SSE 路由只读内存运行态，不会因查看状态而拉起 agent。
- 未改动原有会话列表、选择、发送、fork 等逻辑。
