### PR TITLE
feat: add file download support with download button in explorer and viewer

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -146,18 +146,19 @@ function encodeHeaderValue(value: string): string {
   );
 }
 
-function getContentDisposition(filePath: string): string {
+function getContentDisposition(filePath: string, asDownload = false): string {
+  const disposition = asDownload ? "attachment" : "inline";
   const fileName = path.basename(filePath);
   const fallback = fileName.replace(/[^\x20-\x7E]|["\\;\r\n]/g, "_") || "download";
-  return `inline; filename="${fallback}"; filename*=UTF-8''${encodeHeaderValue(fileName)}`;
+  return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encodeHeaderValue(fileName)}`;
 }
 
-function streamFile(filePath: string, stat: fs.Stats, contentType: string, rangeHeader: string | null): Response {
+function streamFile(filePath: string, stat: fs.Stats, contentType: string, rangeHeader: string | null, asDownload = false): Response {
   const headers = {
     "Content-Type": contentType,
     "Cache-Control": "no-cache",
     "Accept-Ranges": "bytes",
-    "Content-Disposition": getContentDisposition(filePath),
+    "Content-Disposition": getContentDisposition(filePath, asDownload),
   };
 
   if (!rangeHeader) {
@@ -321,6 +322,14 @@ export async function GET(
       const content = fs.readFileSync(filePath, "utf-8");
       const language = getLanguage(filePath);
       return NextResponse.json({ content, language, size: stat.size });
+    }
+
+    if (type === "download") {
+      if (!stat.isFile()) {
+        return NextResponse.json({ error: "Not a file" }, { status: 400 });
+      }
+      const mime = getImageMime(filePath) || getAudioMime(filePath) || getDocumentMime(filePath) || "application/octet-stream";
+      return streamFile(filePath, stat, mime, request.headers.get("range"), true);
     }
 
     if (type === "meta") {

--- a/components/FileExplorer.tsx
+++ b/components/FileExplorer.tsx
@@ -174,7 +174,7 @@ function TreeNode({
             title="Insert path into chat"
             style={{
               position: "absolute",
-              right: 4,
+              right: !node.isDir ? 36 : 4,
               top: "50%",
               transform: "translateY(-50%)",
               display: "flex",
@@ -199,6 +199,41 @@ function TreeNode({
             </svg>
             mention
           </button>
+        )}
+        {hovered && !node.isDir && (
+          <a
+            href={`/api/files/${encodeFilePathForApi(node.fullPath)}?type=download`}
+            download
+            onClick={(e) => e.stopPropagation()}
+            title="Download file"
+            style={{
+              position: "absolute",
+              right: 4,
+              top: "50%",
+              transform: "translateY(-50%)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 4,
+              padding: "0 6px",
+              height: 20,
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              fontSize: 11,
+              fontWeight: 600,
+              whiteSpace: "nowrap",
+              textDecoration: "none",
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </a>
         )}
       </div>
       {node.isDir && open && (

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -49,7 +49,7 @@ function DownloadLink({ filePath, label = "Download" }: { filePath: string; labe
   const encoded = encodeFilePathForApi(filePath);
   return (
     <a
-      href={`/api/files/${encoded}?type=read`}
+      href={`/api/files/${encoded}?type=download`}
       download={getFileName(filePath)}
       style={{
         color: "var(--text-muted)",
@@ -372,6 +372,7 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
         <span style={{ marginLeft: "auto" }}>{ext || "image"}</span>
         {naturalSize && <span>{naturalSize.w} × {naturalSize.h}</span>}
         {formatSizeStr && <span>{formatSizeStr}</span>}
+        <DownloadLink filePath={filePath} />
         <span
           title={watching ? "Live sync active" : "Not watching"}
           style={{ display: "flex", alignItems: "center", gap: 4, color: watching ? "#4ade80" : "var(--text-dim)" }}
@@ -506,6 +507,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
         <span style={{ marginLeft: "auto" }}>{ext || "audio"}</span>
         {duration != null && <span>{formatDuration(duration)}</span>}
         {size != null && <span>{formatSize(size)}</span>}
+        <DownloadLink filePath={filePath} />
         <span
           title={watching ? "Live sync active" : "Not watching"}
           style={{ display: "flex", alignItems: "center", gap: 4, color: watching ? "#4ade80" : "var(--text-dim)" }}
@@ -821,6 +823,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
         <span style={{ marginLeft: "auto" }}>{data.language}</span>
         {viewMode === "source" && <span>{lines.length} lines</span>}
         <span>{formatSize(data.size)}</span>
+        <DownloadLink filePath={filePath} />
 
         {/* Live watch indicator */}
         <span


### PR DESCRIPTION
## Summary

Add file download functionality to pi-web. Users can now download files from two places:

### Left panel (File Explorer)
Hover over any file → a download icon appears (next to the @mention button) → click to download.

### Right panel (File Viewer)
Image, audio, and text file preview headers now include a download button alongside the existing file metadata.

### Backend
New `?type=download` query parameter on `/api/files/[...path]` returns `Content-Disposition: attachment` for all file types (images, audio, documents, and unknown types fall back to `application/octet-stream`).

## Changes
- `app/api/files/[...path]/route.ts` — add `?type=download` branch with `Content-Disposition: attachment`
- `components/FileExplorer.tsx` — download button on hover (files only, not directories)
- `components/FileViewer.tsx` — download button in ImageViewer, AudioViewer, and TextFileViewer header bars

## Notes
- Uses `<a>` tag with native `download` attribute (no `window.open`) to avoid popup blockers
- The `?type=download` branch does not impose the 10MB limit that `?type=read` has for images, since download should serve the original file as-is