### PR TITLE
fix: patch export HTML to avoid stack overflow on deep linear sessions

### DIFF
--- a/app/api/sessions/[id]/export/route.ts
+++ b/app/api/sessions/[id]/export/route.ts
@@ -77,6 +77,108 @@ async function getPiCliPath(): Promise<string | null> {
   return null;
 }
 
+/**
+ * Patch the exported HTML to fix recursive functions that overflow
+ * the call stack on deep linear session trees (e.g., 5000+ entries).
+ *
+ * ## Root Cause
+ * pi-coding-agent's template.js uses two recursive functions to render
+ * the session tree in the exported HTML:
+ *
+ *   1. sortChildren(node) — recursively sorts children of every node.
+ *      Calls itself via node.children.forEach(sortChildren).
+ *      On a 5527-entry linear chain (no branches), this recurses 5527
+ *      levels deep → stack overflow.
+ *
+ *   2. markActive(node) — recursively marks nodes on the active path.
+ *      Calls itself via markActive(child) for each child.
+ *      Same depth → same overflow.
+ *
+ * Both functions are inlined in the HTML by pi-coding-agent at export
+ * time. We cannot modify template.js directly (it's in node_modules
+ * and would be overwritten on npm install). Instead, we patch the
+ * generated HTML string before returning it to the client.
+ *
+ * ## Fix
+ * Replace each recursive function with an iterative equivalent:
+ *
+ *   sortChildren  → explicit stack (DFS pre-order, push children in
+ *                   reverse to maintain order)
+ *   markActive    → two-stack post-order (stack1 for traversal,
+ *                   stack2 for processing children before parent)
+ *
+ * ## Line Ending Normalization
+ * This file (route.ts) uses CRLF (Windows), while template.js uses LF
+ * (Unix). The template strings in the backtick literals inherit the
+ * file's CRLF line endings. At runtime, readFileSync() also returns
+ * CRLF on Windows. We normalize everything to LF before matching.
+ *
+ * The helper `n(s)` strips \r\n → \n on both the HTML and the
+ * replacement strings, ensuring cross-platform matching.
+ */
+function patchExportHtml(html: string): string {
+  // Normalize line endings: route.ts is CRLF, template.js is LF.
+  // Without this, the replace() below would fail on Windows.
+  const n = (s: string) => s.replace(/\r\n/g, "\n");
+  html = n(html);
+
+  // Fix 1: sortChildren — recursive → iterative (explicit stack)
+  html = html.replace(
+    n(`        function sortChildren(node) {
+          node.children.sort((a, b) =>
+            new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime()
+          );
+          node.children.forEach(sortChildren);
+        }`),
+    n(`        function sortChildren(root) {
+          const stack = [root];
+          while (stack.length) {
+            const node = stack.pop();
+            node.children.sort((a, b) =>
+              new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime()
+            );
+            for (let i = node.children.length - 1; i >= 0; i--) {
+              stack.push(node.children[i]);
+            }
+          }
+        }`)
+  );
+
+  // Fix 2: markActive — recursive → iterative (two-stack post-order)
+  html = html.replace(
+    n(`        function markActive(node) {
+          let has = activePathIds.has(node.entry.id);
+          for (const child of node.children) {
+            if (markActive(child)) has = true;
+          }
+          containsActive.set(node, has);
+          return has;
+        }`),
+    n(`        function markActive(root) {
+          // Post-order traversal using two stacks
+          const stack1 = [root];
+          const stack2 = [];
+          while (stack1.length) {
+            const node = stack1.pop();
+            stack2.push(node);
+            for (const child of node.children) {
+              stack1.push(child);
+            }
+          }
+          while (stack2.length) {
+            const node = stack2.pop();
+            let has = activePathIds.has(node.entry.id);
+            for (const child of node.children) {
+              if (containsActive.get(child)) has = true;
+            }
+            containsActive.set(node, has);
+          }
+        }`)
+  );
+
+  return html;
+}
+
 async function exportSession(filePath: string, outputPath: string): Promise<void> {
   const cliPath = await getPiCliPath();
   if (cliPath) {
@@ -124,7 +226,8 @@ export async function GET(
       await exportSession(filePath, outputPath);
 
       const html = readFileSync(outputPath, "utf8");
-      return new Response(html, {
+      const patchedHtml = patchExportHtml(html);
+      return new Response(patchedHtml, {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
           "Content-Disposition": getAttachmentDisposition(fileName),


### PR DESCRIPTION
## Problem

pi-coding-agent's `template.js` embeds two recursive functions in the exported HTML: `sortChildren` and `markActive`. On a 5527-entry linear session chain (no branches), both overflow the call stack (Maximum call stack size exceeded), causing the browser to show a blank page.

## Root Cause

- `sortChildren(node)` calls `node.children.forEach(sortChildren)` — recurses to tree depth (5527 levels)
- `markActive(node)` calls `markActive(child)` for each child — same depth

Both are inlined in the HTML by pi-coding-agent at export time. We cannot modify `template.js` (it's in `node_modules`, overwritten on `npm install`). Instead, we patch the generated HTML string before returning it to the client.

## Fix

Replace each recursive function with an iterative equivalent:

| Function | Old (recursive) | New (iterative) |
|----------|----------------|-----------------|
| `sortChildren` | `node.children.forEach(sortChildren)` | Explicit stack (DFS pre-order, push children in reverse) |
| `markActive` | `if (markActive(child)) has = true` | Two-stack post-order (stack1 for traversal, stack2 for processing children before parent) |

## Cross-platform

This file (`route.ts`) uses CRLF (Windows), `template.js` uses LF (Unix). The backtick template strings inherit the file's CRLF line endings. At runtime, `readFileSync()` also returns CRLF on Windows. The helper `n(s)` strips `\r\n → \n` on both the HTML and the replacement strings, ensuring cross-platform matching.

## Verification

- Tested on a 5599-entry session: `sortChildren` 0ms, `markActive` 6ms (no stack overflow)
- Both CLI export path (`pi --export`) and import fallback path go through the same `patchExportHtml()`
- 1 file changed, +104/-1 lines
