### PR TITLE
fix: done sound not playing due to handler overwrite and suspended AudioContext

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -47,6 +47,7 @@ interface Props {
   onBuiltinCommand?: (message: string) => Promise<BuiltinSlashCommandResult>;
   soundEnabled?: boolean;
   onSoundToggle?: () => void;
+  onAudioUnlock?: () => void;
   draftKey?: string;
 }
 
@@ -149,7 +150,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   retryInfo,
   slashCommands, slashCommandsLoading, onLoadSlashCommands,
   onBuiltinCommand,
-  soundEnabled, onSoundToggle,
+  soundEnabled, onSoundToggle, onAudioUnlock,
   onPromptWithStreamingBehavior,
   draftKey,
 }: Props, ref) {
@@ -316,6 +317,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     const msg = value.trim();
     if (!msg && !attachedImages.length) return;
     if (isStreaming) return;
+    onAudioUnlock?.();
     if (!attachedImages.length && msg.startsWith("/") && onBuiltinCommand) {
       const result = await onBuiltinCommand(msg);
       if (result.handled) {
@@ -325,7 +327,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     }
     onSend(msg, attachedImages.length ? attachedImages : undefined);
     clearInput();
-  }, [value, attachedImages, isStreaming, onBuiltinCommand, onSend, clearInput]);
+  }, [value, attachedImages, isStreaming, onBuiltinCommand, onSend, clearInput, onAudioUnlock]);
 
   const slashQuery = value.startsWith("/") && !/\s/.test(value.slice(1))
     ? value.slice(1).toLowerCase()
@@ -383,6 +385,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const sendQueued = useCallback((mode: "steer" | "followup") => {
     const msg = value.trim();
     if (!msg && !attachedImages.length) return;
+    onAudioUnlock?.();
     const streamingBehavior = mode === "steer" ? "steer" : "followUp";
     if (msg.startsWith("/") && onPromptWithStreamingBehavior) {
       onPromptWithStreamingBehavior(msg, streamingBehavior, attachedImages.length ? attachedImages : undefined);
@@ -395,7 +398,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       onFollowUp(msg, attachedImages.length ? attachedImages : undefined);
     }
     clearInput();
-  }, [value, attachedImages, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput]);
+  }, [value, attachedImages, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput, onAudioUnlock]);
 
   const getNextSlashIndex = useCallback((direction: "up" | "down" | "left" | "right") => {
     const lastIndex = filteredSlashCommands.length - 1;

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -44,7 +44,7 @@ const CHAT_COLUMN_PADDING = 16;
 const CHAT_INPUT_RIGHT_PADDING = CHAT_COLUMN_PADDING + CHAT_MINIMAP_WIDTH;
 
 export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange }: Props) {
-  const { soundEnabled, onSoundToggle, playDoneSound } = useAudio();
+  const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
   const isMobile = useIsMobile();
 
   // Wrap onAgentEnd to play the completion sound. This is more reliable than
@@ -77,7 +77,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
     handleBuiltinSlashCommand,
-    handleToolPresetChange, handleThinkingLevelChange, loadSlashCommands, handleAgentEventRef,
+    handleToolPresetChange, handleThinkingLevelChange, loadSlashCommands,
   } = useAgentSession({
     session, newSessionCwd, onAgentEnd: wrappedOnAgentEnd, onSessionCreated, onSessionForked,
     modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
@@ -172,6 +172,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onBuiltinCommand={handleBuiltinSlashCommand}
       soundEnabled={soundEnabled}
       onSoundToggle={onSoundToggle}
+      onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
     />
   );

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -44,6 +44,24 @@ const CHAT_COLUMN_PADDING = 16;
 const CHAT_INPUT_RIGHT_PADDING = CHAT_COLUMN_PADDING + CHAT_MINIMAP_WIDTH;
 
 export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange }: Props) {
+  const { soundEnabled, onSoundToggle, playDoneSound } = useAudio();
+  const isMobile = useIsMobile();
+
+  // Wrap onAgentEnd to play the completion sound. This is more reliable than
+  // wrapping handleAgentEventRef because useAgentSession overwrites that ref
+  // on every render (it syncs the latest callback), which would blow away an
+  // externally-installed wrapper after the first re-render.
+  const playDoneSoundRef = useRef(playDoneSound);
+  playDoneSoundRef.current = playDoneSound;
+  const soundEnabledRef = useRef(soundEnabled);
+  soundEnabledRef.current = soundEnabled;
+  const wrappedOnAgentEnd = useCallback(() => {
+    if (soundEnabledRef.current) {
+      playDoneSoundRef.current();
+    }
+    onAgentEnd?.();
+  }, [onAgentEnd]);
+
   const {
     loading, error, messages, entryIds, streamState,
     agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
@@ -61,27 +79,9 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     handleBuiltinSlashCommand,
     handleToolPresetChange, handleThinkingLevelChange, loadSlashCommands, handleAgentEventRef,
   } = useAgentSession({
-    session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked,
+    session, newSessionCwd, onAgentEnd: wrappedOnAgentEnd, onSessionCreated, onSessionForked,
     modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
   });
-
-  const { soundEnabled, onSoundToggle, playDoneSound } = useAudio();
-  const isMobile = useIsMobile();
-  const playDoneSoundRef = useRef(playDoneSound);
-  playDoneSoundRef.current = playDoneSound;
-  const soundEnabledRef = useRef(soundEnabled);
-  soundEnabledRef.current = soundEnabled;
-
-  // Wrap agent event handler to play sound on agent_end
-  const origHandler = handleAgentEventRef.current;
-  useEffect(() => {
-    handleAgentEventRef.current = (event) => {
-      if (event.type === "agent_end" && soundEnabledRef.current) {
-        playDoneSoundRef.current();
-      }
-      origHandler?.(event);
-    };
-  }, [origHandler, handleAgentEventRef]);
 
   // Push session stats up to AppShell for the top bar.
   // Compare scalar fields to avoid loops from new object identity each render.

--- a/hooks/useAudio.ts
+++ b/hooks/useAudio.ts
@@ -2,6 +2,25 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 
+function playTone(ctx: AudioContext) {
+  const now = ctx.currentTime;
+  const freqs = [523.25, 659.25];
+  freqs.forEach((freq, i) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "sine";
+    osc.frequency.value = freq;
+    const t = now + i * 0.18;
+    gain.gain.setValueAtTime(0, t);
+    gain.gain.linearRampToValueAtTime(0.18, t + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.45);
+    osc.start(t);
+    osc.stop(t + 0.45);
+  });
+}
+
 export function useAudio() {
   const [enabled, setEnabled] = useState<boolean>(() => {
     if (typeof window === "undefined") return true;
@@ -17,7 +36,7 @@ export function useAudio() {
   // start in "suspended" state and produce no sound).
   const ctxRef = useRef<AudioContext | null>(null);
   const getCtx = useCallback((): AudioContext | null => {
-    if (ctxRef.current) return ctxRef.current;
+    if (ctxRef.current && ctxRef.current.state !== "closed") return ctxRef.current;
     try {
       ctxRef.current = new AudioContext();
     } catch {
@@ -26,43 +45,38 @@ export function useAudio() {
     return ctxRef.current;
   }, []);
 
+  const unlockAudio = useCallback((force = false) => {
+    if (!force && !enabledRef.current) return;
+    const ctx = getCtx();
+    if (!ctx || ctx.state !== "suspended") return;
+    ctx.resume().catch(() => {});
+  }, [getCtx]);
+
   const toggle = useCallback(() => {
-    setEnabled((prev) => {
-      const next = !prev;
-      localStorage.setItem("pi-sound-enabled", String(next));
-      return next;
-    });
-  }, []);
+    const next = !enabledRef.current;
+    if (next) unlockAudio(true);
+    enabledRef.current = next;
+    localStorage.setItem("pi-sound-enabled", String(next));
+    setEnabled(next);
+  }, [unlockAudio]);
 
   const playDone = useCallback(() => {
     if (!enabledRef.current) return;
     const ctx = getCtx();
     if (!ctx) return;
-    // Resume if suspended (browser autoplay policy)
+    const play = () => {
+      try {
+        playTone(ctx);
+      } catch {
+        // AudioContext not available
+      }
+    };
     if (ctx.state === "suspended") {
-      ctx.resume().catch(() => {});
+      ctx.resume().then(play).catch(() => {});
+      return;
     }
-    try {
-      const now = ctx.currentTime;
-      const freqs = [523.25, 659.25];
-      freqs.forEach((freq, i) => {
-        const osc = ctx.createOscillator();
-        const gain = ctx.createGain();
-        osc.connect(gain);
-        gain.connect(ctx.destination);
-        osc.type = "sine";
-        osc.frequency.value = freq;
-        const t = now + i * 0.18;
-        gain.gain.setValueAtTime(0, t);
-        gain.gain.linearRampToValueAtTime(0.18, t + 0.02);
-        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.45);
-        osc.start(t);
-        osc.stop(t + 0.45);
-      });
-    } catch {
-      // AudioContext not available
-    }
+    play();
   }, [getCtx]);
 
-  return { soundEnabled: enabled, onSoundToggle: toggle, playDoneSound: playDone, soundEnabledRef: enabledRef };
+  return { soundEnabled: enabled, onSoundToggle: toggle, playDoneSound: playDone, unlockAudio, soundEnabledRef: enabledRef };
 }

--- a/hooks/useAudio.ts
+++ b/hooks/useAudio.ts
@@ -12,6 +12,20 @@ export function useAudio() {
   const enabledRef = useRef(enabled);
   useEffect(() => { enabledRef.current = enabled; }, [enabled]);
 
+  // Reuse a single AudioContext so it can be resumed if the browser
+  // autoplay policy suspends it (contexts created outside user gestures
+  // start in "suspended" state and produce no sound).
+  const ctxRef = useRef<AudioContext | null>(null);
+  const getCtx = useCallback((): AudioContext | null => {
+    if (ctxRef.current) return ctxRef.current;
+    try {
+      ctxRef.current = new AudioContext();
+    } catch {
+      return null;
+    }
+    return ctxRef.current;
+  }, []);
+
   const toggle = useCallback(() => {
     setEnabled((prev) => {
       const next = !prev;
@@ -22,8 +36,13 @@ export function useAudio() {
 
   const playDone = useCallback(() => {
     if (!enabledRef.current) return;
+    const ctx = getCtx();
+    if (!ctx) return;
+    // Resume if suspended (browser autoplay policy)
+    if (ctx.state === "suspended") {
+      ctx.resume().catch(() => {});
+    }
     try {
-      const ctx = new AudioContext();
       const now = ctx.currentTime;
       const freqs = [523.25, 659.25];
       freqs.forEach((freq, i) => {
@@ -40,11 +59,10 @@ export function useAudio() {
         osc.start(t);
         osc.stop(t + 0.45);
       });
-      setTimeout(() => ctx.close(), 1200);
     } catch {
       // AudioContext not available
     }
-  }, []);
+  }, [getCtx]);
 
   return { soundEnabled: enabled, onSoundToggle: toggle, playDoneSound: playDone, soundEnabledRef: enabledRef };
 }


### PR DESCRIPTION
Fixes #111

Two fixes for the completion sound not playing:

**1. ChatWindow — handler overwrite issue**
The original code tried to wrap `handleAgentEventRef.current` in a `useEffect`, but `useAgentSession` overwrites that ref on every render, which would blow away the wrapper after the first re-render. Fixed by wrapping the `onAgentEnd` callback directly and passing it into `useAgentSession` instead.

**2. useAudio — AudioContext reuse**
Previously a new `AudioContext` was created on each playback (`new AudioContext()` inside `playDone`). Under browser autoplay policy, contexts created outside user gestures start in a "suspended" state and produce no sound. Fixed by reusing a single `AudioContext` instance and calling `resume()` if suspended.