### PR TITLE
fix: prevent stale app shell caching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from "react";
 import { AppShell } from "@/components/AppShell";
 
-export const dynamic = "force-dynamic";
-
 export default function Home() {
   return (
     <Suspense>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import { AppShell } from "@/components/AppShell";
 
+export const dynamic = "force-dynamic";
+
 export default function Home() {
   return (
     <Suspense>

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,16 @@ try {
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@earendil-works/pi-coding-agent", "@earendil-works/pi-ai"],
   allowedDevOrigins: ['192.168.*.*'],
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          { key: "Cache-Control", value: "private, no-cache, max-age=0, must-revalidate" },
+        ],
+      },
+    ];
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
     NEXT_PUBLIC_PI_VERSION: piVersion,


### PR DESCRIPTION
## Summary
- Keep the root app shell statically prerendered, but override the `/` HTML cache policy to require revalidation.
- Let browsers reuse the app-shell HTML only after validating it with the server-provided ETag, while hashed Next.js chunks remain long-cacheable.

## Why
The root page is an application shell whose HTML points at build-specific Next.js chunk URLs. Next.js was serving the prerendered `/` response with a long shared-cache lifetime, so an intermediate cache could keep old HTML after a package rebuild and make clients request chunks that no longer exist.

## Validation
- node_modules/.bin/tsc --noEmit
- npm run lint