### PR TITLE
fix: keep model resources in sync

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -15,6 +15,11 @@ function compareModelEntries(
     || modelNameCollator.compare(a.id, b.id);
 }
 
+function matchesEnabledModels(model: { id: string; provider: string }, enabledModels: string[] | undefined): boolean {
+  if (!enabledModels || enabledModels.length === 0) return true;
+  return enabledModels.includes(`${model.provider}/${model.id}`) || enabledModels.includes(model.id);
+}
+
 export async function GET(req: Request) {
   const nameMap = new Map<string, string>();
   let modelList: { id: string; name: string; provider: string }[] = [];
@@ -38,22 +43,25 @@ export async function GET(req: Request) {
     const services = await createAgentSessionServices({ cwd, agentDir });
     const registry = services.modelRegistry;
     const available = registry.getAvailable();
-    modelList = available.map((m: { id: string; name: string; provider: string }) => ({
+    const settings: SettingsManager = services.settingsManager;
+    const enabledModels = settings.getEnabledModels();
+    const visible = available.filter((m: { id: string; provider: string }) => matchesEnabledModels(m, enabledModels));
+    modelList = visible.map((m: { id: string; name: string; provider: string }) => ({
       id: m.id,
       name: m.name,
       provider: m.provider,
     })).sort(compareModelEntries);
-    for (const m of available) {
+    nameMap.clear();
+    for (const m of visible) {
       const key = `${m.provider}:${m.id}`;
       nameMap.set(key, m.name);
       thinkingLevels[key] = getSupportedThinkingLevels(m);
       if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
     }
 
-    const settings: SettingsManager = services.settingsManager;
     const provider = settings.getDefaultProvider();
     const modelId = settings.getDefaultModel();
-    if (provider && modelId && available.some((m) => m.provider === provider && m.id === modelId)) {
+    if (provider && modelId && visible.some((m) => m.provider === provider && m.id === modelId)) {
       defaultModel = { provider, modelId };
     }
   } catch { /* return empty */ }

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -105,6 +105,7 @@ type SlashCommandSource = SlashCommandPaletteItem["source"];
 
 const BUILTIN_SLASH_COMMANDS: SlashCommandPaletteItem[] = [
   { name: "compact", description: "Compress context, optionally with instructions", source: "builtin" },
+  { name: "reload", description: "Reload extensions, skills, prompts, and tools", source: "builtin" },
   { name: "name", description: "Set the session display name", source: "builtin" },
   { name: "session", description: "Show session message, token, and cost stats", source: "builtin" },
   { name: "copy", description: "Copy the last assistant message", source: "builtin" },

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1157,6 +1157,17 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           return complete({ handled: true, message: "Compacted context" });
         }
 
+        case "reload": {
+          if (!sid) return complete({ handled: true, error: "No active session to reload" });
+          await sendAgentCommand(sid, { type: "reload" });
+          await Promise.all([
+            loadSession(sid),
+            loadTools(sid),
+            loadSlashCommands(),
+          ]);
+          return complete({ handled: true, message: "Reloaded session resources" });
+        }
+
         case "name": {
           if (!sid) return complete({ handled: true, error: "No active session to name" });
           if (!args) return complete({ handled: true, error: "Usage: /name <name>" });
@@ -1192,7 +1203,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } finally {
       if (commandName === "compact") setIsCompacting(false);
     }
-  }, [addNotice, ensureNewSession, isCompacting, loadSession, promoteNewSession, onSessionStatsPanelOpen]);
+  }, [addNotice, ensureNewSession, isCompacting, loadSession, loadSlashCommands, loadTools, promoteNewSession, onSessionStatsPanelOpen]);
 
   // Queued (undelivered) messages live in the queue panel only; the chat gets
   // the real user message when pi delivers it (user message_end event). An

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("RPC session startup preloads extension-registered providers before restoring models", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const startupSource = source.slice(source.indexOf("export async function startRpcSession"));
+
+  assert.match(startupSource, /createAgentSessionServices\(/);
+  assert.match(startupSource, /createAgentSessionFromServices\(/);
+  assert.doesNotMatch(startupSource, /await createAgentSession\(/);
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,4 +1,4 @@
-import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, SessionManager } from "@earendil-works/pi-coding-agent";
 import { randomUUID } from "crypto";
 import { cacheSessionPath } from "./session-reader";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
@@ -911,7 +911,6 @@ export async function startRpcSession(
   if (inflight) return inflight;
 
   const starting = (async () => {
-    const { SessionManager, getAgentDir } = await import("@earendil-works/pi-coding-agent");
     const agentDir = getAgentDir();
 
     const sessionManager = sessionFile
@@ -919,7 +918,7 @@ export async function startRpcSession(
       : SessionManager.create(cwd, undefined);
 
     // Determine which tools to pass based on requested toolNames.
-    // Since v0.68.0, createAgentSession expects string[] tool names instead of Tool[] instances.
+    // Since v0.68.0, session creation expects string[] tool names instead of Tool[] instances.
     let toolsOption: string[] | undefined;
     if (toolNames !== undefined) {
       // toolNames === [] -> "all off" (an empty allow-list disables every tool).
@@ -932,9 +931,11 @@ export async function startRpcSession(
       toolsOption = toolNames.length === 0 ? [] : undefined;
     }
 
-    const { session: inner } = await createAgentSession({
-      cwd,
-      agentDir,
+    // Build services first so extension-registered providers are available
+    // before the SDK restores the saved model from the session file.
+    const services = await createAgentSessionServices({ cwd, agentDir });
+    const { session: inner } = await createAgentSessionFromServices({
+      services,
       sessionManager,
       ...(toolsOption !== undefined ? { tools: toolsOption } : {}),
     });


### PR DESCRIPTION
## Summary
- Respect configured enabledModels when listing and selecting models.
- Add a lightweight reload command so a running session can refresh model/resource state.
- Rebuild RPC session services before restoring the model, so extension-provided models are available during session startup.

## Why
Model resources can change while the web app is running. Without a reload path and correct startup order, the UI can show stale model choices or fail to restore sessions that depend on extension-provided providers.

## Validation
- node_modules/.bin/tsc --noEmit
- npm run lint
- node --test lib/rpc-manager.test.mjs