### PR TITLE
feat: show compaction history in chat

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -281,6 +281,70 @@ pre, code {
   margin: 4px 0;
 }
 
+.markdown-compaction-message {
+  line-height: 1.5;
+}
+.markdown-compaction-message p { margin: 0 0 7px; }
+.markdown-compaction-message h1,
+.markdown-compaction-message h2,
+.markdown-compaction-message h3,
+.markdown-compaction-message h4,
+.markdown-compaction-message h5,
+.markdown-compaction-message h6 {
+  margin: 8px 0 3px;
+  line-height: 1.25;
+}
+.markdown-compaction-message ul,
+.markdown-compaction-message ol {
+  margin: 4px 0 8px;
+}
+.markdown-compaction-message li { margin: 2px 0; }
+.markdown-compaction-message .markdown-table-wrap,
+.markdown-compaction-message .markdown-code-block {
+  margin: 6px 0;
+}
+
+.compaction-file-details {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.compaction-file-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.compaction-file-section {
+  margin-top: 8px;
+}
+.compaction-file-title {
+  margin-bottom: 4px;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 650;
+}
+.compaction-file-list {
+  max-height: 180px;
+  margin: 0;
+  padding: 7px 8px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  list-style: none;
+}
+.compaction-file-list li {
+  overflow-wrap: anywhere;
+}
+.compaction-file-list li + li {
+  margin-top: 3px;
+}
+
 .markdown-code-block {
   position: relative;
   margin: 6px 0;

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { MarkdownBody } from "./MarkdownBody";
+import { parseCompactionSummary } from "@/lib/compaction-summary";
 import type {
   AgentMessage,
   UserMessage,
@@ -74,6 +75,9 @@ export function MessageView({ message, isStreaming, toolResults, modelNames, ent
     return null;
   }
   if (message.role === "custom") {
+    if ((message as CustomMessage).customType === "compaction") {
+      return <CompactionMessageView message={message as CustomMessage} />;
+    }
     return <CustomMessageView message={message as CustomMessage} />;
   }
   return null;
@@ -1061,6 +1065,87 @@ function PairedResult({ text, isEmpty, isError }: {
       >
         {isEmpty ? "(no output)" : text}
       </pre>
+    </div>
+  );
+}
+
+function CompactionMessageView({ message }: { message: CustomMessage }) {
+  const summary = getMessageText(message.content);
+  const parsedSummary = useMemo(() => parseCompactionSummary(summary), [summary]);
+  const time = formatTime(message.timestamp);
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          overflow: "hidden",
+          background: "var(--bg)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "7px 10px",
+            borderBottom: "1px solid var(--border)",
+            background: "var(--bg-panel)",
+            color: "var(--text-muted)",
+          }}
+        >
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, fontWeight: 650 }}>
+            compaction
+          </span>
+          {time && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
+        </div>
+
+        <div style={{ padding: "11px 13px 12px" }}>
+          <div style={{ color: "var(--text)", fontSize: 15, fontWeight: 700, lineHeight: 1.35 }}>
+            Conversation compacted
+          </div>
+          <div style={{ marginTop: 3, marginBottom: 10, color: "var(--text)", fontSize: 14, lineHeight: 1.5 }}>
+            The conversation history before this point was compacted into the following summary:
+          </div>
+          {parsedSummary.body ? (
+            <MarkdownBody className="markdown-compaction-message">{parsedSummary.body}</MarkdownBody>
+          ) : (
+            <span style={{ color: "var(--text-dim)", fontSize: 12 }}>(no summary)</span>
+          )}
+          <CompactionFileMetadata readFiles={parsedSummary.readFiles} modifiedFiles={parsedSummary.modifiedFiles} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompactionFileMetadata({ readFiles, modifiedFiles }: { readFiles: string[]; modifiedFiles: string[] }) {
+  const total = readFiles.length + modifiedFiles.length;
+  if (total === 0) return null;
+
+  const parts = [];
+  if (readFiles.length > 0) parts.push(`${readFiles.length} read`);
+  if (modifiedFiles.length > 0) parts.push(`${modifiedFiles.length} modified`);
+
+  return (
+    <details className="compaction-file-details">
+      <summary>File context: {parts.join(", ")}</summary>
+      {modifiedFiles.length > 0 && <CompactionFileList title="Modified files" files={modifiedFiles} />}
+      {readFiles.length > 0 && <CompactionFileList title="Read files" files={readFiles} />}
+    </details>
+  );
+}
+
+function CompactionFileList({ title, files }: { title: string; files: string[] }) {
+  return (
+    <div className="compaction-file-section">
+      <div className="compaction-file-title">{title}</div>
+      <ul className="compaction-file-list">
+        {files.map((file) => (
+          <li key={file}>{file}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/lib/compaction-summary.test.mjs
+++ b/lib/compaction-summary.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCompactionSummary } from "./compaction-summary.ts";
+
+test("separates pi file metadata tags from the visible compaction summary", () => {
+  const parsed = parseCompactionSummary(`## Goal
+Keep the important user intent.
+
+<read-files>
+/tmp/a.ts
+/tmp/b.ts
+</read-files>
+
+<modified-files>
+/tmp/changed.ts
+</modified-files>`);
+
+  assert.equal(parsed.body, "## Goal\nKeep the important user intent.");
+  assert.deepEqual(parsed.readFiles, ["/tmp/a.ts", "/tmp/b.ts"]);
+  assert.deepEqual(parsed.modifiedFiles, ["/tmp/changed.ts"]);
+});
+
+test("leaves normal summaries unchanged", () => {
+  const summary = "## Goal\nNo file metadata here.";
+
+  assert.deepEqual(parseCompactionSummary(summary), {
+    body: summary,
+    readFiles: [],
+    modifiedFiles: [],
+  });
+});
+
+test("keeps file-like tags that are part of the summary body", () => {
+  const summary = `## Critical Context
+The user asked what this compact metadata means: <read-files>example</read-files>.
+
+More summary text after the mention.`;
+
+  assert.deepEqual(parseCompactionSummary(summary), {
+    body: summary,
+    readFiles: [],
+    modifiedFiles: [],
+  });
+});

--- a/lib/compaction-summary.ts
+++ b/lib/compaction-summary.ts
@@ -1,0 +1,34 @@
+export interface ParsedCompactionSummary {
+  body: string;
+  readFiles: string[];
+  modifiedFiles: string[];
+}
+
+const FILE_SECTION_RE = /<(read-files|modified-files)>\s*([\s\S]*?)\s*<\/\1>/g;
+const TRAILING_FILE_SECTIONS_RE = /(?:\r?\n){2,}((?:[ \t]*<(?:read-files|modified-files)>[ \t]*\r?\n[\s\S]*?\r?\n[ \t]*<\/(?:read-files|modified-files)>[ \t]*(?:\r?\n)?)+)\s*$/;
+
+export function parseCompactionSummary(summary: string): ParsedCompactionSummary {
+  const readFiles: string[] = [];
+  const modifiedFiles: string[] = [];
+  const metadataMatch = summary.match(TRAILING_FILE_SECTIONS_RE);
+  const metadataBlock = metadataMatch?.[1] ?? "";
+  const body = metadataMatch?.index === undefined ? summary : summary.slice(0, metadataMatch.index);
+
+  metadataBlock.replace(FILE_SECTION_RE, (_match, section: string, content: string) => {
+    const files = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    if (section === "read-files") readFiles.push(...files);
+    else modifiedFiles.push(...files);
+
+    return "";
+  });
+
+  return {
+    body: body.trim(),
+    readFiles,
+    modifiedFiles,
+  };
+}

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -1,5 +1,5 @@
 import { SessionManager, buildSessionContext as piBuildSessionContext, getAgentDir } from "@earendil-works/pi-coding-agent";
-import type { AgentMessage, SessionEntry, SessionInfo, SessionContext, AssistantMessage } from "./types";
+import type { AgentMessage, SessionEntry, SessionInfo, SessionContext } from "./types";
 import type { SessionEntry as PiSessionEntry, SessionInfo as PiSessionInfo } from "@earendil-works/pi-coding-agent";
 import { normalizeToolCalls } from "./normalize";
 import { resolveProject, type ProjectInfo } from "./worktree";
@@ -97,85 +97,66 @@ export function buildSessionContext(entries: SessionEntry[], leafId?: string | n
     cur = cur.parentId ? byId.get(cur.parentId) : undefined;
   }
 
-  // Find the last compaction on path (mirrors pi's buildSessionContext logic)
-  let compactionId: string | undefined;
-  let firstKeptEntryId: string | undefined;
+  // Build UI history from the FULL branch path (leaf to root), without trimming.
+  // pi's buildSessionContext targets LLM context: it drops everything before the last
+  // compaction's firstKeptEntryId. Correct for the model, but it would hide compacted
+  // history from the UI. We keep piCtx only for thinkingLevel/model, and render every
+  // displayable entry on the path ourselves; compaction/branch_summary entries become
+  // inline summary messages so the user still sees where context was compressed.
+  const messages: AgentMessage[] = [];
+  const entryIds: string[] = [];
   for (const e of path) {
-    if (e.type === "compaction") {
-      compactionId = e.id;
-      firstKeptEntryId = (e as { firstKeptEntryId: string }).firstKeptEntryId;
+    const m = entryToUiMessage(e);
+    if (m) {
+      messages.push(m);
+      entryIds.push(e.id);
     }
   }
-
-  const contextEntryIds: string[] = [];
-  if (compactionId) {
-    // The first message in piCtx.messages is the synthetic compaction summary — map to compaction entry id
-    contextEntryIds.push(compactionId);
-    const compactionIdx = path.findIndex((e) => e.id === compactionId);
-    const firstKeptIdx = firstKeptEntryId
-      ? path.findIndex((e, i) => i < compactionIdx && e.id === firstKeptEntryId)
-      : -1;
-    const startIdx = firstKeptIdx >= 0 ? firstKeptIdx : compactionIdx;
-    for (let i = startIdx; i < compactionIdx; i++) {
-      if (isContextMessageEntry(path[i])) contextEntryIds.push(path[i].id);
-    }
-    for (let i = compactionIdx + 1; i < path.length; i++) {
-      if (isContextMessageEntry(path[i])) contextEntryIds.push(path[i].id);
-    }
-  } else {
-    for (const e of path) {
-      if (isContextMessageEntry(e)) contextEntryIds.push(e.id);
-    }
-  }
-
-  // pi injects compaction summary as {role:"compactionSummary", summary, tokensBefore}.
-  // Convert to {role:"user"} so MessageView can render it the same as before.
-  const contextMessages = (piCtx.messages as AssistantMessage[]).map((msg) => {
-    const raw = msg as unknown as Record<string, unknown>;
-    if (raw.role === "compactionSummary") {
-      return {
-        role: "user" as const,
-        content: `*The conversation history before this point was compacted into the following summary:*\n\n${raw.summary ?? ""}`,
-        timestamp: raw.timestamp as number | undefined,
-      };
-    }
-    if (raw.role === "branchSummary") {
-      return {
-        role: "user" as const,
-        content: `*The conversation briefly explored another branch and returned with this summary:*\n\n${raw.summary ?? ""}`,
-        timestamp: raw.timestamp as number | undefined,
-      };
-    }
-    return normalizeToolCalls(msg);
-  });
-
-  const display = filterDisplayMessages(contextMessages, contextEntryIds);
 
   return {
-    messages: display.messages,
-    entryIds: display.entryIds,
+    messages,
+    entryIds,
     thinkingLevel: piCtx.thinkingLevel,
     model: piCtx.model,
   };
 }
 
-function isContextMessageEntry(entry: SessionEntry): boolean {
-  return entry.type === "message" || entry.type === "custom_message" || (entry.type === "branch_summary" && !!entry.summary);
-}
-
-function filterDisplayMessages(messages: AgentMessage[], entryIds: string[]): Pick<SessionContext, "messages" | "entryIds"> {
-  const displayMessages: AgentMessage[] = [];
-  const displayEntryIds: string[] = [];
-
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-
-    displayMessages.push(msg);
-    displayEntryIds.push(entryIds[i] ?? "");
+// Convert a session entry on the active branch into a UI message.
+// Returns null for non-displayable entries (metadata, non-message types).
+function entryToUiMessage(entry: SessionEntry): AgentMessage | null {
+  switch (entry.type) {
+    case "message":
+      return normalizeToolCalls(entry.message);
+    case "compaction":
+      return {
+        role: "custom",
+        customType: "compaction",
+        content: entry.summary,
+        display: true,
+        details: {
+          tokensBefore: entry.tokensBefore,
+          firstKeptEntryId: entry.firstKeptEntryId,
+        },
+        timestamp: Date.parse(entry.timestamp) || undefined,
+      };
+    case "branch_summary":
+      if (!entry.summary) return null;
+      return {
+        role: "user",
+        content: `*The conversation briefly explored another branch and returned with this summary:*\n\n${entry.summary}`,
+        timestamp: Date.parse(entry.timestamp) || undefined,
+      };
+    case "custom_message":
+      if (!entry.display) return null;
+      return {
+        role: "custom",
+        customType: entry.customType,
+        content: entry.content,
+        display: entry.display,
+        details: entry.details,
+        timestamp: Date.parse(entry.timestamp) || undefined,
+      };
+    default:
+      return null;
   }
-
-  return {
-    messages: displayMessages,
-    entryIds: displayEntryIds,
-  };
 }


### PR DESCRIPTION
## Summary
- Preserve compaction entries while reading session history and render them as chat-visible custom messages.
- Parse compaction summaries for read/modified file metadata.
- Keep the model-facing context behavior unchanged while making the user's visible history easier to understand.

## Why
After compaction, the UI previously lost useful context about what was summarized. Showing compacted history helps users understand why later assistant messages have less visible prior context.

## Validation
- node --test lib/compaction-summary.test.mjs
- node_modules/.bin/tsc --noEmit
- npm run lint