### PR TITLE
feat: open local file links from chat

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -21,6 +21,10 @@ const TEXT_PREVIEW_MAX_BYTES = 256 * 1024;
 const IMAGE_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
 const DOCX_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
 
+const FILE_REQUEST_TYPES = ["list", "read", "download", "meta", "preview", "watch"] as const;
+type FileRequestType = typeof FILE_REQUEST_TYPES[number];
+const FILE_REQUEST_TYPE_SET = new Set<string>(FILE_REQUEST_TYPES);
+
 const IMAGE_EXT_TO_MIME: Record<string, string> = {
   png: "image/png",
   jpg: "image/jpeg",
@@ -98,6 +102,10 @@ function filePathFromSegments(segments: string[]): string {
   const slashJoined = normalizeSlashes(joined);
   if (isWindowsAbsolutePath(slashJoined)) return slashJoined;
   return "/" + joined.replace(/^\/+/, "");
+}
+
+function parseFileRequestType(value: string): FileRequestType | null {
+  return FILE_REQUEST_TYPE_SET.has(value) ? (value as FileRequestType) : null;
 }
 
 function createFileBodyStream(filePath: string, range?: { start: number; end: number }): ReadableStream<Uint8Array> {
@@ -284,7 +292,11 @@ export async function GET(
   try {
     const { path: segments } = await params;
     const filePath = filePathFromSegments(segments);
-    const type = request.nextUrl.searchParams.get("type") ?? "list";
+    const rawType = request.nextUrl.searchParams.get("type") ?? "list";
+    const type = parseFileRequestType(rawType);
+    if (!type) {
+      return NextResponse.json({ error: "Invalid file request type" }, { status: 400 });
+    }
     const sessionId = request.nextUrl.searchParams.get("sessionId");
 
     const allowedRoots = await getAllowedFileRoots();

--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -7,6 +7,7 @@ import {
   isWindowsAbsolutePath,
   normalizeSlashes,
 } from "@/lib/file-access";
+import { isFilePathReferencedBySession } from "@/lib/session-file-references";
 
 const IGNORED_NAMES = new Set([
   "node_modules", ".git", ".next", "dist", "build", "__pycache__",
@@ -284,9 +285,15 @@ export async function GET(
     const { path: segments } = await params;
     const filePath = filePathFromSegments(segments);
     const type = request.nextUrl.searchParams.get("type") ?? "list";
+    const sessionId = request.nextUrl.searchParams.get("sessionId");
 
     const allowedRoots = await getAllowedFileRoots();
-    if (!isFilePathAllowed(filePath, allowedRoots)) {
+    const allowedByRoot = isFilePathAllowed(filePath, allowedRoots);
+    const allowedBySessionReference =
+      !allowedByRoot &&
+      type !== "list" &&
+      await isFilePathReferencedBySession(filePath, sessionId);
+    if (!allowedByRoot && !allowedBySessionReference) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { PluginsConfig } from "./PluginsConfig";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { getFileName } from "@/lib/file-paths";
 import { buildAtMentionText } from "@/lib/file-fuzzy";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ChatInputHandle } from "./ChatInput";
@@ -286,17 +287,23 @@ export function AppShell() {
     }
   }, [selectedSession, router]);
 
-  const handleOpenFile = useCallback((filePath: string, fileName: string) => {
+  const handleOpenFile = useCallback((filePath: string, fileName: string, sourceSessionId?: string | null) => {
     const tabId = `file:${filePath}`;
     setFileTabs((prev) => {
-      if (prev.find((t) => t.id === tabId)) return prev;
-      return [...prev, { id: tabId, label: fileName, filePath }];
+      const existing = prev.find((t) => t.id === tabId);
+      if (!existing) return [...prev, { id: tabId, label: fileName, filePath, sourceSessionId }];
+      if (!sourceSessionId || existing.sourceSessionId === sourceSessionId) return prev;
+      return prev.map((t) => t.id === tabId ? { ...t, sourceSessionId } : t);
     });
     setActiveFileTabId(tabId);
     setRightPanelOpen(true);
     // On mobile the file panel is full-screen; close the drawer so it shows.
     if (isMobile) setSidebarOpen(false);
   }, [isMobile]);
+
+  const handleOpenLinkedFile = useCallback((filePath: string) => {
+    handleOpenFile(filePath, getFileName(filePath), selectedSession?.id ?? null);
+  }, [handleOpenFile, selectedSession?.id]);
 
   const handleCloseFileTab = useCallback((tabId: string) => {
     setFileTabs((prev) => {
@@ -977,6 +984,7 @@ export function AppShell() {
               onSessionStatsChange={handleSessionStatsChange}
               onSessionStatsPanelOpen={openSessionStatsPanel}
               onContextUsageChange={handleContextUsageChange}
+              onOpenFile={handleOpenLinkedFile}
             />
           ) : showPlaceholder ? (
             activeCwd ? (
@@ -1027,7 +1035,11 @@ export function AppShell() {
         {/* File content */}
         <div style={{ flex: 1, overflow: "hidden" }}>
           {activeFileTab?.filePath ? (
-            <FileViewer filePath={activeFileTab.filePath} cwd={activeCwd ?? undefined} />
+            <FileViewer
+              filePath={activeFileTab.filePath}
+              cwd={activeCwd ?? undefined}
+              sourceSessionId={activeFileTab.sourceSessionId}
+            />
           ) : (
             <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-dim)", fontSize: 12 }}>
               No file open

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -24,6 +24,7 @@ interface Props {
   onSessionStatsChange?: (stats: SessionStatsInfo | null) => void;
   onSessionStatsPanelOpen?: () => void;
   onContextUsageChange?: (usage: { percent: number | null; contextWindow: number; tokens: number | null } | null) => void;
+  onOpenFile?: (filePath: string) => void;
 }
 
 function phaseLabel(phase: AgentPhase): string {
@@ -43,7 +44,7 @@ const CHAT_MINIMAP_WIDTH = 36;
 const CHAT_COLUMN_PADDING = 16;
 const CHAT_INPUT_RIGHT_PADDING = CHAT_COLUMN_PADDING + CHAT_MINIMAP_WIDTH;
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
   const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
   const isMobile = useIsMobile();
 
@@ -133,6 +134,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   const messageRefs = useMessageRefs(visibleMessages.length);
 
   const isEmptyNew = isNew && messages.length === 0 && !streamState.isStreaming && !agentRunning;
+  const messageCwd = session?.cwd ?? newSessionCwd ?? undefined;
 
   const availableThinkingLevels = displayModelValue
     ? (modelThinkingLevels[`${displayModelValue.provider}:${displayModelValue.modelId}`] ?? null)
@@ -349,6 +351,8 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     message={msg}
                     toolResults={toolResultsMap}
                     modelNames={modelNames}
+                    cwd={messageCwd}
+                    onOpenFile={onOpenFile}
                     entryId={entryIds[idx]}
                     onFork={agentRunning || isNew || (idx === 0 && msg.role === "user") ? undefined : handleFork}
                     forking={forkingEntryId === entryIds[idx]}
@@ -372,7 +376,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
             })()}
 
             {streamState.isStreaming && streamState.streamingMessage && (
-              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
+              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} cwd={messageCwd} onOpenFile={onOpenFile} />
             )}
 
             {agentRunning && !streamState.streamingMessage && (

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -12,6 +12,7 @@ import { markdownPreviewRehypePlugins, markdownPreviewRemarkPlugins } from "@/li
 interface Props {
   filePath: string;
   cwd?: string;
+  sourceSessionId?: string | null;
 }
 
 interface FileData {
@@ -45,11 +46,25 @@ function isDocumentPreviewPath(filePath: string): boolean {
   return DOCUMENT_PREVIEW_EXTS.has(getFileExt(filePath));
 }
 
-function DownloadLink({ filePath }: { filePath: string }) {
+function getFileApiUrl(
+  filePath: string,
+  type: "read" | "download" | "meta" | "preview" | "watch",
+  sourceSessionId?: string | null,
+  params: Record<string, string | number | undefined> = {},
+): string {
   const encoded = encodeFilePathForApi(filePath);
+  const searchParams = new URLSearchParams({ type });
+  if (sourceSessionId) searchParams.set("sessionId", sourceSessionId);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) searchParams.set(key, String(value));
+  }
+  return `/api/files/${encoded}?${searchParams.toString()}`;
+}
+
+function DownloadLink({ filePath, sourceSessionId }: { filePath: string; sourceSessionId?: string | null }) {
   return (
     <a
-      href={`/api/files/${encoded}?type=download`}
+      href={getFileApiUrl(filePath, "download", sourceSessionId)}
       download={getFileName(filePath)}
       title="Download file"
       style={{
@@ -311,7 +326,7 @@ function DiffView({ oldContent, newContent }: { oldContent: string; newContent: 
   );
 }
 
-function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
+function ImageViewer({ filePath, cwd, sourceSessionId }: Props) {
   const [watching, setWatching] = useState(false);
   const [bust, setBust] = useState(0);
   const [size, setSize] = useState<number | null>(null);
@@ -333,8 +348,7 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       esRef.current = null;
     }
 
-    const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(getFileApiUrl(filePath, "watch", sourceSessionId));
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -352,10 +366,9 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       es.close();
       esRef.current = null;
     };
-  }, [filePath]);
+  }, [filePath, sourceSessionId]);
 
-  const encoded = encodeFilePathForApi(filePath);
-  const src = `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
+  const src = getFileApiUrl(filePath, "read", sourceSessionId, bust ? { v: bust } : undefined);
 
   const formatSizeStr = size != null ? formatSize(size) : null;
 
@@ -396,7 +409,7 @@ function ImageViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
           />
           {watching ? "live" : "static"}
         </span>
-        <DownloadLink filePath={filePath} />
+        <DownloadLink filePath={filePath} sourceSessionId={sourceSessionId} />
       </div>
       <div
         style={{
@@ -446,7 +459,7 @@ function formatDuration(seconds: number): string {
   return `${mins}:${String(secs).padStart(2, "0")}`;
 }
 
-function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
+function AudioViewer({ filePath, cwd, sourceSessionId }: Props) {
   const [watching, setWatching] = useState(false);
   const [bust, setBust] = useState(0);
   const [size, setSize] = useState<number | null>(null);
@@ -468,8 +481,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       esRef.current = null;
     }
 
-    const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(getFileApiUrl(filePath, "watch", sourceSessionId));
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -489,10 +501,9 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       es.close();
       esRef.current = null;
     };
-  }, [filePath]);
+  }, [filePath, sourceSessionId]);
 
-  const encoded = encodeFilePathForApi(filePath);
-  const src = `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`;
+  const src = getFileApiUrl(filePath, "read", sourceSessionId, bust ? { v: bust } : undefined);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
@@ -531,7 +542,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
           />
           {watching ? "live" : "static"}
         </span>
-        <DownloadLink filePath={filePath} />
+        <DownloadLink filePath={filePath} sourceSessionId={sourceSessionId} />
       </div>
       <div
         style={{
@@ -564,7 +575,7 @@ function AudioViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   );
 }
 
-function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
+function DocumentViewer({ filePath, cwd, sourceSessionId }: Props) {
   const [watching, setWatching] = useState(false);
   const [bust, setBust] = useState(0);
   const [size, setSize] = useState<number | null>(null);
@@ -572,11 +583,10 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   const esRef = useRef<EventSource | null>(null);
 
   const ext = getFileExt(filePath);
-  const encoded = encodeFilePathForApi(filePath);
   const isPdf = ext === "pdf";
   const previewUrl = isPdf
-    ? `/api/files/${encoded}?type=read${bust ? `&v=${bust}` : ""}`
-    : `/api/files/${encoded}?type=preview${bust ? `&v=${bust}` : ""}`;
+    ? getFileApiUrl(filePath, "read", sourceSessionId, bust ? { v: bust } : undefined)
+    : getFileApiUrl(filePath, "preview", sourceSessionId, bust ? { v: bust } : undefined);
 
   useEffect(() => {
     setBust(0);
@@ -589,7 +599,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       esRef.current = null;
     }
 
-    fetch(`/api/files/${encoded}?type=meta`)
+    fetch(getFileApiUrl(filePath, "meta", sourceSessionId))
       .then((r) => r.json())
       .then((d: { size?: number; error?: string }) => {
         if (d.error) setError(d.error);
@@ -602,7 +612,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       })
       .catch((e) => setError(String(e)));
 
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(getFileApiUrl(filePath, "watch", sourceSessionId));
     esRef.current = es;
 
     es.addEventListener("connected", () => setWatching(true));
@@ -627,7 +637,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
       es.close();
       esRef.current = null;
     };
-  }, [encoded, isPdf]);
+  }, [filePath, isPdf, sourceSessionId]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
@@ -649,6 +659,7 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
         </span>
         <span style={{ marginLeft: "auto" }}>{ext === "docx" ? "docx preview" : "pdf"}</span>
         {size != null && <span>{formatSize(size)}</span>}
+        <DownloadLink filePath={filePath} sourceSessionId={sourceSessionId} />
         <span
           title={watching ? "Live sync active" : "Not watching"}
           style={{ display: "flex", alignItems: "center", gap: 4, color: watching ? "#4ade80" : "var(--text-dim)", flexShrink: 0 }}
@@ -665,7 +676,6 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
           />
           {watching ? "live" : "static"}
         </span>
-        <DownloadLink filePath={filePath} />
       </div>
       <div style={{ flex: 1, minHeight: 0, background: "var(--bg-panel)" }}>
         {error ? (
@@ -686,20 +696,20 @@ function DocumentViewer({ filePath, cwd }: { filePath: string; cwd?: string }) {
   );
 }
 
-export function FileViewer({ filePath, cwd }: Props) {
+export function FileViewer({ filePath, cwd, sourceSessionId }: Props) {
   if (isImagePath(filePath)) {
-    return <ImageViewer filePath={filePath} cwd={cwd} />;
+    return <ImageViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
   if (isAudioPath(filePath)) {
-    return <AudioViewer filePath={filePath} cwd={cwd} />;
+    return <AudioViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
   if (isDocumentPreviewPath(filePath)) {
-    return <DocumentViewer filePath={filePath} cwd={cwd} />;
+    return <DocumentViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
 }
 
-function TextFileViewer({ filePath, cwd }: Props) {
+function TextFileViewer({ filePath, cwd, sourceSessionId }: Props) {
   const { isDark } = useTheme();
   const [data, setData] = useState<FileData | null>(null);
   const [prevContent, setPrevContent] = useState<string | null>(null);
@@ -713,8 +723,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
   const esRef = useRef<EventSource | null>(null);
 
   const fetchContent = useCallback((filePath: string, isRefresh = false) => {
-    const encoded = encodeFilePathForApi(filePath);
-    return fetch(`/api/files/${encoded}?type=read`)
+    return fetch(getFileApiUrl(filePath, "read", sourceSessionId))
       .then((r) => r.json())
       .then((d: FileData & { error?: string }) => {
         if (d.error) {
@@ -736,7 +745,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
         setError(String(e));
         return null;
       });
-  }, []);
+  }, [sourceSessionId]);
 
   // Initial load + SSE watch setup
   useEffect(() => {
@@ -760,8 +769,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
     }).finally(() => setLoading(false));
 
     // Set up SSE watch
-    const encoded = encodeFilePathForApi(filePath);
-    const es = new EventSource(`/api/files/${encoded}?type=watch`);
+    const es = new EventSource(getFileApiUrl(filePath, "watch", sourceSessionId));
     esRef.current = es;
 
     es.addEventListener("connected", () => {
@@ -784,7 +792,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
       es.close();
       esRef.current = null;
     };
-  }, [filePath, fetchContent]);
+  }, [filePath, fetchContent, sourceSessionId]);
 
   if (loading) {
     return (
@@ -950,7 +958,7 @@ function TextFileViewer({ filePath, cwd }: Props) {
             </button>
           </div>
         )}
-        <DownloadLink filePath={filePath} />
+        <DownloadLink filePath={filePath} sourceSessionId={sourceSessionId} />
       </div>
 
       {/* Content area */}

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -80,6 +80,9 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
 
             const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
               if (event.defaultPrevented || event.button !== 0) return;
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+              const target = event.currentTarget.getAttribute("target");
+              if (target && target !== "_self") return;
               event.preventDefault();
               openFile(filePath);
             };

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type MouseEvent, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { useTheme } from "@/hooks/useTheme";
+import { resolveLocalFileHref } from "@/lib/file-links";
 import { markdownRehypePlugins, markdownRemarkPlugins } from "@/lib/markdown";
 
 interface MarkdownBodyProps {
   children: string;
   className?: string;
   isStreaming?: boolean;
+  cwd?: string;
+  onOpenFile?: (filePath: string) => void;
 }
 
 function copyText(text: string): Promise<void> {
@@ -33,7 +36,7 @@ function copyText(text: string): Promise<void> {
   }
 }
 
-export function MarkdownBody({ children, className, isStreaming }: MarkdownBodyProps) {
+export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile }: MarkdownBodyProps) {
   const normalizedMarkdown = useMemo(() => normalizeDisplayMath(children), [children]);
 
   return (
@@ -63,6 +66,29 @@ export function MarkdownBody({ children, className, isStreaming }: MarkdownBodyP
           },
           pre({ children }) {
             return <>{children}</>;
+          },
+          a({ href, children, ...props }) {
+            const filePath = onOpenFile ? resolveLocalFileHref(href, cwd) : null;
+            const openFile = onOpenFile;
+            if (!filePath || !openFile) {
+              return (
+                <a href={href} {...props}>
+                  {children}
+                </a>
+              );
+            }
+
+            const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+              if (event.defaultPrevented || event.button !== 0) return;
+              event.preventDefault();
+              openFile(filePath);
+            };
+
+            return (
+              <a href={href} {...props} onClick={handleClick}>
+                {children}
+              </a>
+            );
           },
           table({ children }) {
             return (

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -20,6 +20,8 @@ interface Props {
   isStreaming?: boolean;
   toolResults?: Map<string, ToolResultMessage>;
   modelNames?: Record<string, string>;
+  cwd?: string;
+  onOpenFile?: (filePath: string) => void;
   entryId?: string;
   onFork?: (entryId: string) => void;
   forking?: boolean;
@@ -62,25 +64,27 @@ function copyText(text: string): Promise<void> {
   }
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+export function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
   if (message.role === "user") {
-    return <UserMessageView message={message as UserMessage} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
+    return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} />;
+    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
     return null;
   }
   if (message.role === "custom") {
-    return <CustomMessageView message={message as CustomMessage} />;
+    return <CustomMessageView message={message as CustomMessage} cwd={cwd} onOpenFile={onOpenFile} />;
   }
   return null;
 }
 
-function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {
+function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {
   message: UserMessage;
+  cwd?: string;
+  onOpenFile?: (filePath: string) => void;
   entryId?: string;
   onFork?: (entryId: string) => void;
   forking?: boolean;
@@ -161,7 +165,7 @@ function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAs
               })}
             </div>
           )}
-          {content && <MarkdownBody className="markdown-user-message">{content}</MarkdownBody>}
+          {content && <MarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</MarkdownBody>}
         </div>
 
       </div>
@@ -282,6 +286,8 @@ function AssistantMessageView({
   isStreaming,
   toolResults,
   modelNames,
+  cwd,
+  onOpenFile,
   showTimestamp,
   prevTimestamp,
 }: {
@@ -289,6 +295,8 @@ function AssistantMessageView({
   isStreaming?: boolean;
   toolResults?: Map<string, ToolResultMessage>;
   modelNames?: Record<string, string>;
+  cwd?: string;
+  onOpenFile?: (filePath: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
 }) {
@@ -450,7 +458,7 @@ function AssistantMessageView({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {blocks.map((block, i) => (
-          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} />
+          <BlockView key={i} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(i) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} />
         ))}
       </div>
 
@@ -503,9 +511,9 @@ function AssistantMessageView({
   );
 }
 
-function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number> }) {
+function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, cwd, onOpenFile }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; cwd?: string; onOpenFile?: (filePath: string) => void }) {
   if (block.type === "text") {
-    return <TextBlock block={block as TextContent} isStreaming={isStreaming} />;
+    return <TextBlock block={block as TextContent} isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile} />;
   }
   if (block.type === "thinking") {
     return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} />;
@@ -519,8 +527,8 @@ function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCal
   return null;
 }
 
-function TextBlock({ block, isStreaming }: { block: TextContent; isStreaming?: boolean }) {
-  return <MarkdownBody isStreaming={isStreaming}>{block.text}</MarkdownBody>;
+function TextBlock({ block, isStreaming, cwd, onOpenFile }: { block: TextContent; isStreaming?: boolean; cwd?: string; onOpenFile?: (filePath: string) => void }) {
+  return <MarkdownBody isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile}>{block.text}</MarkdownBody>;
 }
 
 function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?: number }) {
@@ -1065,7 +1073,7 @@ function PairedResult({ text, isEmpty, isError }: {
   );
 }
 
-function CustomMessageView({ message }: { message: CustomMessage }) {
+function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessage; cwd?: string; onOpenFile?: (filePath: string) => void }) {
   const isHiddenDisplay = message.display === false;
   const [contentExpanded, setContentExpanded] = useState(!isHiddenDisplay);
   const [detailsExpanded, setDetailsExpanded] = useState(false);
@@ -1133,7 +1141,7 @@ function CustomMessageView({ message }: { message: CustomMessage }) {
                 })}
               </div>
             )}
-            {text ? <MarkdownBody className="markdown-custom-message">{text}</MarkdownBody> : <span style={{ color: "var(--text-dim)", fontSize: 12 }}>(no message)</span>}
+            {text ? <MarkdownBody className="markdown-custom-message" cwd={cwd} onOpenFile={onOpenFile}>{text}</MarkdownBody> : <span style={{ color: "var(--text-dim)", fontSize: 12 }}>(no message)</span>}
           </div>
         ) : (
           <button

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -7,6 +7,7 @@ export interface Tab {
   id: string;
   label: string;
   filePath: string;
+  sourceSessionId?: string | null;
 }
 
 interface Props {

--- a/lib/file-links.test.mjs
+++ b/lib/file-links.test.mjs
@@ -52,4 +52,28 @@ test("does not treat app or external URLs as file links", async () => {
 
   assert.equal(resolveLocalFileHref("/api/files/home/me/project/a.ts", "/home/me/project"), null);
   assert.equal(resolveLocalFileHref("https://example.com/a.ts", "/home/me/project"), null);
+  assert.equal(resolveLocalFileHref("ftp://example.com/a.ts", "/home/me/project"), null);
+  assert.equal(resolveLocalFileHref("//example.com/a.ts", "/home/me/project"), null);
+});
+
+test("resolves Windows file URLs without a synthetic leading slash", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref("file:///C:/Users/me/project/file.txt:10", "C:/Users/me/project"),
+    "C:/Users/me/project/file.txt",
+  );
+});
+
+test("resolves UNC file URLs and backslash UNC paths", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref("file://server/share/project/file.txt", "/home/me/project"),
+    "//server/share/project/file.txt",
+  );
+  assert.equal(
+    resolveLocalFileHref("\\\\server\\share\\project\\file.txt", "/home/me/project"),
+    "//server/share/project/file.txt",
+  );
 });

--- a/lib/file-links.test.mjs
+++ b/lib/file-links.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./file-links.ts");
+}
+
+test("resolves absolute markdown file links and strips line suffixes", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref(
+      "/home/me/project/components/MarkdownBody.tsx:36",
+      "/home/me/project",
+    ),
+    "/home/me/project/components/MarkdownBody.tsx",
+  );
+});
+
+test("resolves absolute file links outside cwd", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref(
+      "/home/me/.codex/config.toml:12",
+      "/home/me/project",
+    ),
+    "/home/me/.codex/config.toml",
+  );
+});
+
+test("resolves relative markdown file links against cwd", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref("components/AppShell.tsx#L42", "/home/me/project"),
+    "/home/me/project/components/AppShell.tsx",
+  );
+});
+
+test("does not let relative links escape cwd", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(
+    resolveLocalFileHref("../outside.md", "/home/me/project"),
+    null,
+  );
+});
+
+test("does not treat app or external URLs as file links", async () => {
+  const { resolveLocalFileHref } = await loadSubject();
+
+  assert.equal(resolveLocalFileHref("/api/files/home/me/project/a.ts", "/home/me/project"), null);
+  assert.equal(resolveLocalFileHref("https://example.com/a.ts", "/home/me/project"), null);
+});

--- a/lib/file-links.ts
+++ b/lib/file-links.ts
@@ -20,7 +20,8 @@ function stripLineSuffix(filePath: string): string {
 function normalizeLocalPath(filePath: string): string {
   const normalized = normalizeFilePathSlashes(filePath);
   const isWindowsDrive = /^[a-zA-Z]:\//.test(normalized);
-  const leadingSlash = normalized.startsWith("/") && !isWindowsDrive;
+  const isUnc = normalized.startsWith("//");
+  const leadingSlash = normalized.startsWith("/") && !isWindowsDrive && !isUnc;
   const parts: string[] = [];
 
   for (const part of normalized.split("/")) {
@@ -28,7 +29,7 @@ function normalizeLocalPath(filePath: string): string {
     if (part === "..") {
       if (parts.length > 0 && parts[parts.length - 1] !== "..") {
         parts.pop();
-      } else if (!leadingSlash && !isWindowsDrive) {
+      } else if (!leadingSlash && !isWindowsDrive && !isUnc) {
         parts.push(part);
       }
       continue;
@@ -38,6 +39,7 @@ function normalizeLocalPath(filePath: string): string {
 
   const joined = parts.join("/");
   if (isWindowsDrive) return joined;
+  if (isUnc) return `//${joined}`;
   return leadingSlash ? `/${joined}` : joined;
 }
 
@@ -61,7 +63,12 @@ function fileUrlToPath(href: string): string | null {
   try {
     const url = new URL(href);
     if (url.protocol !== "file:") return null;
-    return safeDecode(url.pathname);
+    const pathname = safeDecode(url.pathname);
+    if (url.hostname) {
+      return `//${url.hostname}${pathname.startsWith("/") ? pathname : `/${pathname}`}`;
+    }
+    if (/^\/[a-zA-Z]:\//.test(pathname)) return pathname.slice(1);
+    return pathname;
   } catch {
     return null;
   }
@@ -76,11 +83,15 @@ export function resolveLocalFileHref(href: string | undefined, cwd?: string): st
   let candidate: string | null = null;
   let candidateKind: "absolute" | "relative" | null = null;
   const decodedHref = safeDecode(cleanHref);
+  const isBackslashUncPath = decodedHref.startsWith("\\\\");
   const normalizedHref = normalizeFilePathSlashes(decodedHref);
   const lowerHref = normalizedHref.toLowerCase();
 
   if (lowerHref.startsWith("/api/") || lowerHref.startsWith("/_next/")) return null;
-  if (/^(https?|mailto|tel|data|blob|about):/i.test(normalizedHref)) return null;
+  if (!isBackslashUncPath && normalizedHref.startsWith("//")) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/i.test(normalizedHref) && !lowerHref.startsWith("file:") && !/^[a-zA-Z]:\//.test(normalizedHref)) {
+    return null;
+  }
 
   if (lowerHref.startsWith("file:")) {
     candidate = fileUrlToPath(normalizedHref);

--- a/lib/file-links.ts
+++ b/lib/file-links.ts
@@ -1,0 +1,104 @@
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeFilePathSlashes(filePath: string): string {
+  if (/^[a-zA-Z]:[\\/]/.test(filePath) || filePath.startsWith("\\\\")) {
+    return filePath.replace(/\\/g, "/");
+  }
+  return filePath;
+}
+
+function stripLineSuffix(filePath: string): string {
+  return filePath.replace(/:\d+(?::\d+)?$/, "");
+}
+
+function normalizeLocalPath(filePath: string): string {
+  const normalized = normalizeFilePathSlashes(filePath);
+  const isWindowsDrive = /^[a-zA-Z]:\//.test(normalized);
+  const leadingSlash = normalized.startsWith("/") && !isWindowsDrive;
+  const parts: string[] = [];
+
+  for (const part of normalized.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!leadingSlash && !isWindowsDrive) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+
+  const joined = parts.join("/");
+  if (isWindowsDrive) return joined;
+  return leadingSlash ? `/${joined}` : joined;
+}
+
+function isPathInside(candidate: string, root: string): boolean {
+  const normalizedCandidate = normalizeLocalPath(candidate).replace(/\/+$/, "");
+  const normalizedRoot = normalizeLocalPath(root).replace(/\/+$/, "");
+  const useCaseInsensitive = /^[a-zA-Z]:\//.test(normalizedCandidate) || /^[a-zA-Z]:\//.test(normalizedRoot);
+  const filePath = useCaseInsensitive ? normalizedCandidate.toLowerCase() : normalizedCandidate;
+  const rootPath = useCaseInsensitive ? normalizedRoot.toLowerCase() : normalizedRoot;
+  return filePath === rootPath || filePath.startsWith(`${rootPath}/`);
+}
+
+function looksLikeRelativeFileHref(href: string): boolean {
+  if (href.startsWith("#") || href.startsWith("?")) return false;
+  if (href.startsWith("./") || href.startsWith("../")) return true;
+  if (href.includes("/")) return true;
+  return /(^|\/)\.?[^/]+\.[^/.]+$/.test(href);
+}
+
+function fileUrlToPath(href: string): string | null {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "file:") return null;
+    return safeDecode(url.pathname);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveLocalFileHref(href: string | undefined, cwd?: string): string | null {
+  if (!href) return null;
+
+  const cleanHref = href.split("#", 1)[0].split("?", 1)[0].trim();
+  if (!cleanHref) return null;
+
+  let candidate: string | null = null;
+  let candidateKind: "absolute" | "relative" | null = null;
+  const decodedHref = safeDecode(cleanHref);
+  const normalizedHref = normalizeFilePathSlashes(decodedHref);
+  const lowerHref = normalizedHref.toLowerCase();
+
+  if (lowerHref.startsWith("/api/") || lowerHref.startsWith("/_next/")) return null;
+  if (/^(https?|mailto|tel|data|blob|about):/i.test(normalizedHref)) return null;
+
+  if (lowerHref.startsWith("file:")) {
+    candidate = fileUrlToPath(normalizedHref);
+    candidateKind = candidate ? "absolute" : null;
+  } else if (/^[a-zA-Z]:\//.test(normalizedHref)) {
+    candidate = normalizedHref;
+    candidateKind = "absolute";
+  } else if (normalizedHref.startsWith("/")) {
+    candidate = normalizedHref;
+    candidateKind = "absolute";
+  } else if (cwd && looksLikeRelativeFileHref(normalizedHref)) {
+    candidate = `${normalizeFilePathSlashes(cwd).replace(/\/+$/, "")}/${normalizedHref}`;
+    candidateKind = "relative";
+  }
+
+  if (!candidate) return null;
+
+  const filePath = stripLineSuffix(normalizeLocalPath(candidate));
+  if (candidateKind === "relative" && cwd && !isPathInside(filePath, cwd)) return null;
+  return filePath;
+}

--- a/lib/session-file-references-core.ts
+++ b/lib/session-file-references-core.ts
@@ -1,5 +1,11 @@
 import type { SessionEntry } from "./types";
 
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidSessionId(sessionId: string | null): sessionId is string {
+  return !!sessionId && SESSION_ID_RE.test(sessionId);
+}
+
 function safeDecode(value: string): string {
   try {
     return decodeURIComponent(value);

--- a/lib/session-file-references-core.ts
+++ b/lib/session-file-references-core.ts
@@ -1,0 +1,68 @@
+import type { SessionEntry } from "./types";
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSlashes(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function isPathChar(ch: string): boolean {
+  return /[A-Za-z0-9._~+%@/\\:-]/.test(ch);
+}
+
+function hasReferenceBoundaryAfter(text: string, index: number): boolean {
+  if (index >= text.length) return true;
+  const ch = text[index];
+  if (ch === ":") return /\d/.test(text[index + 1] ?? "");
+  return !isPathChar(ch);
+}
+
+function containsExactPathReference(text: string, filePath: string): boolean {
+  const target = normalizeSlashes(filePath);
+  const targets = target.startsWith("/") ? [target, `file://${target}`] : [target];
+  const haystacks = new Set([normalizeSlashes(text), normalizeSlashes(safeDecode(text))]);
+
+  for (const haystack of haystacks) {
+    for (const t of targets) {
+      let index = haystack.indexOf(t);
+      while (index !== -1) {
+        const before = index === 0 ? "" : haystack[index - 1];
+        const afterIndex = index + t.length;
+        if ((index === 0 || !isPathChar(before)) && hasReferenceBoundaryAfter(haystack, afterIndex)) {
+          return true;
+        }
+        index = haystack.indexOf(t, index + 1);
+      }
+    }
+  }
+
+  return false;
+}
+
+function collectStrings(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out);
+    return;
+  }
+  for (const item of Object.values(value)) collectStrings(item, out);
+}
+
+export function isFilePathReferencedByEntries(filePath: string, entries: SessionEntry[]): boolean {
+  for (const entry of entries) {
+    const strings: string[] = [];
+    collectStrings(entry, strings);
+    if (strings.some((text) => containsExactPathReference(text, filePath))) return true;
+  }
+  return false;
+}

--- a/lib/session-file-references.test.mjs
+++ b/lib/session-file-references.test.mjs
@@ -50,3 +50,11 @@ test("does not authorize sibling files by prefix match", async () => {
 
   assert.equal(isFilePathReferencedByEntries("/home/me/.codex/config.toml", entries), false);
 });
+
+test("validates session ids before resolving session paths", async () => {
+  const { isValidSessionId } = await loadSubject();
+
+  assert.equal(isValidSessionId("not-a-session-id"), false);
+  assert.equal(isValidSessionId("../../sessions/foo"), false);
+  assert.equal(isValidSessionId("550e8400-e29b-41d4-a716-446655440000"), true);
+});

--- a/lib/session-file-references.test.mjs
+++ b/lib/session-file-references.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./session-file-references-core.ts");
+}
+
+test("detects exact external file paths referenced in session entries", async () => {
+  const { isFilePathReferencedByEntries } = await loadSubject();
+  const entries = [
+    {
+      type: "message",
+      id: "entry-1",
+      parentId: null,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "See [/home/me/.codex/config.toml:12](/home/me/.codex/config.toml:12)",
+          },
+        ],
+      },
+    },
+  ];
+
+  assert.equal(isFilePathReferencedByEntries("/home/me/.codex/config.toml", entries), true);
+});
+
+test("does not authorize sibling files by prefix match", async () => {
+  const { isFilePathReferencedByEntries } = await loadSubject();
+  const entries = [
+    {
+      type: "message",
+      id: "entry-1",
+      parentId: null,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "See /home/me/.codex/config.toml.bak",
+          },
+        ],
+      },
+    },
+  ];
+
+  assert.equal(isFilePathReferencedByEntries("/home/me/.codex/config.toml", entries), false);
+});

--- a/lib/session-file-references.ts
+++ b/lib/session-file-references.ts
@@ -1,9 +1,9 @@
 import { getSessionEntries, resolveSessionPath } from "./session-reader";
 export { isFilePathReferencedByEntries } from "./session-file-references-core";
-import { isFilePathReferencedByEntries } from "./session-file-references-core";
+import { isFilePathReferencedByEntries, isValidSessionId } from "./session-file-references-core";
 
 export async function isFilePathReferencedBySession(filePath: string, sessionId: string | null): Promise<boolean> {
-  if (!sessionId) return false;
+  if (!isValidSessionId(sessionId)) return false;
   try {
     const sessionPath = await resolveSessionPath(sessionId);
     if (!sessionPath) return false;

--- a/lib/session-file-references.ts
+++ b/lib/session-file-references.ts
@@ -1,0 +1,14 @@
+import { getSessionEntries, resolveSessionPath } from "./session-reader";
+export { isFilePathReferencedByEntries } from "./session-file-references-core";
+import { isFilePathReferencedByEntries } from "./session-file-references-core";
+
+export async function isFilePathReferencedBySession(filePath: string, sessionId: string | null): Promise<boolean> {
+  if (!sessionId) return false;
+  try {
+    const sessionPath = await resolveSessionPath(sessionId);
+    if (!sessionPath) return false;
+    return isFilePathReferencedByEntries(filePath, getSessionEntries(sessionPath));
+  } catch {
+    return false;
+  }
+}

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -70,6 +70,11 @@ export function invalidateSessionPathCache(sessionId: string): void {
   getPathCache().delete(sessionId);
 }
 
+export function getSessionEntries(filePath: string): SessionEntry[] {
+  const entries = SessionManager.open(filePath).getEntries();
+  return entries as unknown as SessionEntry[];
+}
+
 export function buildSessionContext(entries: SessionEntry[], leafId?: string | null): SessionContext {
   const byId = new Map<string, SessionEntry>();
   for (const e of entries) byId.set(e.id, e);


### PR DESCRIPTION
## Summary
- Turn local markdown file links in chat into open-file actions inside the existing file viewer.
- Pass the source session id to file requests so files referenced by a session can be opened even when they are outside the current project root.
- Keep file access scoped to known roots or files referenced in the session log.

## Why
Agents often mention local file paths in their responses. Opening those links directly in the app avoids manual path copying while keeping the file endpoint constrained.

## Validation
- node --test lib/file-links.test.mjs lib/session-file-references.test.mjs
- node_modules/.bin/tsc --noEmit
- npm run lint