### PR TITLE
fix: prevent SSE event loss in connectEvents onerror handler

### DIFF
--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -159,10 +159,27 @@ const PROMPT_SETTLE_INITIAL_DELAY_MS = 800;
 const PROMPT_SETTLE_POLL_MS = 600;
 const PROMPT_SETTLE_MAX_MS = 20_000;
 const AGENT_STATE_RECONCILE_MS = 15_000;
+const EVENT_STREAM_CONNECT_TIMEOUT_MS = 5_000;
 const MAX_NOTICES = 5;
 const NOTICE_VISIBLE_MS = 5000;
 const NOTICE_EXIT_ANIMATION_MS = 180;
 const SCROLL_KEYS = new Set(["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ", "Space", "Spacebar"]);
+
+type EventStreamConnectionStatus = "connected" | "timeout" | "closed";
+
+type EventStreamConnectionResult = {
+  status: EventStreamConnectionStatus;
+  source: EventSource;
+};
+
+class EventStreamConnectionError extends Error {
+  constructor(public readonly status: Exclude<EventStreamConnectionStatus, "connected">) {
+    super(status === "timeout"
+      ? "Timed out connecting to the agent event stream. Please try again."
+      : "Failed to connect to the agent event stream. Please try again.");
+    this.name = "EventStreamConnectionError";
+  }
+}
 
 function createNoticeId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -547,7 +564,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [ensureNewSession]);
 
-  const connectEvents = useCallback((sid: string): Promise<void> => {
+  const connectEvents = useCallback((sid: string): Promise<EventStreamConnectionResult> => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
       eventSourceRef.current = null;
@@ -557,18 +574,18 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
     return new Promise((resolve) => {
       let settled = false;
-      const settle = () => {
+      const settle = (status: EventStreamConnectionStatus) => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        resolve();
+        resolve({ status, source: es });
       };
-      const timeout = setTimeout(settle, 1500);
+      const timeout = setTimeout(() => settle("timeout"), EVENT_STREAM_CONNECT_TIMEOUT_MS);
 
       es.onmessage = (e) => {
         try {
           const event = JSON.parse(e.data) as AgentEvent;
-          if (event.type === "connected") settle();
+          if (event.type === "connected") settle("connected");
           handleAgentEventRef.current?.(event);
         } catch {
           // ignore
@@ -577,9 +594,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       es.onerror = () => {
         if (es.readyState === EventSource.CLOSED) {
           // Fatal error (404/500/content-type mismatch): browser won't
-          // auto-reconnect. Settle the Promise so handleSend can proceed,
-          // then manually reconnect for live streaming.
-          settle();
+          // auto-reconnect. Settle the Promise and manually reconnect for
+          // already-running sessions.
+          settle("closed");
           if (eventSourceRef.current === es && agentRunningRef.current) {
             eventSourceRef.current = null;
             setTimeout(() => {
@@ -588,12 +605,19 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           }
         }
         // Recoverable errors (CONNECTING): let EventSource auto-reconnect.
-        // Don't settle() — that would let handleSend proceed with a broken
-        // connection and miss events emitted during the reconnect gap.
-        // The 1.5s timeout above will settle if the connection never recovers.
+        // The timeout above resolves only to let callers decide whether this
+        // connection must be ready before they continue.
       };
     });
   }, []);
+
+  const ensureEventsConnected = useCallback(async (sid: string) => {
+    const result = await connectEvents(sid);
+    if (result.status === "connected" || result.source.readyState === EventSource.OPEN) return;
+    if (eventSourceRef.current === result.source) eventSourceRef.current = null;
+    result.source.close();
+    throw new EventStreamConnectionError(result.status);
+  }, [connectEvents]);
 
   const respondToExtensionUi = useCallback(async (
     request: ExtensionUiDialogRequest,
@@ -985,7 +1009,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             setPendingModel(selectedModel);
             await sendAgentCommand(existingSid, { type: "set_model", provider: selectedModel.provider, modelId: selectedModel.modelId });
           }
-          await connectEvents(existingSid);
+          await ensureEventsConnected(existingSid);
           await sendAgentCommand(existingSid, {
             type: "prompt",
             message,
@@ -1012,7 +1036,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           const realId = result.sessionId;
           sessionIdRef.current = realId;
           sentSessionId = realId;
-          await connectEvents(realId);
+          await ensureEventsConnected(realId);
           await sendAgentCommand(realId, {
             type: "prompt",
             message,
@@ -1022,7 +1046,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         }
       } else if (session) {
         sentSessionId = session.id;
-        await connectEvents(session.id);
+        await ensureEventsConnected(session.id);
         await sendAgentCommand(session.id, {
           type: "prompt",
           message,
@@ -1034,13 +1058,25 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       }
     } catch (e) {
       console.error("Failed to send message:", e);
+      if (e instanceof EventStreamConnectionError) {
+        const optimisticKey = optimisticUserMessageKeyRef.current;
+        if (optimisticKey) {
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            return last?.role === "user" && userMessageKey(last) === optimisticKey
+              ? prev.slice(0, -1)
+              : prev;
+          });
+        }
+        addNotice({ type: "error", message: e.message });
+      }
       optimisticUserMessageKeyRef.current = null;
       agentRunningRef.current = false;
       setAgentRunning(false);
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, toolPreset, thinkingLevel, session, agentRunning, connectEvents, promoteNewSession, waitForPromptSettlement]);
+  }, [isNew, newSessionCwd, newSessionModel, toolPreset, thinkingLevel, session, agentRunning, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice]);
 
   const handleAbort = useCallback(async () => {
     const sid = sessionIdRef.current;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -575,14 +575,22 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         }
       };
       es.onerror = () => {
-        settle();
-        if (eventSourceRef.current === es && agentRunningRef.current) {
-          es.close();
-          eventSourceRef.current = null;
-          setTimeout(() => {
-            if (agentRunningRef.current) void connectEvents(sid);
-          }, 1000);
+        if (es.readyState === EventSource.CLOSED) {
+          // Fatal error (404/500/content-type mismatch): browser won't
+          // auto-reconnect. Settle the Promise so handleSend can proceed,
+          // then manually reconnect for live streaming.
+          settle();
+          if (eventSourceRef.current === es && agentRunningRef.current) {
+            eventSourceRef.current = null;
+            setTimeout(() => {
+              if (agentRunningRef.current) void connectEvents(sid);
+            }, 1000);
+          }
         }
+        // Recoverable errors (CONNECTING): let EventSource auto-reconnect.
+        // Don't settle() — that would let handleSend proceed with a broken
+        // connection and miss events emitted during the reconnect gap.
+        // The 1.5s timeout above will settle if the connection never recovers.
       };
     });
   }, []);


### PR DESCRIPTION
## Problem

The `connectEvents` `onerror` handler unconditionally called `settle()` +
`es.close()` on every error, then manually reconnected after 1s. This
created a race condition:

1. A recoverable network glitch triggers `onerror`
2. `settle()` resolves the Promise immediately → `handleSend` proceeds
   to send the prompt
3. `es.close()` kills the SSE connection → all events emitted during
   the 1s reconnect window (`agent_start`, `message_*`, `prompt_done`,
   `agent_end`) are **lost**
4. The UI stays stuck in "waiting for model" until
   `reconcileAgentState` (15s polling) recovers

## Fix

Distinguish between fatal errors (`readyState === CLOSED`, e.g. 404/500)
where manual reconnect is needed, and recoverable errors (`CONNECTING`)
where EventSource auto-reconnects on its own.

For recoverable errors we no longer `settle()` or `close()` — the 1.5s
timeout in the Promise constructor still ensures `handleSend` won't
hang. This eliminates the 1s event-loss window that was the root cause
of the stuck UI.

## Testing

- **Recoverable error**: simulate network glitch (offline/online in
  DevTools) during an active run → SSE auto-reconnects, no events lost,
  streaming continues
- **Fatal error**: return 500 from events route → manual reconnect kicks
  in, UI recovers via reconcile polling if needed
- **Normal flow**: new session + prompt → streaming works as expected