### PR TITLE
fix: render nested content inside task-list-items correctly

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -174,7 +174,8 @@ pre, code {
   padding-left: 25px;
 }
 .markdown-body .task-list-item::marker { content: ""; }
-.markdown-body .task-list-item input[type="checkbox"] {
+.markdown-body .task-list-item > input[type="checkbox"],
+.markdown-body .task-list-item > p:first-child > input[type="checkbox"]:first-child {
   appearance: none;
   position: absolute;
   left: 0;
@@ -188,11 +189,13 @@ pre, code {
   display: inline-grid;
   place-content: center;
 }
-.markdown-body .task-list-item input[type="checkbox"]:checked {
+.markdown-body .task-list-item > input[type="checkbox"]:checked,
+.markdown-body .task-list-item > p:first-child > input[type="checkbox"]:first-child:checked {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
   background: color-mix(in srgb, var(--accent) 10%, var(--bg));
 }
-.markdown-body .task-list-item input[type="checkbox"]:checked::before {
+.markdown-body .task-list-item > input[type="checkbox"]:checked::before,
+.markdown-body .task-list-item > p:first-child > input[type="checkbox"]:first-child:checked::before {
   content: "";
   width: 4px;
   height: 8px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -169,18 +169,19 @@ pre, code {
   list-style: none;
 }
 .markdown-body .task-list-item {
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
-  gap: 7px;
-  align-items: start;
-  padding-left: 0;
+  display: block;
+  position: relative;
+  padding-left: 25px;
 }
 .markdown-body .task-list-item::marker { content: ""; }
 .markdown-body .task-list-item input[type="checkbox"] {
   appearance: none;
+  position: absolute;
+  left: 0;
+  top: 0.35em;
   width: 14px;
   height: 14px;
-  margin: 5px 0 0;
+  margin: 0;
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--bg);


### PR DESCRIPTION
## Problem

Task-list items that contain **nested block content** (a nested `<ul>`, or multiple paragraphs) render broken. The nested list gets squeezed into the narrow checkbox column and its content wraps character-by-character into a tall vertical strip.

This is most visible in **compaction summaries**, which are model-generated and commonly contain `- [x]` items with nested sub-lists, e.g.:

````markdown
## Progress
- [x] Researched local Codex plugins:
  - `~/.codex/plugins/cache/openai-api-curated/build-web-apps/3fdeeb49`
  - semantic caches:
    - `~/.codex/plugins/cache/openai-curated-remote/build-web-apps/0.1.2`
- [x] Done.
````

## Root cause

`.markdown-body .task-list-item` uses a 2-column grid:

```css
.markdown-body .task-list-item {
  display: grid;
  grid-template-columns: 18px minmax(0, 1fr);
  gap: 7px;
  align-items: start;
  padding-left: 0;
}
```

`remark-gfm` renders the above markdown as:

```html
<li class="task-list-item">
  <input type="checkbox" checked />
  Researched local Codex plugins:
  <ul>…nested items…</ul>
</li>
```

The `<li>` now has three in-flow children: `<input>`, a text run, and the nested `<ul>`. With default `grid-auto-flow: row`, grid auto-placement places them as:

| | col 1 (18px) | col 2 (1fr) |
|---|---|---|
| row 1 | `<input>` | text |
| row 2 | **`<ul>` (nested)** | — |

The nested `<ul>` lands in the **18px checkbox column**, so its content (long file paths) is constrained to ~18px and wraps per character.

Simple task lists (`- [x] text` with no nested content) are unaffected — input goes to col 1, text to col 2 — which is why this stayed latent.

## Measured impact (headless Chrome, viewport 600px)

Rendering the snippet above against current `main` CSS:

| | nested `<ul>` width | long `<code>` path |
|---|---|---|
| main (grid) | **22px** | **10px × 1360px** (char-by-char vertical) |
| this PR (block) | 551px | 425px × 16px (one line) |

## Fix

Switch to block layout with the checkbox absolutely positioned, so nested content stays in normal block flow and indents naturally:

```css
.markdown-body .task-list-item {
  display: block;
  position: relative;
  padding-left: 25px;
}
.markdown-body .task-list-item input[type="checkbox"] {
  appearance: none;
  position: absolute;
  left: 0;
  top: 0.35em;
  margin: 0;
  /* width/height/border/… unchanged */
}
```

This is the standard, robust pattern for task-list checkboxes and handles arbitrary nested content (nested lists, multiple paragraphs, nested task lists) without column-placement issues.

Only `app/globals.css` is touched; no behavioral or DOM changes.