### PR TITLE
fix: restore custom tool config loading in ensureNewSession

### DIFF
--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -521,7 +521,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const promise = (async () => {
       const selectedModel = newSessionModel ?? newSessionDefaultModel;
       if (selectedModel) setPendingModel(selectedModel);
-      const toolNames = getToolNamesForPreset(toolPreset);
+      let toolNames: string[];
+      try {
+        const savedRes = await fetch("/api/tools");
+        const saved = await savedRes.json() as { config?: { activeTools?: string[] } };
+        toolNames = saved.config?.activeTools && Array.isArray(saved.config.activeTools)
+          ? saved.config.activeTools
+          : getToolNamesForPreset(toolPreset);
+      } catch {
+        toolNames = getToolNamesForPreset(toolPreset);
+      }
       const res = await fetch("/api/agent/new", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Problem

Commit 3f6b0c6 (Fix new session startup path) replaced the `/api/tools` fetch that loaded saved custom tool configurations with a direct call to `getToolNamesForPreset()`. This caused **all custom and post-installed tools to be lost** when creating new sessions.

## Root Cause

`ensureNewSession()` previously had a two-step logic:
1. Fetch `/api/tools` to get the user's saved custom tool configuration
2. Fall back to the preset if no saved config exists

Commit 3f6b0c6 collapsed this into just `getToolNamesForPreset(toolPreset)`, discarding any custom tool setup the user had configured.

## Fix

Restore the saved-config lookup with fallback to preset.

## Verification

- All downstream callers (`handleSend` → `ensureNewSession()`) automatically benefit
- The only other `getToolNamesForPreset` call site is `handleToolPresetChange`, which is correct — it's triggered by explicit user preset selection
- TypeScript compiles cleanly
- Full production build passes