### PR TITLE
improve web page loading speed

### DIFF
--- a/app/api/sessions/[id]/context/route.ts
+++ b/app/api/sessions/[id]/context/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { resolveSessionPath, buildSessionContext } from "@/lib/session-reader";
+import { resolveSessionPath, buildSessionContext, readSessionSnapshot } from "@/lib/session-reader";
 
 export async function GET(
   req: Request,
@@ -9,6 +8,7 @@ export async function GET(
   const { id } = await params;
   const url = new URL(req.url);
   const leafId = url.searchParams.get("leafId") ?? undefined;
+  const deferThinking = url.searchParams.has("deferThinking");
 
   try {
     const filePath = await resolveSessionPath(id);
@@ -16,8 +16,8 @@ export async function GET(
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const sm = SessionManager.open(filePath);
-    const context = buildSessionContext(sm.getEntries() as never, leafId);
+    const snapshot = await readSessionSnapshot(filePath, leafId, false);
+    const context = buildSessionContext(snapshot.branch, leafId, { deferThinking });
 
     return NextResponse.json({ context });
   } catch (error) {

--- a/app/api/sessions/[id]/entries/[entryId]/thinking/route.ts
+++ b/app/api/sessions/[id]/entries/[entryId]/thinking/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { readSessionEntry, resolveSessionPath } from "@/lib/session-reader";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string; entryId: string }> },
+) {
+  const { id, entryId } = await params;
+  const blockIndex = Number.parseInt(new URL(req.url).searchParams.get("blockIndex") ?? "", 10);
+  if (!Number.isSafeInteger(blockIndex) || blockIndex < 0) {
+    return NextResponse.json({ error: "Valid blockIndex is required" }, { status: 400 });
+  }
+
+  try {
+    const filePath = await resolveSessionPath(id);
+    if (!filePath) return NextResponse.json({ error: "Session not found" }, { status: 404 });
+
+    const entry = await readSessionEntry(filePath, entryId);
+    if (!entry || entry.type !== "message" || entry.message.role !== "assistant") {
+      return NextResponse.json({ error: "Assistant message not found" }, { status: 404 });
+    }
+
+    const block = entry.message.content[blockIndex];
+    if (!block || block.type !== "thinking") {
+      return NextResponse.json({ error: "Thinking block not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ thinking: block.thinking });
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -4,9 +4,11 @@ import { join } from "path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
   resolveSessionPath,
+  resolveSessionIdByPath,
   invalidateSessionPathCache,
   buildSessionContext,
-  listAllSessions,
+  readSessionHeader,
+  readSessionSnapshot,
 } from "@/lib/session-reader";
 import { getRpcSession } from "@/lib/rpc-manager";
 
@@ -121,22 +123,22 @@ export async function GET(
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const sm = SessionManager.open(filePath);
-    const entries = sm.getEntries() as never;
-    const leafId = sm.getLeafId();
-    const tree = projectTreeForResponse(sm.getTree());
-    const context = buildSessionContext(entries, leafId);
+    const snapshot = await readSessionSnapshot(filePath);
+    const { header, leafId } = snapshot;
+    const tree = projectTreeForResponse(snapshot.tree);
+    const deferThinking = new URL(req.url).searchParams.has("deferThinking");
+    const context = buildSessionContext(snapshot.branch, leafId, { deferThinking });
 
-    const header = sm.getHeader();
     let modified = header?.timestamp ?? new Date().toISOString();
     try { modified = statSync(filePath).mtime.toISOString(); } catch { /* use header timestamp */ }
-    const allSessions = await listAllSessions();
-    const parentSessionId = allSessions.find((s) => s.id === id)?.parentSessionId;
+    const parentSessionId = header?.parentSession
+      ? await resolveSessionIdByPath(header.parentSession)
+      : undefined;
     const info = header ? {
       path: filePath,
       id: header.id,
       cwd: header.cwd ?? "",
-      name: sm.getSessionName(),
+      name: snapshot.name,
       created: header.timestamp,
       modified,
       messageCount: context.messages.length,
@@ -150,18 +152,6 @@ export async function GET(
       parentSessionId,
     } : null;
 
-    const url = new URL(req.url);
-    let agentState: { running: boolean; state?: unknown } | undefined;
-    if (url.searchParams.has("includeState")) {
-      const rpc = getRpcSession(id);
-      if (rpc?.isAlive()) {
-        const state = await rpc.send({ type: "get_state" });
-        agentState = { running: true, state };
-      } else {
-        agentState = { running: false };
-      }
-    }
-
     return NextResponse.json({
       sessionId: id,
       filePath,
@@ -169,7 +159,6 @@ export async function GET(
       leafId,
       tree,
       context,
-      ...(agentState !== undefined ? { agentState } : {}),
     });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
@@ -211,13 +200,11 @@ export async function DELETE(
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    // Read header before deleting to get parentSession path
-    const firstLine = readFileSync(filePath, "utf8").split("\n")[0];
+    // Read only the small header before deleting.
     let parentSessionPath: string | undefined;
     try {
-      const header = JSON.parse(firstLine) as { type?: string; parentSession?: string };
-      if (header.type === "session") parentSessionPath = header.parentSession;
-    } catch { /* ignore */ }
+      parentSessionPath = readSessionHeader(filePath)?.parentSession;
+    } catch { /* ignore malformed header */ }
 
     // Re-attach all direct children to this session's parent (cascade re-parent)
     // Scan sibling files in the same directory

--- a/app/api/sessions/[id]/state/route.ts
+++ b/app/api/sessions/[id]/state/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getRpcSession } from "@/lib/rpc-manager";
+import { resolveSessionPath } from "@/lib/session-reader";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    if (!await resolveSessionPath(id)) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const rpc = getRpcSession(id);
+    if (!rpc?.isAlive()) return NextResponse.json({ running: false });
+
+    const state = await rpc.send({ type: "get_state" });
+    return NextResponse.json({ running: true, state });
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -467,6 +467,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp : undefined}
+                    sessionId={session?.id}
                   />
                 );
                 if (!isVisible || options.attachRef === false || currentRefIdx === undefined) return view;

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
@@ -8,7 +8,20 @@ import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { useTheme } from "@/hooks/useTheme";
 import { copyText } from "@/lib/clipboard";
 import { resolveLocalFileHref } from "@/lib/file-links";
+import { encodeFilePathForApi } from "@/lib/file-paths";
 import { markdownRehypePlugins, markdownRemarkPlugins } from "@/lib/markdown";
+import { renderMermaid } from "@/lib/mermaid";
+
+const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"]);
+
+function isImagePath(filePath: string): boolean {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_EXTS.has(ext);
+}
+
+function filePathToApiUrl(filePath: string): string {
+  return `/api/files/${encodeFilePathForApi(filePath)}?type=read`;
+}
 
 interface MarkdownBodyProps {
   children: string;
@@ -49,9 +62,52 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
           pre({ children }) {
             return <>{children}</>;
           },
+          img({ src, alt, ...props }) {
+            if (!src || typeof src !== "string") return null;
+            const filePath = resolveLocalFileHref(src, cwd);
+            if (filePath && isImagePath(filePath)) {
+              // eslint-disable-next-line @next/next/no-img-element
+              return (
+                <img
+                  src={filePathToApiUrl(filePath)}
+                  alt={alt ?? ""}
+                  style={{ maxWidth: "100%", maxHeight: 480, borderRadius: 8, display: "block", margin: "8px 0" }}
+                  loading="lazy"
+                />
+              );
+            }
+            // eslint-disable-next-line @next/next/no-img-element
+            return <img src={src} alt={alt} {...props} />;
+          },
           a({ href, children, ...props }) {
             const filePath = onOpenFile ? resolveLocalFileHref(href, cwd) : null;
             const openFile = onOpenFile;
+            const isImage = filePath ? isImagePath(filePath) : false;
+
+            const handleClick = (event: MouseEvent<HTMLElement>) => {
+              if (event.defaultPrevented || event.button !== 0) return;
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+              const target = event.currentTarget.getAttribute("target");
+              if (target && target !== "_self") return;
+              event.preventDefault();
+              if (filePath && openFile) openFile(filePath);
+            };
+
+            if (isImage && filePath) {
+              return (
+                <span>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={filePathToApiUrl(filePath)}
+                    alt={String(children)}
+                    style={{ maxWidth: "100%", maxHeight: 480, borderRadius: 8, display: "block", margin: "8px 0", cursor: "pointer" }}
+                    loading="lazy"
+                    onClick={openFile ? handleClick : undefined}
+                  />
+                </span>
+              );
+            }
+
             if (!filePath || !openFile) {
               return (
                 <a href={href} {...props}>
@@ -59,15 +115,6 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
                 </a>
               );
             }
-
-            const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-              if (event.defaultPrevented || event.button !== 0) return;
-              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
-              const target = event.currentTarget.getAttribute("target");
-              if (target && target !== "_self") return;
-              event.preventDefault();
-              openFile(filePath);
-            };
 
             return (
               <a href={href} {...props} onClick={handleClick}>
@@ -124,46 +171,49 @@ function MermaidBlock({ code, isStreaming }: { code: string; isStreaming?: boole
   const [showPreview, setShowPreview] = useState(false);
   const [svg, setSvg] = useState<string | null>(null);
   const [renderedKey, setRenderedKey] = useState("");
-  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const [error, setError] = useState<{ key: string; message: string } | null>(null);
+  const diagramRef = useRef<HTMLDivElement>(null);
+  const bindFunctionsRef = useRef<((element: Element) => void) | undefined>(undefined);
   const currentKey = `${isDark ? "dark" : "light"}\n${code}`;
 
   useEffect(() => {
     if (!showPreview || isStreaming) return;
 
     let cancelled = false;
-    setFailedKey(null);
+    setError(null);
 
     const render = async () => {
-      const { default: mermaid } = await import("mermaid");
-      mermaid.initialize({
-        startOnLoad: false,
-        securityLevel: "strict",
-        suppressErrorRendering: true,
-        theme: isDark ? "dark" : "default",
-      });
-
-      const parsed = await mermaid.parse(code, { suppressErrors: true });
-      if (!parsed) throw new Error("Invalid Mermaid diagram");
-
       const id =
         typeof crypto !== "undefined" && "randomUUID" in crypto
           ? `mermaid-${crypto.randomUUID()}`
           : `mermaid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const result = await mermaid.render(id, code);
+      const result = await renderMermaid(id, code, isDark);
       if (!cancelled) {
+        bindFunctionsRef.current = result.bindFunctions;
         setSvg(result.svg);
         setRenderedKey(currentKey);
       }
     };
 
-    render().catch(() => {
-      if (!cancelled) setFailedKey(currentKey);
+    render().catch((err: unknown) => {
+      if (!cancelled) {
+        setError({
+          key: currentKey,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
 
     return () => {
       cancelled = true;
     };
   }, [code, currentKey, isDark, isStreaming, showPreview]);
+
+  useEffect(() => {
+    if (renderedKey === currentKey && diagramRef.current) {
+      bindFunctionsRef.current?.(diagramRef.current);
+    }
+  }, [currentKey, renderedKey, svg]);
 
   const previewButton = (
     <button
@@ -181,12 +231,13 @@ function MermaidBlock({ code, isStreaming }: { code: string; isStreaming?: boole
   }
 
   const body =
-    failedKey === currentKey ? (
-      <div className="mermaid-block mermaid-block-error">Invalid Mermaid diagram</div>
+    error?.key === currentKey ? (
+      <div className="mermaid-block mermaid-block-error">{error.message}</div>
     ) : !svg || renderedKey !== currentKey ? (
       <div className="mermaid-block mermaid-block-loading" aria-label="Rendering Mermaid diagram" />
     ) : (
       <div
+        ref={diagramRef}
         className="mermaid-block"
         dangerouslySetInnerHTML={{ __html: svg }}
       />

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -19,6 +19,33 @@ import type {
   ThinkingContent,
 } from "@/lib/types";
 
+const MAX_THINKING_CACHE_ENTRIES = 100;
+const thinkingContentCache = new Map<string, Promise<string>>();
+
+function loadThinkingContent(sessionId: string, entryId: string, blockIndex: number): Promise<string> {
+  const key = `${sessionId}:${entryId}:${blockIndex}`;
+  const cached = thinkingContentCache.get(key);
+  if (cached) return cached;
+
+  const request = fetch(
+    `/api/sessions/${encodeURIComponent(sessionId)}/entries/${encodeURIComponent(entryId)}/thinking?blockIndex=${blockIndex}`,
+  ).then(async (response) => {
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json() as { thinking?: unknown };
+    if (typeof data.thinking !== "string") throw new Error("Invalid thinking response");
+    return data.thinking;
+  }).catch((error) => {
+    thinkingContentCache.delete(key);
+    throw error;
+  });
+  thinkingContentCache.set(key, request);
+  if (thinkingContentCache.size > MAX_THINKING_CACHE_ENTRIES) {
+    const oldestKey = thinkingContentCache.keys().next().value;
+    if (oldestKey) thinkingContentCache.delete(oldestKey);
+  }
+  return request;
+}
+
 interface Props {
   message: AgentMessage;
   isStreaming?: boolean;
@@ -34,6 +61,7 @@ interface Props {
   onEditContent?: (content: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
+  sessionId?: string;
 }
 
 function formatTime(ts?: number): string | null {
@@ -49,12 +77,12 @@ function formatTime(ts?: number): string | null {
   return `${date} ${time}`;
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+export function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} />;
+    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
@@ -278,6 +306,8 @@ function AssistantMessageView({
   onOpenFile,
   showTimestamp,
   prevTimestamp,
+  sessionId,
+  entryId,
 }: {
   message: AssistantMessage;
   isStreaming?: boolean;
@@ -287,6 +317,8 @@ function AssistantMessageView({
   onOpenFile?: (filePath: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
+  sessionId?: string;
+  entryId?: string;
 }) {
   const time = showTimestamp ? formatTime(message.timestamp) : null;
   const blockItems = (message.content ?? [])
@@ -454,7 +486,7 @@ function AssistantMessageView({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {blockItems.map(({ block, originalIndex }) => (
-          <BlockView key={originalIndex} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(originalIndex) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} />
+          <BlockView key={`${entryId ?? "stream"}-${originalIndex}`} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(originalIndex) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} sessionId={sessionId} entryId={entryId} blockIndex={originalIndex} />
         ))}
       </div>
 
@@ -507,12 +539,12 @@ function AssistantMessageView({
   );
 }
 
-function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, cwd, onOpenFile }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; cwd?: string; onOpenFile?: (filePath: string) => void }) {
+function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, cwd, onOpenFile, sessionId, entryId, blockIndex }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; cwd?: string; onOpenFile?: (filePath: string) => void; sessionId?: string; entryId?: string; blockIndex: number }) {
   if (block.type === "text") {
     return <TextBlock block={block as TextContent} isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile} />;
   }
   if (block.type === "thinking") {
-    return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} />;
+    return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} sessionId={sessionId} entryId={entryId} blockIndex={blockIndex} />;
   }
   if (block.type === "toolCall") {
     const tc = block as ToolCallContent;
@@ -527,8 +559,38 @@ function TextBlock({ block, isStreaming, cwd, onOpenFile }: { block: TextContent
   return <MarkdownBody isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile}>{block.text}</MarkdownBody>;
 }
 
-function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?: number }) {
+function ThinkingBlock({ block, duration, sessionId, entryId, blockIndex }: {
+  block: ThinkingContent;
+  duration?: number;
+  sessionId?: string;
+  entryId?: string;
+  blockIndex: number;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async () => {
+    const nextExpanded = !expanded;
+    setExpanded(nextExpanded);
+    if (!nextExpanded || !block.deferred || content !== null) return;
+    if (!sessionId || !entryId) {
+      setError("Thinking content unavailable");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      setContent(await loadThinkingContent(sessionId, entryId, blockIndex));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div
       style={{
@@ -539,7 +601,7 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
       }}
     >
       <button
-        onClick={() => setExpanded((v) => !v)}
+        onClick={() => void toggle()}
         style={{
           display: "flex",
           alignItems: "center",
@@ -563,7 +625,7 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
         <div
           style={{
             padding: "8px 10px",
-            color: "var(--text-muted)",
+            color: error ? "#f87171" : "var(--text-muted)",
             fontSize: 12,
             lineHeight: 1.6,
             whiteSpace: "pre-wrap",
@@ -571,7 +633,7 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
             borderTop: "1px solid var(--border)",
           }}
         >
-          {block.thinking}
+          {loading ? "Loading thinking…" : error ?? (block.deferred ? content : block.thinking)}
         </div>
       )}
     </div>

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -423,13 +423,17 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } satisfies SessionStatsInfo;
   })();
 
-  const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
+  const loadSession = useCallback(async (
+    sid: string,
+    showLoading = false,
+    includeState = false,
+    deferThinking = true,
+  ) => {
+    let messagesLoaded = false;
     try {
       if (showLoading) setLoading(true);
-      const url = includeState
-        ? `/api/sessions/${encodeURIComponent(sid)}?includeState`
-        : `/api/sessions/${encodeURIComponent(sid)}`;
-      const res = await fetch(url);
+      const sessionUrl = `/api/sessions/${encodeURIComponent(sid)}${deferThinking ? "?deferThinking" : ""}`;
+      const res = await fetch(sessionUrl);
       if (res.status === 404) {
         if (showLoading) {
           setData(null);
@@ -440,41 +444,57 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         return null;
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = await res.json() as SessionData & { agentState?: { running: boolean; state?: AgentStateResponse } };
+      const d = await res.json() as SessionData;
+      if (sessionIdRef.current !== sid) return null;
       setData(d);
       setActiveLeafId(d.leafId);
       setMessages(d.context.messages);
       setEntryIds(d.context.entryIds ?? []);
       setCurrentModelOverride(null);
       setError(null);
-      const liveState = d.agentState?.state;
-      if (liveState) {
-        if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
-        if (liveState.systemPrompt !== undefined) setSystemPrompt(liveState.systemPrompt ?? null);
-        if (liveState.thinkingLevel !== undefined) setThinkingLevel((liveState.thinkingLevel as ThinkingLevelOption) ?? "auto");
-        if (liveState.extensionStatuses !== undefined) setExtensionStatuses(liveState.extensionStatuses ?? []);
-        if (liveState.extensionWidgets !== undefined) setExtensionWidgets(liveState.extensionWidgets ?? []);
-        if (liveState.queuedMessages !== undefined) setQueuedMessages(normalizeQueuedMessages(liveState.queuedMessages));
-      }
-      else if (d.agentState && !d.agentState.running) setQueuedMessages({ steering: [], followUp: [] });
-      // If no live agent state, fall back to thinking level from session file
-      if (!liveState?.thinkingLevel && d.context.thinkingLevel && d.context.thinkingLevel !== "off") {
+      if (d.context.thinkingLevel && d.context.thinkingLevel !== "off") {
         setThinkingLevel(d.context.thinkingLevel as ThinkingLevelOption);
       }
-      return d.agentState ?? null;
+
+      // Show persisted messages immediately; live agent state may block on RPC.
+      messagesLoaded = true;
+      if (showLoading) setLoading(false);
+      if (!includeState) return null;
+
+      try {
+        const stateRes = await fetch(`/api/sessions/${encodeURIComponent(sid)}/state`);
+        if (!stateRes.ok) throw new Error(`HTTP ${stateRes.status}`);
+        const agentState = await stateRes.json() as { running: boolean; state?: AgentStateResponse };
+        if (sessionIdRef.current !== sid) return null;
+        const liveState = agentState.state;
+        if (liveState) {
+          if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
+          if (liveState.systemPrompt !== undefined) setSystemPrompt(liveState.systemPrompt ?? null);
+          if (liveState.thinkingLevel !== undefined) setThinkingLevel((liveState.thinkingLevel as ThinkingLevelOption) ?? "auto");
+          if (liveState.extensionStatuses !== undefined) setExtensionStatuses(liveState.extensionStatuses ?? []);
+          if (liveState.extensionWidgets !== undefined) setExtensionWidgets(liveState.extensionWidgets ?? []);
+          if (liveState.queuedMessages !== undefined) setQueuedMessages(normalizeQueuedMessages(liveState.queuedMessages));
+        } else if (!agentState.running) {
+          setQueuedMessages({ steering: [], followUp: [] });
+        }
+        return agentState;
+      } catch (e) {
+        console.error("Failed to load agent state:", e);
+        return null;
+      }
     } catch (e) {
       setError(String(e));
       return null;
     } finally {
-      if (showLoading) setLoading(false);
+      if (showLoading && !messagesLoaded) setLoading(false);
     }
   }, []);
 
   const loadContext = useCallback(async (sid: string, leafId: string | null) => {
     try {
-      const url = leafId
-        ? `/api/sessions/${encodeURIComponent(sid)}/context?leafId=${encodeURIComponent(leafId)}`
-        : `/api/sessions/${encodeURIComponent(sid)}/context`;
+      const params = new URLSearchParams({ deferThinking: "1" });
+      if (leafId) params.set("leafId", leafId);
+      const url = `/api/sessions/${encodeURIComponent(sid)}/context?${params}`;
       const res = await fetch(url);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const d = await res.json() as { context: { messages: AgentMessage[]; entryIds: string[] } };
@@ -1390,7 +1410,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   useEffect(() => {
     if (session) {
       sessionIdRef.current = session.id;
-      loadSession(session.id, true, true).then((agentState) => {
+      loadSession(session.id, true, true, true).then((agentState) => {
         if (agentState?.running) {
           loadTools(session.id);
           if (agentState.state?.isStreaming || agentState.state?.isPromptRunning) {

--- a/lib/mermaid.ts
+++ b/lib/mermaid.ts
@@ -1,0 +1,59 @@
+import type { RenderResult } from "mermaid";
+
+type MermaidModule = typeof import("mermaid");
+type MermaidTheme = "dark" | "default";
+
+// Mermaid configuration is global; serialize initialization and rendering so
+// a theme change cannot reset config during another diagram's render.
+const MAX_CONCURRENT_RENDERS = 1;
+
+let modulePromise: Promise<MermaidModule> | null = null;
+let initializedTheme: MermaidTheme | null = null;
+let activeRenders = 0;
+const pendingRenders: (() => void)[] = [];
+
+function loadMermaid(): Promise<MermaidModule> {
+  modulePromise ??= import("mermaid");
+  return modulePromise;
+}
+
+async function acquireRenderSlot(): Promise<void> {
+  if (activeRenders < MAX_CONCURRENT_RENDERS) {
+    activeRenders += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => pendingRenders.push(resolve));
+}
+
+function releaseRenderSlot(): void {
+  const next = pendingRenders.shift();
+  if (next) next();
+  else activeRenders -= 1;
+}
+
+export async function renderMermaid(
+  id: string,
+  code: string,
+  isDark: boolean,
+): Promise<RenderResult> {
+  await acquireRenderSlot();
+  try {
+    const { default: mermaid } = await loadMermaid();
+    const theme: MermaidTheme = isDark ? "dark" : "default";
+    if (initializedTheme !== theme) {
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "strict",
+        suppressErrorRendering: true,
+        theme,
+      });
+      initializedTheme = theme;
+    }
+
+    const parsed = await mermaid.parse(code, { suppressErrors: true });
+    if (!parsed) throw new Error("Invalid Mermaid diagram");
+    return await mermaid.render(id, code);
+  } finally {
+    releaseRenderSlot();
+  }
+}

--- a/lib/message-display.test.mjs
+++ b/lib/message-display.test.mjs
@@ -87,3 +87,12 @@ test("keeps empty thinking while streaming", async () => {
   assert.deepEqual(result.answerBlocks.map((block) => block.type), ["text"]);
   assert.deepEqual(result.processBlocks.map((block) => block.type), ["thinking"]);
 });
+
+test("keeps deferred historical thinking placeholders", async () => {
+  const { getDisplayableAssistantBlocks } = await loadSubject();
+  const message = assistant([
+    { type: "thinking", thinking: "", deferred: true },
+  ]);
+
+  assert.equal(getDisplayableAssistantBlocks(message).length, 1);
+});

--- a/lib/message-display.ts
+++ b/lib/message-display.ts
@@ -5,7 +5,7 @@ interface DisplayOptions {
 }
 
 export function isEmptyThinkingBlock(block: AssistantContentBlock, options: DisplayOptions = {}): block is ThinkingContent {
-  return block.type === "thinking" && !options.isStreaming && block.thinking.trim() === "";
+  return block.type === "thinking" && !block.deferred && !options.isStreaming && block.thinking.trim() === "";
 }
 
 export function getDisplayableAssistantBlocks(

--- a/lib/session-reader.test.mjs
+++ b/lib/session-reader.test.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { buildSessionContext } = await jiti.import("./session-reader.ts");
+const { buildSessionContext, readSessionHeader, readSessionSnapshot } = await jiti.import("./session-reader.ts");
 
 function userEntry(id, parentId, content, timestamp = "2026-01-01T00:00:00.000Z") {
   return {
@@ -65,6 +68,34 @@ test("renders full branch history with compaction at its original entry position
   );
 });
 
+test("defers historical thinking while preserving live-session behavior", () => {
+  const entries = [
+    userEntry("u1", null, "start"),
+    {
+      ...assistantEntry("a1", "u1", "answer"),
+      message: {
+        role: "assistant",
+        provider: "test",
+        model: "test-model",
+        content: [
+          { type: "thinking", thinking: "large private reasoning" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    },
+  ];
+
+  const deferred = buildSessionContext(entries, undefined, { deferThinking: true });
+  assert.deepEqual(deferred.messages[1].content[0], {
+    type: "thinking",
+    thinking: "",
+    deferred: true,
+  });
+
+  const full = buildSessionContext(entries);
+  assert.equal(full.messages[1].content[0].thinking, "large private reasoning");
+});
+
 test("preserves hidden custom messages so the UI can render them collapsed", () => {
   const entries = [
     userEntry("u1", null, "start"),
@@ -109,4 +140,51 @@ test("preserves valid epoch timestamps on synthetic UI messages", () => {
   assert.equal(context.messages[1].role, "custom");
   assert.equal(context.messages[1].customType, "compaction");
   assert.equal(context.messages[1].timestamp, 0);
+});
+
+test("streams only the requested branch across chunks and without a trailing newline", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-web-session-"));
+  const filePath = join(dir, "session.jsonl");
+  const largeUtf8Content = "水".repeat(30_000);
+  const lines = [
+    { type: "session", version: 3, id: "session", timestamp: "2026-01-01T00:00:00.000Z", cwd: dir },
+    userEntry("u1", null, largeUtf8Content),
+    assistantEntry("a1", "u1", "main branch"),
+    userEntry("b1", "u1", "other branch"),
+  ];
+  writeFileSync(filePath, lines.map(JSON.stringify).join("\n"));
+
+  try {
+    const selected = await readSessionSnapshot(filePath, "a1");
+    assert.equal(selected.leafId, "b1");
+    assert.deepEqual(selected.branch.map((entry) => entry.id), ["u1", "a1"]);
+    assert.equal(selected.branch[0].message.content, largeUtf8Content);
+    assert.equal(selected.tree[0].children.length, 2);
+
+    const latest = await readSessionSnapshot(filePath, undefined, false);
+    assert.deepEqual(latest.branch.map((entry) => entry.id), ["u1", "b1"]);
+    assert.deepEqual(latest.tree, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("reads a session header longer than the initial 4 KiB buffer", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-web-header-"));
+  const filePath = join(dir, "session.jsonl");
+  const parentSession = `/tmp/${"p".repeat(5_000)}.jsonl`;
+  writeFileSync(filePath, `${JSON.stringify({
+    type: "session",
+    version: 3,
+    id: "session",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    cwd: dir,
+    parentSession,
+  })}\n`);
+
+  try {
+    assert.equal(readSessionHeader(filePath).parentSession, parentSession);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/lib/session-reader.test.mjs
+++ b/lib/session-reader.test.mjs
@@ -96,6 +96,42 @@ test("defers historical thinking while preserving live-session behavior", () => 
   assert.equal(full.messages[1].content[0].thinking, "large private reasoning");
 });
 
+test("defers historical embedded images while preserving session data behavior", () => {
+  const userImage = { type: "image", data: "A".repeat(1024), mimeType: "image/png" };
+  const toolImage = { type: "image", data: "B".repeat(2048), mimeType: "image/jpeg" };
+  const entries = [
+    userEntry("u1", null, [{ type: "text", text: "show screenshot" }, userImage]),
+    assistantEntry("a1", "u1", "reading"),
+    {
+      type: "message",
+      id: "tr1",
+      parentId: "a1",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      message: {
+        role: "toolResult",
+        toolCallId: "call1",
+        content: [
+          { type: "text", text: "Read image file [image/jpeg]" },
+          toolImage,
+        ],
+      },
+    },
+  ];
+
+  const deferred = buildSessionContext(entries, undefined, { deferThinking: true });
+  assert.equal(deferred.messages[0].role, "user");
+  assert.equal(deferred.messages[0].content.some((block) => block.type === "image"), false);
+  assert.match(deferred.messages[0].content.at(-1).text, /embedded image.*omitted/);
+  assert.equal(deferred.messages[2].role, "toolResult");
+  assert.deepEqual(deferred.messages[2].content[0], { type: "text", text: "Read image file [image/jpeg]" });
+  assert.equal(deferred.messages[2].content.some((block) => block.type === "image"), false);
+  assert.match(deferred.messages[2].content.at(-1).text, /embedded image.*omitted/);
+
+  const full = buildSessionContext(entries);
+  assert.deepEqual(full.messages[0].content[1], userImage);
+  assert.deepEqual(full.messages[2].content[1], toolImage);
+});
+
 test("preserves hidden custom messages so the UI can render them collapsed", () => {
   const entries = [
     userEntry("u1", null, "start"),

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -342,21 +342,74 @@ function parseEntryTimestamp(timestamp: string): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function embeddedImageInfo(block: unknown): { mime?: string; bytes: number } | null {
+  if (!isRecord(block) || block.type !== "image") return null;
+
+  const flatData = block.data;
+  if (typeof flatData === "string" && flatData.length > 0) {
+    return {
+      mime: typeof block.mimeType === "string" ? block.mimeType : undefined,
+      bytes: Math.round(flatData.length * 3 / 4),
+    };
+  }
+
+  const source = block.source;
+  if (!isRecord(source) || source.type !== "base64") return null;
+  const sourceData = source.data;
+  if (typeof sourceData !== "string" || sourceData.length === 0) return null;
+  return {
+    mime: typeof source.media_type === "string" ? source.media_type : undefined,
+    bytes: Math.round(sourceData.length * 3 / 4),
+  };
+}
+
+function omitHistoricalEmbeddedImages(message: AgentMessage): AgentMessage {
+  const rawContent = (message as { content?: unknown }).content;
+  if (!Array.isArray(rawContent)) return message;
+
+  let omitted = 0;
+  let bytes = 0;
+  const mimes = new Set<string>();
+  const content = rawContent.filter((block) => {
+    const image = embeddedImageInfo(block);
+    if (!image) return true;
+    omitted += 1;
+    bytes += image.bytes;
+    if (image.mime) mimes.add(image.mime);
+    return false;
+  });
+
+  if (omitted === 0) return message;
+  content.push({
+    type: "text",
+    text: `[${omitted} embedded image${omitted === 1 ? "" : "s"} omitted from pi-web history payload${mimes.size ? `: ${[...mimes].join(", ")}` : ""}, ~${bytes.toLocaleString()} bytes]`,
+  });
+  return { ...message, content } as AgentMessage;
+}
+
 // Convert a session entry on the active branch into a UI message.
 // Returns null for entries that do not map to chat history (metadata, non-message types).
 function entryToUiMessage(entry: SessionEntry, deferThinking: boolean): AgentMessage | null {
   switch (entry.type) {
     case "message": {
       const message = normalizeToolCalls(entry.message);
-      if (!deferThinking || message.role !== "assistant") return message;
-      return {
-        ...message,
-        content: message.content.map((block) => (
-          block.type === "thinking"
-            ? { ...block, thinking: "", deferred: true }
-            : block
-        )),
-      };
+      if (deferThinking) {
+        const deferred = omitHistoricalEmbeddedImages(message);
+        if (deferred.role !== "assistant") return deferred;
+        return {
+          ...deferred,
+          content: deferred.content.map((block) => (
+            block.type === "thinking"
+              ? { ...block, thinking: "", deferred: true }
+              : block
+          )),
+        };
+      }
+      return message;
     }
     case "compaction":
       return {

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -1,5 +1,7 @@
 import { SessionManager, buildSessionContext as piBuildSessionContext, getAgentDir } from "@earendil-works/pi-coding-agent";
-import type { AgentMessage, SessionEntry, SessionInfo, SessionContext } from "./types";
+import { closeSync, createReadStream, openSync, readSync } from "fs";
+import { createInterface } from "readline";
+import type { AgentMessage, SessionEntry, SessionHeader, SessionInfo, SessionContext, SessionTreeNode } from "./types";
 import type { SessionEntry as PiSessionEntry, SessionInfo as PiSessionInfo } from "@earendil-works/pi-coding-agent";
 import { normalizeToolCalls } from "./normalize";
 import { resolveProject, type ProjectInfo } from "./worktree";
@@ -20,9 +22,11 @@ export async function listAllSessions(): Promise<SessionInfo[]> {
   }));
 
   const cache = getPathCache();
+  const reverseCache = getPathToIdCache();
   return piSessions.map((s) => {
-    // Populate path cache so resolveSessionPath works without a full scan
+    // Populate both caches so detail routes avoid another full session scan.
     cache.set(s.id, s.path);
+    reverseCache.set(s.path, s.id);
     const project = s.cwd ? projectByCwd.get(s.cwd) : undefined;
     return {
       path: s.path,
@@ -41,16 +45,21 @@ export async function listAllSessions(): Promise<SessionInfo[]> {
 }
 
 // ============================================================================
-// Session path cache: sessionId → absolute file path
-// Stored in globalThis for hot-reload safety
+// Session path caches, stored in globalThis for hot-reload safety.
 // ============================================================================
 declare global {
   var __piSessionPathCache: Map<string, string> | undefined;
+  var __piPathToIdCache: Map<string, string> | undefined;
 }
 
 function getPathCache(): Map<string, string> {
   if (!globalThis.__piSessionPathCache) globalThis.__piSessionPathCache = new Map();
   return globalThis.__piSessionPathCache;
+}
+
+function getPathToIdCache(): Map<string, string> {
+  if (!globalThis.__piPathToIdCache) globalThis.__piPathToIdCache = new Map();
+  return globalThis.__piPathToIdCache;
 }
 
 export async function resolveSessionPath(sessionId: string): Promise<string | null> {
@@ -62,12 +71,73 @@ export async function resolveSessionPath(sessionId: string): Promise<string | nu
   return getPathCache().get(sessionId) ?? null;
 }
 
+export async function resolveSessionIdByPath(filePath: string): Promise<string | undefined> {
+  const cached = getPathToIdCache().get(filePath);
+  if (cached) return cached;
+
+  // Cold-start fallback: sidebar may not have populated caches yet.
+  await listAllSessions();
+  return getPathToIdCache().get(filePath);
+}
+
 export function cacheSessionPath(sessionId: string, filePath: string): void {
   getPathCache().set(sessionId, filePath);
+  getPathToIdCache().set(filePath, sessionId);
 }
 
 export function invalidateSessionPathCache(sessionId: string): void {
+  const filePath = getPathCache().get(sessionId);
   getPathCache().delete(sessionId);
+  if (filePath && getPathToIdCache().get(filePath) === sessionId) {
+    getPathToIdCache().delete(filePath);
+  }
+}
+
+export function readSessionHeader(filePath: string): SessionHeader | null {
+  const fd = openSync(filePath, "r");
+  try {
+    const chunks: Buffer[] = [];
+    let position = 0;
+    let foundNewline = false;
+    const maxHeaderBytes = 64 * 1024;
+
+    while (position < maxHeaderBytes && !foundNewline) {
+      const buffer = Buffer.alloc(Math.min(4096, maxHeaderBytes - position));
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      const data = buffer.subarray(0, bytesRead);
+      const newline = data.indexOf(0x0a);
+      chunks.push(newline === -1 ? data : data.subarray(0, newline));
+      position += bytesRead;
+      foundNewline = newline !== -1;
+    }
+
+    if (!foundNewline && position >= maxHeaderBytes) {
+      throw new Error(`Session header exceeds ${maxHeaderBytes} bytes`);
+    }
+    const firstLine = Buffer.concat(chunks).toString("utf8").trimEnd();
+    if (!firstLine) return null;
+    const header = JSON.parse(firstLine) as SessionHeader;
+    return header.type === "session" ? header : null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export async function readSessionEntry(filePath: string, entryId: string): Promise<SessionEntry | null> {
+  const input = createReadStream(filePath);
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (!line) continue;
+      const parsed = JSON.parse(line) as SessionHeader | SessionEntry;
+      if (parsed.type !== "session" && parsed.id === entryId) return parsed as SessionEntry;
+    }
+    return null;
+  } finally {
+    lines.close();
+    input.destroy();
+  }
 }
 
 export function getSessionEntries(filePath: string): SessionEntry[] {
@@ -75,7 +145,148 @@ export function getSessionEntries(filePath: string): SessionEntry[] {
   return entries as unknown as SessionEntry[];
 }
 
-export function buildSessionContext(entries: SessionEntry[], leafId?: string | null): SessionContext {
+type EntryLocation = { parentId: string | null; offset: number; length: number };
+
+export interface SessionSnapshot {
+  header: SessionHeader | null;
+  leafId: string | null;
+  name?: string;
+  tree: SessionTreeNode[];
+  branch: SessionEntry[];
+}
+
+function treeEntry(entry: SessionEntry): SessionEntry {
+  const base = {
+    type: entry.type,
+    id: entry.id,
+    parentId: entry.parentId,
+    timestamp: entry.timestamp,
+  };
+  if (entry.type !== "message") return base as SessionEntry;
+  const content = entry.message.content;
+  const preview = typeof content === "string"
+    ? content.slice(0, 41)
+    : Array.isArray(content)
+      ? content
+          .map((block) => {
+            const text = (block as { type?: string; text?: unknown });
+            return text.type === "text" && typeof text.text === "string" ? text.text : "";
+          })
+          .filter(Boolean)
+          .join(" ")
+          .slice(0, 41)
+      : "";
+  return {
+    ...base,
+    message: { role: entry.message.role, content: preview },
+  } as SessionEntry;
+}
+
+/**
+ * Stream a JSONL session once, retaining only tree metadata and byte offsets.
+ * Full message payloads are then read only for the selected root-to-leaf branch.
+ */
+export async function readSessionSnapshot(
+  filePath: string,
+  requestedLeafId?: string | null,
+  includeTree = true,
+): Promise<SessionSnapshot> {
+  let header: SessionHeader | null = null;
+  let leafId: string | null = null;
+  let name: string | undefined;
+  const locations = new Map<string, EntryLocation>();
+  const treeEntries: SessionEntry[] = [];
+  const labels = new Map<string, string>();
+
+  let absoluteOffset = 0;
+  let lineOffset = 0;
+  let fragments: Buffer[] = [];
+
+  const processLine = (line: Buffer, offset: number) => {
+    if (line.length === 0) return;
+    const parsed = JSON.parse(line.toString("utf8").trimEnd()) as SessionHeader | SessionEntry;
+    if (parsed.type === "session") {
+      header = parsed as SessionHeader;
+      return;
+    }
+
+    const entry = parsed as SessionEntry;
+    locations.set(entry.id, { parentId: entry.parentId, offset, length: line.length });
+    leafId = entry.id;
+    if (entry.type === "session_info") name = entry.name?.trim() || undefined;
+    if (entry.type === "label") {
+      if (entry.label) labels.set(entry.targetId, entry.label);
+      else labels.delete(entry.targetId);
+    }
+    if (includeTree) treeEntries.push(treeEntry(entry));
+  };
+
+  for await (const chunkValue of createReadStream(filePath)) {
+    const chunk = chunkValue as Buffer;
+    let segmentStart = 0;
+    for (let i = 0; i < chunk.length; i++) {
+      if (chunk[i] !== 0x0a) continue;
+      const segment = chunk.subarray(segmentStart, i);
+      const line = fragments.length === 0 ? segment : Buffer.concat([...fragments, segment]);
+      processLine(line, lineOffset);
+      fragments = [];
+      segmentStart = i + 1;
+      lineOffset = absoluteOffset + segmentStart;
+    }
+    if (segmentStart < chunk.length) fragments.push(chunk.subarray(segmentStart));
+    absoluteOffset += chunk.length;
+  }
+  if (fragments.length > 0) processLine(Buffer.concat(fragments), lineOffset);
+
+  const targetLeafId = requestedLeafId === undefined ? leafId : requestedLeafId;
+  const branchLocations: EntryLocation[] = [];
+  let currentId = targetLeafId;
+  const seen = new Set<string>();
+  while (currentId && !seen.has(currentId)) {
+    seen.add(currentId);
+    const location = locations.get(currentId);
+    if (!location) break;
+    branchLocations.push(location);
+    currentId = location.parentId;
+  }
+  branchLocations.reverse();
+
+  const branch: SessionEntry[] = [];
+  if (branchLocations.length > 0) {
+    const fd = openSync(filePath, "r");
+    try {
+      for (const location of branchLocations) {
+        const buffer = Buffer.alloc(location.length);
+        const bytesRead = readSync(fd, buffer, 0, location.length, location.offset);
+        branch.push(JSON.parse(buffer.subarray(0, bytesRead).toString("utf8").trimEnd()) as SessionEntry);
+      }
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  const tree: SessionTreeNode[] = [];
+  if (includeTree) {
+    const nodes = new Map<string, SessionTreeNode>();
+    for (const entry of treeEntries) {
+      nodes.set(entry.id, { entry, children: [], label: labels.get(entry.id) });
+    }
+    for (const entry of treeEntries) {
+      const node = nodes.get(entry.id)!;
+      const parent = entry.parentId && entry.parentId !== entry.id ? nodes.get(entry.parentId) : undefined;
+      if (parent) parent.children.push(node);
+      else tree.push(node);
+    }
+  }
+
+  return { header, leafId, name, tree, branch };
+}
+
+export function buildSessionContext(
+  entries: SessionEntry[],
+  leafId?: string | null,
+  options: { deferThinking?: boolean } = {},
+): SessionContext {
   const byId = new Map<string, SessionEntry>();
   for (const e of entries) byId.set(e.id, e);
 
@@ -111,7 +322,7 @@ export function buildSessionContext(entries: SessionEntry[], leafId?: string | n
   const messages: AgentMessage[] = [];
   const entryIds: string[] = [];
   for (const e of path) {
-    const m = entryToUiMessage(e);
+    const m = entryToUiMessage(e, options.deferThinking ?? false);
     if (m) {
       messages.push(m);
       entryIds.push(e.id);
@@ -133,10 +344,20 @@ function parseEntryTimestamp(timestamp: string): number | undefined {
 
 // Convert a session entry on the active branch into a UI message.
 // Returns null for entries that do not map to chat history (metadata, non-message types).
-function entryToUiMessage(entry: SessionEntry): AgentMessage | null {
+function entryToUiMessage(entry: SessionEntry, deferThinking: boolean): AgentMessage | null {
   switch (entry.type) {
-    case "message":
-      return normalizeToolCalls(entry.message);
+    case "message": {
+      const message = normalizeToolCalls(entry.message);
+      if (!deferThinking || message.role !== "assistant") return message;
+      return {
+        ...message,
+        content: message.content.map((block) => (
+          block.type === "thinking"
+            ? { ...block, thinking: "", deferred: true }
+            : block
+        )),
+      };
+    }
     case "compaction":
       return {
         role: "custom",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,8 @@ export interface ImageContent {
 export interface ThinkingContent {
   type: "thinking";
   thinking: string;
+  /** Historical content omitted from initial payload; fetched when expanded. */
+  deferred?: boolean;
 }
 
 export interface ToolCallContent {


### PR DESCRIPTION

Co-author with gpt 5.6-sol:

## Session 加载卡

`app/api/sessions/[id]/route.ts` + `lib/session-reader.ts`。

- [x] **详情路由去掉冗余 `listAllSessions()`**。每次 GET 跑 N 次 `git -C cwd rev-parse`，只为算一个 `parentSessionId`。直接从 session JSONL 第一行读 `parentSession` 路径，反向查 id。
- [x] **加 `pathToId` 反向 cache**。代码里只有 `id → path` 单向 `getPathCache()`。新加 `globalThis.__piPathToIdCache`，sidebar 调 `/api/sessions` 时填，session 增删时同步失效。
- [x] **`readFileSync` 改 `openSync` + 小 buffer**。10MB JSONL 整文件加载浪费。只读首 4KB 找第一个 `\n`。
- [x] **冷启动兜底**。sidebar 未 mount 时 cache 空，回退到一次 `listAllSessions()` 填 cache（不可避免的一次）。
- [x] **大 JSONL 流式读 leaf path**。`SessionManager.open().getEntries()` 每次全 parse，大文件（1 万+ entry）占 80% 时间。改成 `readline` 流式解析，仅收集 leaf path 上 entries。**最大单一瓶颈**，优先级最高。
- [x] **拆 `agentState` 独立路由**。`?includeState=true` 时 `rpc.send({type:"get_state"})` 阻塞响应。新建 `app/api/sessions/[id]/state/route.ts`，前端先 `setLoading(false)` 显示消息，再异步填 `thinkingLevel` / `queuedMessages`。
- [x] **`setLoading(false)` 提前**。`hooks/useAgentSession.ts` `loadSession` finally 包含 agentState 解析。挪到 messages setData 之后立即触发，agentState 异步填。

## 历史图片 base64 清理（已完成）

`lib/session-reader.ts` + `~/.pi/agent/sessions/**/*.jsonl` + pi agent image extension。

- [x] **定位 session 加载慢主因**。目标 session 后端读取约 0.1s，但 `/api/sessions/[id]?deferThinking` 响应体约 6.7MB；大头是 `toolResult.content` 中的 base64 图片，而非 JSONL 流式解析或 `agentState`。
- [x] **pi-web 代码端过滤历史内嵌图片**。仅在 `deferThinking` 历史加载响应中移除 user / toolResult 等消息里的 base64 image block，并替换为小文本占位；不改写 session JSONL，因此不影响 pi agent 后续模型 context。
- [x] **删除 `image-inject.ts` 扩展**。已删除 `~/.pi/agent/extensions/image-inject.ts`，避免其继续扫描所有 `tool_result` 文本并自动注入 base64 图片。已运行的 pi / pi-web 会话需 `/reload` 或重启后彻底失效。
- [x] **清理历史 session 文件**。扫描 `~/.pi/agent/sessions/**/*.jsonl`，修改 26/109 个文件；删除/替换 215 个 base64 image block，重写 6 处 `data:image/...;base64,...`；总大小约 158.7MB → 31.8MB。
- [x] **校验清理结果**。`files_with_base64_img=0`，`json_errors=0`；目标 session 响应体降至约 288KB，接口耗时约 0.012s。

## 历史 Thinking 延迟加载（已完成）

- [x] **初始加载不传输 thinking 正文**。历史消息仅返回占位符，减少响应体与 React state 占用。
- [x] **点击后按需加载**。新增 thinking block 独立接口，按 `sessionId + entryId + blockIndex` 读取正文。
- [x] **前端缓存**。缓存最近 100 个已加载 thinking block，避免重复请求。
- [x] **保留实时 thinking**。新对话流式输出继续实时渲染；历史分支仍采用延迟加载。
- [x] **补充测试**。覆盖历史占位符、空 thinking 显示及实时 thinking 保留行为。
