### PR TITLE
fix: normalize tool call blocks in API-loaded messages

### DIFF
--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -11,6 +11,13 @@ import type {
 } from "@/lib/types";
 import { normalizeToolCalls } from "@/lib/normalize";
 import { sendAgentCommand } from "@/lib/agent-client";
+
+/** Normalize tool call blocks in messages loaded from the API.
+ * The API returns blocks with id/name/arguments, but components expect
+ * toolCallId/toolName/input. Without this, isEditToolName() crashes on undefined. */
+function normalizeMessages(msgs: AgentMessage[]): AgentMessage[] {
+  return msgs.map(normalizeToolCalls);
+}
 import { getToolNamesForPreset, type ToolEntry } from "@/lib/tool-presets";
 import type { SessionStatsInfo } from "@/lib/pi-types";
 
@@ -443,7 +450,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const d = await res.json() as SessionData & { agentState?: { running: boolean; state?: AgentStateResponse } };
       setData(d);
       setActiveLeafId(d.leafId);
-      setMessages(d.context.messages);
+      setMessages(normalizeMessages(d.context.messages));
       setEntryIds(d.context.entryIds ?? []);
       setCurrentModelOverride(null);
       setError(null);
@@ -478,7 +485,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const res = await fetch(url);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const d = await res.json() as { context: { messages: AgentMessage[]; entryIds: string[] } };
-      setMessages(d.context.messages);
+      setMessages(normalizeMessages(d.context.messages));
       setEntryIds(d.context.entryIds ?? []);
     } catch (e) {
       console.error("Failed to load context:", e);


### PR DESCRIPTION
## Problem

The API returns tool call blocks with `id`/`name`/`arguments` fields, but UI components expect `toolCallId`/`toolName`/`input`. This causes `isEditToolName(undefined)` to crash when expanding Process Details (the function calls `.toLowerCase()` on `undefined`).

## Root Cause

`normalizeToolCalls` was only applied to streaming/completed messages, but not to messages loaded from the API via `setMessages(d.context.messages)`.

## Fix

Added `normalizeMessages()` helper that applies `normalizeToolCalls` to all messages loaded from the API (initial load and context reload).

## Testing

- TypeScript compilation passes
- Process Details expand/collapse works without crash
- Tool call blocks render correctly with normalized fields