### PR TITLE
fix: disable single-dollar math rendering

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -14,7 +14,7 @@ const markdownSanitizeSchema = {
   strip: [...(defaultSchema.strip || []), "iframe", "object", "style", "form"],
 };
 
-export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
+export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, [remarkMath, { singleDollarTextMath: false }]];
 export const markdownPreviewRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm];
 
 export const markdownRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [


### PR DESCRIPTION
## Problem

`remarkMath` defaults to interpreting single dollar signs (`$`) as math delimiters, which breaks text containing currency values like `$10`. These get rendered as inline math instead of plain text.

## Fix

Set `singleDollarTextMath: false` so only double-dollar (`$$`) triggers math rendering, while single dollar signs are treated as literal text.