### PR TITLE
fix: fall back to cwd when __dirname is unavailable in Next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,18 @@ import type { NextConfig } from "next";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")) as { version: string };
+const appRoot = (() => {
+  try {
+    return __dirname;
+  } catch {
+    return process.cwd();
+  }
+})();
+
+const { version } = JSON.parse(readFileSync(join(appRoot, "package.json"), "utf8")) as { version: string };
 let piVersion = "unknown";
 try {
-  const piPkgPath = join(__dirname, "node_modules/@earendil-works/pi-coding-agent/package.json");
+  const piPkgPath = join(appRoot, "node_modules/@earendil-works/pi-coding-agent/package.json");
   piVersion = (JSON.parse(readFileSync(piPkgPath, "utf8")) as { version: string }).version;
 } catch { /* package not found, use default */ }
 


### PR DESCRIPTION
Fixes #145

## Summary

Preserve the existing `__dirname` behavior in `next.config.ts` and fall back to `process.cwd()` only when the config loader does not provide `__dirname`.

This prevents configuration evaluation from failing in ESM-like loading environments while preserving the existing CommonJS path resolution in normal environments.

## 中文说明

保留 `next.config.ts` 中原有的 `__dirname` 行为；仅当配置加载器未提供该变量、访问它抛出异常时，回退到 `process.cwd()`。

这避免了 ESM 类配置加载环境因 `__dirname` 缺失而无法加载配置，同时不改变正常 CommonJS 环境中的路径解析行为。

## Changes

- Add an `appRoot` compatibility resolver.
- Continue using `__dirname` when it is available.
- Use `process.cwd()` only as the fallback.
- Use `appRoot` for pi-web and bundled `pi-coding-agent` package metadata paths.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- ESM fallback-path check
- Fresh-cache package installation check
- Packaged CLI startup check
- `GET /` returned HTTP 200

## Scope

This is a compatibility hardening change only. It does not modify package metadata, lockfiles, shrinkwrap files, or npm dependency-resolution behavior.