### PR TITLE
perf: add 30s TTL cache for listAllSessions 

### DIFF
--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
 import { allowFileRoot } from "@/lib/file-access";
+import { invalidateSessionListCache } from "@/lib/session-reader";
 import { startRpcSession } from "@/lib/rpc-manager";
-
 // POST /api/agent/new  body: { cwd: string; type: string; message?: string; ... }
 // Spawns a brand-new pi session. Most calls immediately send the first command;
 // type:"ensure_session" only creates the runtime so clients can query commands.
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
     // in sync so the new cwd is immediately readable via /api/files. Without this,
     // a file request under a brand-new cwd would 403 for up to the cache TTL.
     allowFileRoot(cwd);
+    invalidateSessionListCache();
 
     // Apply pre-selected model before sending the prompt
     if (provider && modelId) {

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   resolveSessionPath,
   resolveSessionIdByPath,
   invalidateSessionPathCache,
+  invalidateSessionListCache,
   buildSessionContext,
   readSessionHeader,
 } from "@/lib/session-reader";
@@ -185,6 +186,7 @@ export async function PATCH(
     }
     const sm = SessionManager.open(filePath);
     sm.appendSessionInfo(name.trim());
+    invalidateSessionListCache();
     return NextResponse.json({ ok: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
@@ -230,6 +232,7 @@ export async function DELETE(
     getRpcSession(id)?.destroy();
     unlinkSync(filePath);
     invalidateSessionPathCache(id);
+    invalidateSessionListCache();
     return NextResponse.json({ ok: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,7 +1,7 @@
 import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
-import { cacheSessionPath } from "./session-reader";
+import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
 import type { ExtensionUiRequest, ExtensionUiResponse, ExtensionWidgetItem } from "./types";
@@ -140,6 +140,9 @@ export class AgentSessionWrapper {
   start(): void {
     this.unsubscribe = this.inner.subscribe((event: AgentEvent) => {
       this.resetIdleTimer();
+      if (event.type === "agent_end") {
+        invalidateSessionListCache();
+      }
       this.emit(event);
       // Streaming / compaction / tool events flow through here; re-broadcast
       // the running-status snapshot so the sidebar can update live.
@@ -287,6 +290,7 @@ export class AgentSessionWrapper {
           notifyRunningChange();
         }).catch((error) => {
           this.promptRunning = false;
+          invalidateSessionListCache();
           this.emit({
             type: "prompt_error",
             errorMessage: error instanceof Error ? error.message : String(error),
@@ -335,6 +339,7 @@ export class AgentSessionWrapper {
         const model = registry.find(provider, modelId);
         if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
         await this.inner.setModel(model);
+        invalidateSessionListCache();
         return { id: model.id, provider: model.provider };
       }
 
@@ -367,6 +372,7 @@ export class AgentSessionWrapper {
 
         const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
         cacheSessionPath(newSessionId, newSessionFile);
+        invalidateSessionListCache();
         this.destroy();
         return { cancelled: false, newSessionId };
       }
@@ -385,20 +391,25 @@ export class AgentSessionWrapper {
         if (level === "xhigh" && (this.inner.model as { compat?: { thinkingFormat?: string } } | null)?.compat?.thinkingFormat === "deepseek" && this.inner.agent?.state) {
           this.inner.agent.state.thinkingLevel = "xhigh";
         }
+        invalidateSessionListCache();
         return null;
       }
 
       case "compact": {
-        const result = await this.withFinalRunningNotification(() =>
-          this.inner.compact(command.customInstructions as string | undefined)
-        );
-        return result;
+        try {
+          return await this.withFinalRunningNotification(() =>
+            this.inner.compact(command.customInstructions as string | undefined)
+          );
+        } finally {
+          invalidateSessionListCache();
+        }
       }
 
       case "set_session_name": {
         const name = (command.name as string | undefined)?.trim();
         if (!name) throw new Error("Session name cannot be empty");
         this.inner.setSessionName(name);
+        invalidateSessionListCache();
         return null;
       }
 

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -46,10 +46,20 @@ async function loadAllSessions(): Promise<SessionInfo[]> {
 }
 
 export async function listAllSessions(): Promise<SessionInfo[]> {
+  // Return cached result if still fresh (avoids re-scanning session files
+  // and re-spawning git processes on every page load).
+  if (globalThis.__piSessionListCache && Date.now() - globalThis.__piSessionListCache.ts < SESSION_LIST_CACHE_TTL_MS) {
+    return globalThis.__piSessionListCache.data;
+  }
+
+  // Coalescing dedup: concurrent callers share the same in-flight promise
   globalThis.__piSessionListPromise ??= loadAllSessions().finally(() => {
     globalThis.__piSessionListPromise = undefined;
   });
-  return globalThis.__piSessionListPromise;
+  const data = await globalThis.__piSessionListPromise;
+
+  globalThis.__piSessionListCache = { data, ts: Date.now() };
+  return data;
 }
 
 // ============================================================================
@@ -59,6 +69,13 @@ declare global {
   var __piSessionPathCache: Map<string, string> | undefined;
   var __piPathToSessionIdCache: Map<string, string> | undefined;
   var __piSessionListPromise: Promise<SessionInfo[]> | undefined;
+  var __piSessionListCache: { data: SessionInfo[]; ts: number } | undefined;
+}
+
+const SESSION_LIST_CACHE_TTL_MS = 30_000;
+
+export function invalidateSessionListCache(): void {
+  globalThis.__piSessionListCache = undefined;
 }
 
 function getPathCache(): Map<string, string> {

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -46,6 +46,8 @@ async function loadAllSessions(): Promise<SessionInfo[]> {
 }
 
 export async function listAllSessions(): Promise<SessionInfo[]> {
+  const generation = globalThis.__piSessionListGeneration ?? 0;
+
   // Return cached result if still fresh (avoids re-scanning session files
   // and re-spawning git processes on every page load).
   if (globalThis.__piSessionListCache && Date.now() - globalThis.__piSessionListCache.ts < SESSION_LIST_CACHE_TTL_MS) {
@@ -53,13 +55,29 @@ export async function listAllSessions(): Promise<SessionInfo[]> {
   }
 
   // Coalescing dedup: concurrent callers share the same in-flight promise
-  globalThis.__piSessionListPromise ??= loadAllSessions().finally(() => {
-    globalThis.__piSessionListPromise = undefined;
-  });
-  const data = await globalThis.__piSessionListPromise;
+  // only while it belongs to the current cache generation.
+  if (globalThis.__piSessionListPromise && globalThis.__piSessionListPromiseGeneration === generation) {
+    return globalThis.__piSessionListPromise;
+  }
 
-  globalThis.__piSessionListCache = { data, ts: Date.now() };
-  return data;
+  const loadPromise = loadAllSessions().then((data) => {
+    // An invalidation may happen while the scan is in flight. Do not let that
+    // older result repopulate the cache after a session mutation.
+    if ((globalThis.__piSessionListGeneration ?? 0) === generation) {
+      globalThis.__piSessionListCache = { data, ts: Date.now() };
+    }
+    return data;
+  });
+  const trackedPromise = loadPromise.finally(() => {
+    if (globalThis.__piSessionListPromise === trackedPromise) {
+      globalThis.__piSessionListPromise = undefined;
+      globalThis.__piSessionListPromiseGeneration = undefined;
+    }
+  });
+
+  globalThis.__piSessionListPromise = trackedPromise;
+  globalThis.__piSessionListPromiseGeneration = generation;
+  return trackedPromise;
 }
 
 // ============================================================================
@@ -69,12 +87,15 @@ declare global {
   var __piSessionPathCache: Map<string, string> | undefined;
   var __piPathToSessionIdCache: Map<string, string> | undefined;
   var __piSessionListPromise: Promise<SessionInfo[]> | undefined;
+  var __piSessionListPromiseGeneration: number | undefined;
+  var __piSessionListGeneration: number | undefined;
   var __piSessionListCache: { data: SessionInfo[]; ts: number } | undefined;
 }
 
 const SESSION_LIST_CACHE_TTL_MS = 30_000;
 
 export function invalidateSessionListCache(): void {
+  globalThis.__piSessionListGeneration = (globalThis.__piSessionListGeneration ?? 0) + 1;
   globalThis.__piSessionListCache = undefined;
 }
 


### PR DESCRIPTION
## PR 描述

### Summary

为 `listAllSessions` 添加 30 秒 TTL 内存缓存，避免每次页面加载重复扫描 session 文件目录和启动 git 进程。

### Problem

每次 pi-web 页面加载或刷新时，`listAllSessions` 都会：

1. 遍历 session 文件目录、读取文件头
2. 为每个 session 执行 `git` 命令获取分支信息

在 session 数量较多时（几十上百个），这些操作在每次请求中重复执行，造成不必要的延迟。

### Solution

在 `globalThis.__piSessionListCache` 中缓存已加载的 session 列表：

- **TTL 30s**：30 秒内的重复调用直接返回缓存，零 I/O
- **Coalescing**：并发调用共享同一个 in-flight Promise，不会重复发起加载
- **主动失效**：创建/重命名/删除 session 时立即调用 `invalidateSessionListCache()` 使缓存失效，保证数据一致

### Changes

| 文件 | 改动 |
|------|------|
| `lib/session-reader.ts` | 新增 `__piSessionListCache` 缓存、30s TTL 常量、`invalidateSessionListCache()` 导出函数 |
| `app/api/agent/new/route.ts` | 创建新 session 后调用 `invalidateSessionListCache()` |
| `app/api/sessions/[id]/route.ts` | 重命名/删除 session 后调用 `invalidateSessionListCache()` |

### Performance Impact

- 首次加载后 30s 内重复访问 session 列表：从 N 次文件 I/O + N 次 git 调用降为 0（内存读取）
- Session 变更（新建/重命名/删除）时立即失效，不存在数据不一致窗口