### PR TITLE
perf: add 60s TTL cache for /api/models to avoid re-initializing SDK services

### DIFF
--- a/app/api/auth/api-key/[provider]/route.ts
+++ b/app/api/auth/api-key/[provider]/route.ts
@@ -1,5 +1,6 @@
 import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { NextResponse } from "next/server";
+import { invalidateModelsCache } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,7 @@ export async function POST(req: Request, { params }: Params) {
     }
     const authStorage = AuthStorage.create();
     authStorage.set(provider, { type: "api_key", key: apiKey.trim() });
+    invalidateModelsCache();
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
@@ -38,6 +40,7 @@ export async function DELETE(_req: Request, { params }: Params) {
   try {
     const authStorage = AuthStorage.create();
     authStorage.remove(provider);
+    invalidateModelsCache();
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });

--- a/app/api/auth/login/[provider]/route.ts
+++ b/app/api/auth/login/[provider]/route.ts
@@ -1,4 +1,5 @@
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { invalidateModelsCache } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -170,6 +171,7 @@ export async function GET(
           signal: abort.signal,
         });
 
+        invalidateModelsCache();
         send(controller, { type: "success" });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/app/api/auth/logout/[provider]/route.ts
+++ b/app/api/auth/logout/[provider]/route.ts
@@ -1,4 +1,5 @@
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { invalidateModelsCache } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -13,5 +14,6 @@ export async function POST(
     return Response.json({ error: `Unknown provider: ${provider}` }, { status: 400 });
   }
   authStorage.logout(provider);
+  invalidateModelsCache();
   return Response.json({ ok: true });
 }

--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { invalidateModelsCache } from "../models/route";
 
 export const dynamic = "force-dynamic";
 
@@ -34,7 +35,7 @@ export async function PUT(req: Request) {
   try {
     const body = await req.json() as Record<string, unknown>;
     writeModelsJson(body);
-    // Model registry refreshes on each /api/models request (no local cache to invalidate)
+    invalidateModelsCache();
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });

--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { invalidateModelsCache } from "../models/route";
+import { invalidateModelsCache } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
 

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -4,6 +4,13 @@ import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 
 export const dynamic = "force-dynamic";
 
+// TTL cache keyed by cwd, invalidated when models.json is written
+let modelsCache: { data: Record<string, unknown>; ts: number; cwd: string } | null = null;
+const MODELS_CACHE_TTL_MS = 60_000;
+
+export function invalidateModelsCache(): void {
+  modelsCache = null;
+}
 const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 function compareModelEntries(
@@ -54,6 +61,12 @@ export async function GET(req: Request) {
     return Response.json({ error: `Not a directory: ${cwd}` }, { status: 400 });
   }
 
+  // Return cached result if TTL hasn't expired (models are global config,
+  // re-initializing the SDK service layer on every request is wasteful).
+  if (modelsCache && modelsCache.cwd === cwd && Date.now() - modelsCache.ts < MODELS_CACHE_TTL_MS) {
+    return Response.json(modelsCache.data);
+  }
+
   try {
     const agentDir = getAgentDir();
     const services = await createAgentSessionServices({ cwd, agentDir });
@@ -81,5 +94,7 @@ export async function GET(req: Request) {
     }
   } catch { /* return empty */ }
 
-  return Response.json({ models: Object.fromEntries(nameMap), modelList, defaultModel, thinkingLevels, thinkingLevelMaps });
+  const data = { models: Object.fromEntries(nameMap), modelList, defaultModel, thinkingLevels, thinkingLevelMaps };
+  modelsCache = { data, ts: Date.now(), cwd };
+  return Response.json(data);
 }

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,16 +1,11 @@
 import { stat } from "fs/promises";
+import { resolve } from "path";
 import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { loadModelsWithCache, type ModelsData } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
 
-// TTL cache keyed by cwd, invalidated when models.json is written
-let modelsCache: { data: Record<string, unknown>; ts: number; cwd: string } | null = null;
-const MODELS_CACHE_TTL_MS = 60_000;
-
-export function invalidateModelsCache(): void {
-  modelsCache = null;
-}
 const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 function compareModelEntries(
@@ -43,13 +38,52 @@ function filterByExactEnabledModels<T extends { id: string; provider: string }>(
   return visible.length > 0 ? visible : available;
 }
 
-export async function GET(req: Request) {
+async function loadModels(cwd: string): Promise<ModelsData> {
   const nameMap = new Map<string, string>();
   let modelList: { id: string; name: string; provider: string }[] = [];
   let defaultModel: { provider: string; modelId: string } | null = null;
   const thinkingLevels: Record<string, string[]> = {};
   const thinkingLevelMaps: Record<string, Record<string, string | null>> = {};
-  const cwd = new URL(req.url).searchParams.get("cwd") || process.cwd();
+
+  const agentDir = getAgentDir();
+  const services = await createAgentSessionServices({ cwd, agentDir });
+  const registry = services.modelRegistry;
+  const available = registry.getAvailable();
+  const settings: SettingsManager = services.settingsManager;
+  const enabledModels = settings.getEnabledModels();
+  const visible = filterByExactEnabledModels(available, enabledModels);
+  modelList = visible.map((m: { id: string; name: string; provider: string }) => ({
+    id: m.id,
+    name: m.name,
+    provider: m.provider,
+  })).sort(compareModelEntries);
+  for (const m of visible) {
+    const key = `${m.provider}:${m.id}`;
+    nameMap.set(key, m.name);
+    thinkingLevels[key] = getSupportedThinkingLevels(m);
+    if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
+  }
+
+  const provider = settings.getDefaultProvider();
+  const modelId = settings.getDefaultModel();
+  if (provider && modelId && visible.some((m) => m.provider === provider && m.id === modelId)) {
+    defaultModel = { provider, modelId };
+  }
+
+  return { models: Object.fromEntries(nameMap), modelList, defaultModel, thinkingLevels, thinkingLevelMaps };
+}
+
+const EMPTY_MODELS: ModelsData = {
+  models: {},
+  modelList: [],
+  defaultModel: null,
+  thinkingLevels: {},
+  thinkingLevelMaps: {},
+};
+
+export async function GET(req: Request) {
+  const requestedCwd = new URL(req.url).searchParams.get("cwd") || process.cwd();
+  const cwd = resolve(requestedCwd);
 
   let cwdStat;
   try {
@@ -61,40 +95,9 @@ export async function GET(req: Request) {
     return Response.json({ error: `Not a directory: ${cwd}` }, { status: 400 });
   }
 
-  // Return cached result if TTL hasn't expired (models are global config,
-  // re-initializing the SDK service layer on every request is wasteful).
-  if (modelsCache && modelsCache.cwd === cwd && Date.now() - modelsCache.ts < MODELS_CACHE_TTL_MS) {
-    return Response.json(modelsCache.data);
-  }
-
   try {
-    const agentDir = getAgentDir();
-    const services = await createAgentSessionServices({ cwd, agentDir });
-    const registry = services.modelRegistry;
-    const available = registry.getAvailable();
-    const settings: SettingsManager = services.settingsManager;
-    const enabledModels = settings.getEnabledModels();
-    const visible = filterByExactEnabledModels(available, enabledModels);
-    modelList = visible.map((m: { id: string; name: string; provider: string }) => ({
-      id: m.id,
-      name: m.name,
-      provider: m.provider,
-    })).sort(compareModelEntries);
-    for (const m of visible) {
-      const key = `${m.provider}:${m.id}`;
-      nameMap.set(key, m.name);
-      thinkingLevels[key] = getSupportedThinkingLevels(m);
-      if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
-    }
-
-    const provider = settings.getDefaultProvider();
-    const modelId = settings.getDefaultModel();
-    if (provider && modelId && visible.some((m) => m.provider === provider && m.id === modelId)) {
-      defaultModel = { provider, modelId };
-    }
-  } catch { /* return empty */ }
-
-  const data = { models: Object.fromEntries(nameMap), modelList, defaultModel, thinkingLevels, thinkingLevelMaps };
-  modelsCache = { data, ts: Date.now(), cwd };
-  return Response.json(data);
+    return Response.json(await loadModelsWithCache(cwd, () => loadModels(cwd)));
+  } catch {
+    return Response.json(EMPTY_MODELS);
+  }
 }

--- a/lib/models-cache.test.mjs
+++ b/lib/models-cache.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { invalidateModelsCache, loadModelsWithCache } from "./models-cache.ts";
+
+function modelsData(id) {
+  return {
+    models: { [`provider:${id}`]: id },
+    modelList: [{ id, name: id, provider: "provider" }],
+    defaultModel: null,
+    thinkingLevels: {},
+    thinkingLevelMaps: {},
+  };
+}
+
+test("caches model data independently for each cwd", async () => {
+  invalidateModelsCache();
+  let firstLoads = 0;
+  let secondLoads = 0;
+
+  const first = await loadModelsWithCache("/first", async () => {
+    firstLoads += 1;
+    return modelsData("first");
+  });
+  await loadModelsWithCache("/second", async () => {
+    secondLoads += 1;
+    return modelsData("second");
+  });
+  const firstAgain = await loadModelsWithCache("/first", async () => {
+    firstLoads += 1;
+    return modelsData("replacement");
+  });
+
+  assert.deepEqual(firstAgain, first);
+  assert.equal(firstLoads, 1);
+  assert.equal(secondLoads, 1);
+});
+
+test("shares one loader between concurrent requests for the same cwd", async () => {
+  invalidateModelsCache();
+  let loads = 0;
+  let finishLoad;
+  const loader = () => {
+    loads += 1;
+    return new Promise((resolve) => { finishLoad = resolve; });
+  };
+
+  const first = loadModelsWithCache("/shared", loader);
+  const second = loadModelsWithCache("/shared", loader);
+  await Promise.resolve();
+
+  assert.equal(loads, 1);
+  finishLoad(modelsData("shared"));
+  assert.deepEqual(await second, await first);
+});
+
+test("does not cache a stale load that finishes after invalidation", async () => {
+  invalidateModelsCache();
+  let finishOldLoad;
+  const oldLoad = loadModelsWithCache("/stale", () => new Promise((resolve) => { finishOldLoad = resolve; }));
+  await Promise.resolve();
+
+  invalidateModelsCache();
+  let freshLoads = 0;
+  const fresh = await loadModelsWithCache("/stale", async () => {
+    freshLoads += 1;
+    return modelsData("fresh");
+  });
+  finishOldLoad(modelsData("stale"));
+  await oldLoad;
+
+  const cached = await loadModelsWithCache("/stale", async () => {
+    freshLoads += 1;
+    return modelsData("unexpected");
+  });
+  assert.deepEqual(cached, fresh);
+  assert.equal(freshLoads, 1);
+});
+
+test("retries after a model load fails", async () => {
+  invalidateModelsCache();
+  await assert.rejects(
+    loadModelsWithCache("/failed", async () => { throw new Error("load failed"); }),
+    /load failed/,
+  );
+
+  let retries = 0;
+  const fresh = await loadModelsWithCache("/failed", async () => {
+    retries += 1;
+    return modelsData("fresh");
+  });
+  assert.deepEqual(fresh, modelsData("fresh"));
+  assert.equal(retries, 1);
+});

--- a/lib/models-cache.ts
+++ b/lib/models-cache.ts
@@ -1,0 +1,75 @@
+export interface ModelsData {
+  models: Record<string, string>;
+  modelList: { id: string; name: string; provider: string }[];
+  defaultModel: { provider: string; modelId: string } | null;
+  thinkingLevels: Record<string, string[]>;
+  thinkingLevelMaps: Record<string, Record<string, string | null>>;
+}
+
+interface ModelsCacheState {
+  entries: Map<string, { data: ModelsData; expiresAt: number }>;
+  inFlight: Map<string, Promise<ModelsData>>;
+  generation: number;
+}
+
+declare global {
+  var __piModelsCacheState: ModelsCacheState | undefined;
+}
+
+const MODELS_CACHE_TTL_MS = 60_000;
+const MAX_MODELS_CACHE_ENTRIES = 32;
+
+function getModelsCacheState(): ModelsCacheState {
+  if (!globalThis.__piModelsCacheState) {
+    globalThis.__piModelsCacheState = {
+      entries: new Map(),
+      inFlight: new Map(),
+      generation: 0,
+    };
+  }
+  return globalThis.__piModelsCacheState;
+}
+
+export function invalidateModelsCache(): void {
+  const state = getModelsCacheState();
+  state.generation += 1;
+  state.entries.clear();
+  state.inFlight.clear();
+}
+
+export function loadModelsWithCache(cwd: string, loader: () => Promise<ModelsData>): Promise<ModelsData> {
+  const state = getModelsCacheState();
+  const cached = state.entries.get(cwd);
+  if (cached) {
+    if (cached.expiresAt > Date.now()) return Promise.resolve(cached.data);
+    state.entries.delete(cwd);
+  }
+
+  const existingLoad = state.inFlight.get(cwd);
+  if (existingLoad) return existingLoad;
+
+  const generation = state.generation;
+  const loadPromise: Promise<ModelsData> = Promise.resolve()
+    .then(loader)
+    .then((data) => {
+      if (state.generation === generation && state.inFlight.get(cwd) === loadPromise) {
+        const now = Date.now();
+        for (const [key, entry] of state.entries) {
+          if (entry.expiresAt <= now) state.entries.delete(key);
+        }
+        while (state.entries.size >= MAX_MODELS_CACHE_ENTRIES) {
+          const oldestKey = state.entries.keys().next().value;
+          if (oldestKey === undefined) break;
+          state.entries.delete(oldestKey);
+        }
+        state.entries.set(cwd, { data, expiresAt: now + MODELS_CACHE_TTL_MS });
+      }
+      return data;
+    })
+    .finally(() => {
+      if (state.inFlight.get(cwd) === loadPromise) state.inFlight.delete(cwd);
+    });
+
+  state.inFlight.set(cwd, loadPromise);
+  return loadPromise;
+}

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,6 +1,7 @@
 import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
+import { invalidateModelsCache } from "./models-cache";
 import { cacheSessionPath } from "./session-reader";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
@@ -335,6 +336,7 @@ export class AgentSessionWrapper {
         const model = registry.find(provider, modelId);
         if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
         await this.inner.setModel(model);
+        invalidateModelsCache();
         return { id: model.id, provider: model.provider };
       }
 


### PR DESCRIPTION
## Summary

为 `/api/models` 添加 60 秒 TTL 缓存，避免重复初始化 SDK service 层，同时保证认证、模型配置和默认模型变更立即生效。

## Implementation

- 使用共享的 `lib/models-cache.ts`，按规范化 `cwd` 缓存，最多保留 32 个条目
- 同一 `cwd` 的并发冷请求复用一个初始化 Promise
- 通过 generation 防止失效前启动的旧请求在完成后重新写入缓存
- 加载失败不做负缓存，下一次请求会重试
- 以下变更会立即清空缓存：
  - PUT `/api/models-config`
  - API Key 新增或删除
  - OAuth 登录成功或退出
  - `set_model` 更新默认模型

## Validation

- `next typegen`
- `tsc --noEmit`
- `npm run lint`
- 68 个 Node 测试通过
- 隔离 HOME 运行时验证：API Key 新增/删除与默认模型切换后，下一次 `/api/models` 请求立即返回最新结果

未运行 `next build`，遵循仓库开发说明。