### PR TITLE
perf: parallelize checkCwdAllowed and resolveProject in /api/worktrees

### DIFF
--- a/app/api/worktrees/route.ts
+++ b/app/api/worktrees/route.ts
@@ -20,10 +20,12 @@ export async function GET(req: Request) {
     if (!cwd) {
       return NextResponse.json({ error: "cwd is required" }, { status: 400 });
     }
-    const denied = await checkCwdAllowed(cwd);
+    const [denied, project] = await Promise.all([
+      checkCwdAllowed(cwd),
+      resolveProject(cwd),
+    ]);
     if (denied) return denied;
 
-    const project = await resolveProject(cwd);
     let worktrees: Awaited<ReturnType<typeof listWorktrees>> = [];
     let isGit = true;
     try {


### PR DESCRIPTION
## PR 描述

### Summary

将 `/api/worktrees` 接口中的 `checkCwdAllowed` 和 `resolveProject` 从串行改为 `Promise.all` 并行执行。

### Problem

这两个调用相互独立，`resolveProject` 不依赖 `checkCwdAllowed` 的结果。串行执行时总耗时 = 两者之和。改为并行后总耗时 = max(两者)。

### Before / After

**Before**（串行，~2 次 RTT）：
```ts
const denied = await checkCwdAllowed(cwd);
if (denied) return denied;
const project = await resolveProject(cwd);
```

**After**（并行，~1 次 RTT）：
```ts
const [denied, project] = await Promise.all([
  checkCwdAllowed(cwd),
  resolveProject(cwd),
]);
if (denied) return denied;
```

### Changes

| 文件 | 改动 |
|------|------|
| `app/api/worktrees/route.ts` | `checkCwdAllowed` 和 `resolveProject` 改为 `Promise.all` 并行 |

### Performance Impact

- 两个独立异步操作的执行时间从累加变为取最大值
- 典型场景下减少一次网络/磁盘往返延迟