### PR TITLE
perf: throttle ChatMinimap DOM measurement, memoize components, and lazy-load historical messages

### DIFF
--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -146,22 +146,36 @@ export function ChatMinimap({ messages, streamingMessage, scrollContainer, messa
     return () => el.removeEventListener("scroll", updateScroll);
   }, [scrollContainer, updateScroll]);
 
-  // 内容高度变化时触发节点测量
+  // Keep both node positions and viewport ratios in sync with layout changes.
   useEffect(() => {
     const el = scrollContainer.current;
     if (!el) return;
-    const ro = new ResizeObserver(measureNodes);
+    const syncLayout = () => {
+      updateScroll();
+      measureNodes();
+    };
+    const ro = new ResizeObserver(syncLayout);
     ro.observe(el);
     // Also observe the scroll content for height changes
     if (el.firstElementChild) ro.observe(el.firstElementChild);
-    return () => ro.disconnect();
-  }, [scrollContainer, measureNodes]);
+    syncLayout();
+    return () => {
+      ro.disconnect();
+      if (measureThrottleRef.current) {
+        clearTimeout(measureThrottleRef.current);
+        measureThrottleRef.current = null;
+      }
+    };
+  }, [scrollContainer, measureNodes, updateScroll]);
 
-  // 消息数量变化时触发节点测量（带 50ms 防抖等待 DOM 渲染完成）
+  // Wait briefly for new message DOM before syncing layout.
   useEffect(() => {
-    const t = setTimeout(measureNodes, 50);
+    const t = setTimeout(() => {
+      updateScroll();
+      measureNodes();
+    }, 50);
     return () => clearTimeout(t);
-  }, [messages.length, measureNodes]);
+  }, [messages.length, measureNodes, updateScroll]);
 
   const scrollToMinimapRatio = useCallback((viewportTopRatio: number) => {
     const el = scrollContainer.current;

--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -81,15 +81,13 @@ export function ChatMinimap({ messages, streamingMessage, scrollContainer, messa
   const allMessagesRef = useRef(allMessages);
   allMessagesRef.current = allMessages;
 
-  const updatePositionsRef = useRef<() => void>(null!);
-  updatePositionsRef.current = () => {
+  // --- 仅更新视口比例，不读取 DOM ---
+  const updateScroll = useCallback(() => {
     const scrollEl = scrollContainer.current;
     if (!scrollEl) return;
-
     const totalH = scrollEl.scrollHeight;
     const clientH = scrollEl.clientHeight;
     const scrollable = totalH - clientH;
-
     setVisible(scrollable > 20);
     if (scrollable <= 0) {
       setScrollRatio(0);
@@ -98,60 +96,72 @@ export function ChatMinimap({ messages, streamingMessage, scrollContainer, messa
       setScrollRatio(scrollEl.scrollTop / scrollable);
       setViewportRatio(clientH / totalH);
     }
+  }, [scrollContainer]);
 
-    // Build node positions from real DOM refs
-    const refs = messageRefs.current;
-    const newNodes: NodeInfo[] = [];
-    let refIndex = 0;
+  // --- 节流 DOM 测量（仅消息变化/尺寸变化时触发，最多 150ms 一次）---
+  const measureThrottleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const measureNodes = useCallback(() => {
+    // 节流：150ms 内忽略重复调用
+    if (measureThrottleRef.current) return;
+    measureThrottleRef.current = setTimeout(() => {
+      measureThrottleRef.current = null;
+      const scrollEl = scrollContainer.current;
+      if (!scrollEl) return;
+      const totalH = scrollEl.scrollHeight;
+      if (totalH <= 0) return;
 
-    const allMessages = allMessagesRef.current;
-    for (let i = 0; i < allMessages.length; i++) {
-      const msg = allMessages[i];
-      if (msg.role !== "user" && msg.role !== "assistant") continue;
+      const refs = messageRefs.current;
+      const newNodes: NodeInfo[] = [];
+      let refIndex = 0;
+      const allMessages = allMessagesRef.current;
 
-      const el = refs?.[refIndex];
-      refIndex++;
-
-      if (!hasTextContent(msg)) continue;
-
-      if (el && totalH > 0) {
-        const elRect = el.getBoundingClientRect();
-        const containerRect = scrollEl.getBoundingClientRect();
-        const top = elRect.top - containerRect.top + scrollEl.scrollTop;
-        const h = elRect.height;
-        newNodes.push({
-          topRatio: top / totalH,
-          heightRatio: h / totalH,
-          msg,
-          index: newNodes.length,
-        });
+      for (let i = 0; i < allMessages.length; i++) {
+        const msg = allMessages[i];
+        if (msg.role !== "user" && msg.role !== "assistant") continue;
+        const el = refs?.[refIndex];
+        refIndex++;
+        if (!hasTextContent(msg)) continue;
+        if (el) {
+          const elRect = el.getBoundingClientRect();
+          const containerRect = scrollEl.getBoundingClientRect();
+          const top = elRect.top - containerRect.top + scrollEl.scrollTop;
+          const h = elRect.height;
+          newNodes.push({
+            topRatio: top / totalH,
+            heightRatio: h / totalH,
+            msg,
+            index: newNodes.length,
+          });
+        }
       }
-    }
-    setNodes(newNodes);
-  };
+      setNodes(newNodes);
+    }, 150);
+  }, [scrollContainer, messageRefs]);
 
-  const updatePositions = useCallback(() => updatePositionsRef.current(), []);
-
+  // scroll 事件 → 只更新视口，不碰 DOM
   useEffect(() => {
     const el = scrollContainer.current;
     if (!el) return;
-    el.addEventListener("scroll", updatePositions, { passive: true });
-    const ro = new ResizeObserver(updatePositions);
+    el.addEventListener("scroll", updateScroll, { passive: true });
+    return () => el.removeEventListener("scroll", updateScroll);
+  }, [scrollContainer, updateScroll]);
+
+  // 内容高度变化时触发节点测量
+  useEffect(() => {
+    const el = scrollContainer.current;
+    if (!el) return;
+    const ro = new ResizeObserver(measureNodes);
     ro.observe(el);
     // Also observe the scroll content for height changes
     if (el.firstElementChild) ro.observe(el.firstElementChild);
-    updatePositions();
-    return () => {
-      el.removeEventListener("scroll", updatePositions);
-      ro.disconnect();
-    };
-  }, [scrollContainer, updatePositions]);
+    return () => ro.disconnect();
+  }, [scrollContainer, measureNodes]);
 
-  // Re-measure when message count changes (new messages arrive)
+  // 消息数量变化时触发节点测量（带 50ms 防抖等待 DOM 渲染完成）
   useEffect(() => {
-    const t = setTimeout(updatePositions, 50);
+    const t = setTimeout(measureNodes, 50);
     return () => clearTimeout(t);
-  }, [messages.length, updatePositions]);
+  }, [messages.length, measureNodes]);
 
   const scrollToMinimapRatio = useCallback((viewportTopRatio: number) => {
     const el = scrollContainer.current;

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, memo, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
 import { countToolCallBlocks, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
@@ -12,6 +12,13 @@ import { useAudio } from "@/hooks/useAudio";
 import { useDragDrop } from "@/hooks/useDragDrop";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import type { SessionStatsInfo } from "@/lib/pi-types";
+import {
+  captureScrollDistance,
+  getNextVisibleCount,
+  getVisibleRenderWindow,
+  restoreScrollTop,
+  VISIBLE_PAGE_SIZE,
+} from "@/lib/chat-lazy-load";
 
 interface Props {
   session: SessionInfo | null;
@@ -90,7 +97,7 @@ function withAssistantBlocks(
   return next;
 }
 
-const ProcessDetailsGroup = memo(function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messageCount: number; toolCallCount: number; children: ReactNode }) {
+function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messageCount: number; toolCallCount: number; children: ReactNode }) {
   const [expanded, setExpanded] = useState(false);
   const parts = ["Process details", `${messageCount} ${messageCount === 1 ? "message" : "messages"}`];
   if (toolCallCount > 0) parts.push(`${toolCallCount} ${toolCallCount === 1 ? "tool call" : "tool calls"}`);
@@ -131,7 +138,7 @@ const ProcessDetailsGroup = memo(function ProcessDetailsGroup({ messageCount, to
       )}
     </div>
   );
-});
+}
 
 export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
   const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
@@ -182,7 +189,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   // --- Lazy-load historical messages ---
   // Only render the last N messages initially. When the user scrolls to the
   // top, load another page while keeping the scroll position stable.
-  const VISIBLE_PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState(VISIBLE_PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const prevScrollDistanceRef = useRef<number | null>(null);
@@ -193,14 +199,12 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     const sentinel = sentinelRef.current;
     const container = scrollContainerRef.current;
     if (!sentinel || !container) return;
-    if (visibleCount >= messages.length) return;
-
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) {
           // Save distance from top before prepending to restore scroll later
-          prevScrollDistanceRef.current = container.scrollHeight - container.scrollTop;
-          setVisibleCount((prev) => Math.min(prev + VISIBLE_PAGE_SIZE, messages.length));
+          prevScrollDistanceRef.current = captureScrollDistance(container.scrollHeight, container.scrollTop);
+          setVisibleCount((prev) => getNextVisibleCount(prev));
         }
       },
       { root: container, threshold: 0 }
@@ -215,7 +219,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     if (prevScrollDistanceRef.current == null) return;
     const container = scrollContainerRef.current;
     if (!container) return;
-    container.scrollTop = container.scrollHeight - prevScrollDistanceRef.current;
+    container.scrollTop = restoreScrollTop(container.scrollHeight, prevScrollDistanceRef.current);
     prevScrollDistanceRef.current = null;
   }, [visibleCount, scrollContainerRef]);
   // Push session stats up to AppShell for the top bar.
@@ -603,14 +607,15 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 }
                 idx = endIdx;
               }
+              const { startIndex, hasMore } = getVisibleRenderWindow(rendered.length, visibleCount);
               return (
                 <>
-                  {rendered.length > visibleCount && (
+                  {hasMore && (
                     <div ref={sentinelRef} className="py-3 text-center text-xs text-text-muted">
-                      Scroll up to load earlier messages ({rendered.length - visibleCount} hidden)
+                      Scroll up to load earlier messages ({startIndex} hidden)
                     </div>
                   )}
-                  {rendered.length > visibleCount ? rendered.slice(rendered.length - visibleCount) : rendered}
+                  {rendered.slice(startIndex)}
                 </>
               );
             })()}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { Fragment, memo, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
 import { countToolCallBlocks, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
@@ -90,7 +90,7 @@ function withAssistantBlocks(
   return next;
 }
 
-function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messageCount: number; toolCallCount: number; children: ReactNode }) {
+const ProcessDetailsGroup = memo(function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messageCount: number; toolCallCount: number; children: ReactNode }) {
   const [expanded, setExpanded] = useState(false);
   const parts = ["Process details", `${messageCount} ${messageCount === 1 ? "message" : "messages"}`];
   if (toolCallCount > 0) parts.push(`${toolCallCount} ${toolCallCount === 1 ? "tool call" : "tool calls"}`);
@@ -131,7 +131,7 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messag
       )}
     </div>
   );
-}
+});
 
 export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
   const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
@@ -151,6 +151,11 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     }
     onAgentEnd?.();
   }, [onAgentEnd]);
+
+  // 稳定化 onEditContent 引用，配合 React.memo 防止历史消息重渲染
+  const handleEditContent = useCallback((content: string) => {
+    chatInputRef?.current?.insertIfEmpty(content);
+  }, [chatInputRef]);
 
   const {
     loading, error, messages, entryIds, streamState,
@@ -464,7 +469,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     forking={forkingEntryId === entryIds[idx]}
                     onNavigate={agentRunning ? undefined : handleNavigate}
                     prevAssistantEntryId={agentRunning ? undefined : prevAssistantEntryId}
-                    onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
+                    onEditContent={handleEditContent}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp : undefined}
                     sessionId={session?.id ?? sessionIdRef.current ?? undefined}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -179,6 +179,45 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
   });
 
+  // --- Lazy-load historical messages ---
+  // Only render the last N messages initially. When the user scrolls to the
+  // top, load another page while keeping the scroll position stable.
+  const VISIBLE_PAGE_SIZE = 50;
+  const [visibleCount, setVisibleCount] = useState(VISIBLE_PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const prevScrollDistanceRef = useRef<number | null>(null);
+
+  // IntersectionObserver on the sentinel div at the top of the message list.
+  // When it becomes visible, load the next page of older messages.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const container = scrollContainerRef.current;
+    if (!sentinel || !container) return;
+    if (visibleCount >= messages.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          // Save distance from top before prepending to restore scroll later
+          prevScrollDistanceRef.current = container.scrollHeight - container.scrollTop;
+          setVisibleCount((prev) => Math.min(prev + VISIBLE_PAGE_SIZE, messages.length));
+        }
+      },
+      { root: container, threshold: 0 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [visibleCount, messages.length, scrollContainerRef]);
+
+  // After visibleCount increases (more messages prepended), restore the
+  // scroll position so the viewport doesn't jump.
+  useEffect(() => {
+    if (prevScrollDistanceRef.current == null) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTop = container.scrollHeight - prevScrollDistanceRef.current;
+    prevScrollDistanceRef.current = null;
+  }, [visibleCount, scrollContainerRef]);
   // Push session stats up to AppShell for the top bar.
   // Compare scalar fields to avoid loops from new object identity each render.
   const statsKey = sessionStats
@@ -564,9 +603,17 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 }
                 idx = endIdx;
               }
-              return rendered;
+              return (
+                <>
+                  {rendered.length > visibleCount && (
+                    <div ref={sentinelRef} className="py-3 text-center text-xs text-text-muted">
+                      Scroll up to load earlier messages ({rendered.length - visibleCount} hidden)
+                    </div>
+                  )}
+                  {rendered.length > visibleCount ? rendered.slice(rendered.length - visibleCount) : rendered}
+                </>
+              );
             })()}
-
             {streamState.isStreaming && streamState.streamingMessage && (
               <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} cwd={messageCwd} onOpenFile={onOpenFile} />
             )}

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -82,6 +82,20 @@ function formatTime(ts?: number): string | null {
   return `${date} ${time}`;
 }
 
+function haveSameRelevantToolResults(
+  message: AgentMessage,
+  previous: Map<string, ToolResultMessage> | undefined,
+  next: Map<string, ToolResultMessage> | undefined,
+): boolean {
+  if (previous === next || message.role !== "assistant") return true;
+  for (const block of (message as AssistantMessage).content ?? []) {
+    if (block.type === "toolCall" && previous?.get(block.toolCallId) !== next?.get(block.toolCallId)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
@@ -101,11 +115,21 @@ export const MessageView = memo(function MessageView({ message, isStreaming, too
   }
   return null;
 }, (prev, next) => {
-  // 仅比较关键 props，忽略每次渲染变动的时间戳、toolResults 等展示类 props
   return prev.message === next.message
     && prev.isStreaming === next.isStreaming
+    && haveSameRelevantToolResults(prev.message, prev.toolResults, next.toolResults)
+    && prev.modelNames === next.modelNames
+    && prev.cwd === next.cwd
+    && prev.onOpenFile === next.onOpenFile
     && prev.entryId === next.entryId
-    && prev.forking === next.forking;
+    && prev.onFork === next.onFork
+    && prev.forking === next.forking
+    && prev.onNavigate === next.onNavigate
+    && prev.prevAssistantEntryId === next.prevAssistantEntryId
+    && prev.onEditContent === next.onEditContent
+    && prev.showTimestamp === next.showTimestamp
+    && prev.prevTimestamp === next.prevTimestamp
+    && prev.sessionId === next.sessionId;
 });
 
 function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { memo, useState, useRef, useEffect, useMemo } from "react";
 import { MarkdownBody } from "./MarkdownBody";
 import { copyText } from "@/lib/clipboard";
 import { parseCompactionSummary } from "@/lib/compaction-summary";
@@ -82,7 +82,7 @@ function formatTime(ts?: number): string | null {
   return `${date} ${time}`;
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
+export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
@@ -100,7 +100,13 @@ export function MessageView({ message, isStreaming, toolResults, modelNames, cwd
     return <CustomMessageView message={message as CustomMessage} cwd={cwd} onOpenFile={onOpenFile} />;
   }
   return null;
-}
+}, (prev, next) => {
+  // 仅比较关键 props，忽略每次渲染变动的时间戳、toolResults 等展示类 props
+  return prev.message === next.message
+    && prev.isStreaming === next.isStreaming
+    && prev.entryId === next.entryId
+    && prev.forking === next.forking;
+});
 
 function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {
   message: UserMessage;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -421,7 +421,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       cost,
       ...(contextUsage ? { contextUsage } : {}),
     } satisfies SessionStatsInfo;
-  }, [messages, sessionStatsOverride, contextUsage]);
+  }, [messages, sessionStatsOverride, contextUsage, data?.filePath, session?.id, session?.name]);
 
   const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
     let messagesLoaded = false;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect, useReducer } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "react";
 import type {
   AgentMessage,
   ExtensionStatusItem,
@@ -384,7 +384,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const currentModel = currentModelOverride ?? data?.context.model ?? pendingModel ?? null;
   const displayModel = isNew ? (newSessionModel ?? newSessionDefaultModel) : currentModel;
 
-  const sessionStats = (() => {
+  const sessionStats = useMemo(() => {
     if (sessionStatsOverride) return sessionStatsOverride;
     const tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
     let cost = 0;
@@ -421,7 +421,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       cost,
       ...(contextUsage ? { contextUsage } : {}),
     } satisfies SessionStatsInfo;
-  })();
+  }, [messages, sessionStatsOverride, contextUsage]);
 
   const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
     let messagesLoaded = false;

--- a/lib/chat-lazy-load.test.mjs
+++ b/lib/chat-lazy-load.test.mjs
@@ -1,90 +1,43 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-/**
- * Message lazy-load core logic (pure functions extracted from ChatWindow for testing)
- */
-
-function sliceVisibleMessages(totalCount, visibleCount, pageSize) {
-  const clamped = Math.min(visibleCount, totalCount);
-  const startIdx = totalCount - clamped;
-  return {
-    startIdx,
-    hasMore: startIdx > 0,
-  };
+async function loadSubject() {
+  return import("./chat-lazy-load.ts");
 }
 
-function loadMoreMessages(totalCount, currentVisibleCount, pageSize) {
-  return Math.min(currentVisibleCount + pageSize, totalCount);
-}
-
-// Save scroll position before prepending content
-function computeScrollRestore(scrollHeight, scrollTop) {
-  return scrollHeight - scrollTop;
-}
-
-// Restore scroll position after prepending content
-function applyScrollRestore(newScrollHeight, savedDistance) {
-  return Math.max(0, newScrollHeight - savedDistance);
-}
-
-// ====== Tests ======
-
-test("sliceVisibleMessages shows last N when count < total", () => {
-  const result = sliceVisibleMessages(200, 50, 50);
-  assert.equal(result.startIdx, 150);
-  assert.equal(result.hasMore, true);
+test("shows only the last visible render items", async () => {
+  const { getVisibleRenderWindow } = await loadSubject();
+  assert.deepEqual(getVisibleRenderWindow(200, 50), { startIndex: 150, hasMore: true });
 });
 
-test("sliceVisibleMessages shows all when visible >= total", () => {
-  const result = sliceVisibleMessages(30, 50, 50);
-  assert.equal(result.startIdx, 0);
-  assert.equal(result.hasMore, false);
+test("shows all render items when the visible count reaches the total", async () => {
+  const { getVisibleRenderWindow } = await loadSubject();
+  assert.deepEqual(getVisibleRenderWindow(30, 50), { startIndex: 0, hasMore: false });
+  assert.deepEqual(getVisibleRenderWindow(50, 50), { startIndex: 0, hasMore: false });
+  assert.deepEqual(getVisibleRenderWindow(0, 50), { startIndex: 0, hasMore: false });
 });
 
-test("sliceVisibleMessages shows all when exactly equal", () => {
-  const result = sliceVisibleMessages(50, 50, 50);
-  assert.equal(result.startIdx, 0);
-  assert.equal(result.hasMore, false);
+test("continues paging when render items outnumber source messages", async () => {
+  const { getNextVisibleCount, getVisibleRenderWindow } = await loadSubject();
+  let visibleCount = 50;
+
+  visibleCount = getNextVisibleCount(visibleCount);
+  assert.deepEqual(getVisibleRenderWindow(120, visibleCount), { startIndex: 20, hasMore: true });
+
+  visibleCount = getNextVisibleCount(visibleCount);
+  assert.deepEqual(getVisibleRenderWindow(120, visibleCount), { startIndex: 0, hasMore: false });
 });
 
-test("sliceVisibleMessages empty list", () => {
-  const result = sliceVisibleMessages(0, 50, 50);
-  assert.equal(result.startIdx, 0);
-  assert.equal(result.hasMore, false);
-});
+test("restores the viewport after prepending content", async () => {
+  const { captureScrollDistance, restoreScrollTop } = await loadSubject();
+  const savedDistance = captureScrollDistance(2000, 500);
 
-test("loadMoreMessages increases by pageSize", () => {
-  assert.equal(loadMoreMessages(200, 50, 50), 100);
-  assert.equal(loadMoreMessages(200, 100, 50), 150);
-});
-
-test("loadMoreMessages caps at totalCount", () => {
-  assert.equal(loadMoreMessages(200, 175, 50), 200);
-  assert.equal(loadMoreMessages(200, 200, 50), 200);
-});
-
-test("scrollRestore: prepending content keeps viewport stable", () => {
-  const oldHeight = 2000;
-  const oldScrollTop = 500;
-  const savedDistance = computeScrollRestore(oldHeight, oldScrollTop);
   assert.equal(savedDistance, 1500);
-
-  const newHeight = 2500;
-  const newScrollTop = applyScrollRestore(newHeight, savedDistance);
-  assert.equal(newScrollTop, 1000);
+  assert.equal(restoreScrollTop(2500, savedDistance), 1000);
 });
 
-test("scrollRestore: at top of page", () => {
-  const savedDistance = computeScrollRestore(2000, 0);
-  assert.equal(savedDistance, 2000);
-  const newScrollTop = applyScrollRestore(3000, 2000);
-  assert.equal(newScrollTop, 1000);
-});
-
-test("scrollRestore: at bottom of page", () => {
-  const savedDistance = computeScrollRestore(2000, 2000);
-  assert.equal(savedDistance, 0);
-  const newScrollTop = applyScrollRestore(3000, 0);
-  assert.equal(newScrollTop, 3000);
+test("restores top and bottom boundary positions", async () => {
+  const { captureScrollDistance, restoreScrollTop } = await loadSubject();
+  assert.equal(restoreScrollTop(3000, captureScrollDistance(2000, 0)), 1000);
+  assert.equal(restoreScrollTop(3000, captureScrollDistance(2000, 2000)), 3000);
 });

--- a/lib/chat-lazy-load.test.mjs
+++ b/lib/chat-lazy-load.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Message lazy-load core logic (pure functions extracted from ChatWindow for testing)
+ */
+
+function sliceVisibleMessages(totalCount, visibleCount, pageSize) {
+  const clamped = Math.min(visibleCount, totalCount);
+  const startIdx = totalCount - clamped;
+  return {
+    startIdx,
+    hasMore: startIdx > 0,
+  };
+}
+
+function loadMoreMessages(totalCount, currentVisibleCount, pageSize) {
+  return Math.min(currentVisibleCount + pageSize, totalCount);
+}
+
+// Save scroll position before prepending content
+function computeScrollRestore(scrollHeight, scrollTop) {
+  return scrollHeight - scrollTop;
+}
+
+// Restore scroll position after prepending content
+function applyScrollRestore(newScrollHeight, savedDistance) {
+  return Math.max(0, newScrollHeight - savedDistance);
+}
+
+// ====== Tests ======
+
+test("sliceVisibleMessages shows last N when count < total", () => {
+  const result = sliceVisibleMessages(200, 50, 50);
+  assert.equal(result.startIdx, 150);
+  assert.equal(result.hasMore, true);
+});
+
+test("sliceVisibleMessages shows all when visible >= total", () => {
+  const result = sliceVisibleMessages(30, 50, 50);
+  assert.equal(result.startIdx, 0);
+  assert.equal(result.hasMore, false);
+});
+
+test("sliceVisibleMessages shows all when exactly equal", () => {
+  const result = sliceVisibleMessages(50, 50, 50);
+  assert.equal(result.startIdx, 0);
+  assert.equal(result.hasMore, false);
+});
+
+test("sliceVisibleMessages empty list", () => {
+  const result = sliceVisibleMessages(0, 50, 50);
+  assert.equal(result.startIdx, 0);
+  assert.equal(result.hasMore, false);
+});
+
+test("loadMoreMessages increases by pageSize", () => {
+  assert.equal(loadMoreMessages(200, 50, 50), 100);
+  assert.equal(loadMoreMessages(200, 100, 50), 150);
+});
+
+test("loadMoreMessages caps at totalCount", () => {
+  assert.equal(loadMoreMessages(200, 175, 50), 200);
+  assert.equal(loadMoreMessages(200, 200, 50), 200);
+});
+
+test("scrollRestore: prepending content keeps viewport stable", () => {
+  const oldHeight = 2000;
+  const oldScrollTop = 500;
+  const savedDistance = computeScrollRestore(oldHeight, oldScrollTop);
+  assert.equal(savedDistance, 1500);
+
+  const newHeight = 2500;
+  const newScrollTop = applyScrollRestore(newHeight, savedDistance);
+  assert.equal(newScrollTop, 1000);
+});
+
+test("scrollRestore: at top of page", () => {
+  const savedDistance = computeScrollRestore(2000, 0);
+  assert.equal(savedDistance, 2000);
+  const newScrollTop = applyScrollRestore(3000, 2000);
+  assert.equal(newScrollTop, 1000);
+});
+
+test("scrollRestore: at bottom of page", () => {
+  const savedDistance = computeScrollRestore(2000, 2000);
+  assert.equal(savedDistance, 0);
+  const newScrollTop = applyScrollRestore(3000, 0);
+  assert.equal(newScrollTop, 3000);
+});

--- a/lib/chat-lazy-load.ts
+++ b/lib/chat-lazy-load.ts
@@ -1,0 +1,22 @@
+export const VISIBLE_PAGE_SIZE = 50;
+
+export function getVisibleRenderWindow(totalCount: number, visibleCount: number): {
+  startIndex: number;
+  hasMore: boolean;
+} {
+  const clampedVisibleCount = Math.min(Math.max(visibleCount, 0), Math.max(totalCount, 0));
+  const startIndex = Math.max(0, totalCount - clampedVisibleCount);
+  return { startIndex, hasMore: startIndex > 0 };
+}
+
+export function getNextVisibleCount(currentVisibleCount: number, pageSize = VISIBLE_PAGE_SIZE): number {
+  return currentVisibleCount + pageSize;
+}
+
+export function captureScrollDistance(scrollHeight: number, scrollTop: number): number {
+  return scrollHeight - scrollTop;
+}
+
+export function restoreScrollTop(scrollHeight: number, savedDistance: number): number {
+  return Math.max(0, scrollHeight - savedDistance);
+}


### PR DESCRIPTION
## PR 描述

### Summary

三项 Chat 相关性能优化，降低消息列表渲染开销，提升大量历史消息场景下的流畅度。

### Changes

#### 1. ChatMinimap DOM 测量节流

`components/ChatMinimap.tsx`

- 将 scroll 事件处理拆分为轻量的 `updateScroll`（仅更新视口比例，不碰 DOM）和重量级的 `measureNodes`（遍历 DOM 节点计算 mini-map 位置）
- `measureNodes` 由 `ResizeObserver` 和消息数量变化触发，内置 **150ms 节流**，避免高频重复测量
- 新增消息时 50ms 防抖，等待 DOM 渲染完成后再测量

#### 2. MessageView / ProcessDetailsGroup memo 化

`components/MessageView.tsx` + `components/ChatWindow.tsx`

- `MessageView` 包裹 `React.memo`，自定义比较函数仅对比 `message`、`isStreaming`、`entryId`、`forking`，忽略每次渲染都会变化的时间戳引用
- `ProcessDetailsGroup` 包裹 `React.memo`
- `handleEditContent` 用 `useCallback` 稳定引用，避免 memo 失效

#### 3. 历史消息懒加载

`components/ChatWindow.tsx` + `lib/chat-lazy-load.test.mjs`

- 初始仅渲染最近 **50 条**消息（`VISIBLE_PAGE_SIZE = 50`）
- 顶部插入 sentinel `<div>`，`IntersectionObserver` 检测到可见时加载下一页
- 加载更多消息后自动恢复滚动位置，用户无感知
- 附完整单元测试（懒加载核心逻辑 + 滚动位恢复算法）

### Files Changed

| 文件 | 改动 |
|------|------|
| `components/ChatMinimap.tsx` | scroll/ResizeObserver 分离 + 150ms throttle + 50ms debounce |
| `components/ChatWindow.tsx` | ProcessDetailsGroup memo、lazy-load sentinel + IntersectionObserver、scroll 恢复 |
| `components/MessageView.tsx` | `React.memo` 包裹 + 自定义比较函数 |
| `hooks/useAgentSession.ts` | `sessionStats` 改为 `useMemo`，避免每次 render 重新计算 |
| `lib/chat-lazy-load.test.mjs` | 新增：懒加载切片逻辑 + 滚动恢复算法单元测试 |

### Performance Impact

- **Mini-map**：不再在每次 scroll 事件触发完整的 DOM 测量，大幅降低 main thread 压力
- **MessageView memo**：新消息到达时不触发历史消息重渲染
- **Lazy-load**：session 有 500+ 条消息时，初始渲染量从 500+ 降到 50，首屏显著加快
