### PR TITLE
feat: update browser tab title with workspace directory name

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -177,6 +177,12 @@ export function AppShell() {
     router.replace("/", { scroll: false });
   }, [router, selectedSession]);
 
+  // Update browser tab title when workspace changes
+  useEffect(() => {
+    const name = activeCwd ? getFileName(activeCwd) : null;
+    document.title = name ? `${name} — Pi Agent Web` : "Pi Agent Web";
+  }, [activeCwd]);
+
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
     setNewSessionCwd(null);
     setSelectedSession(session);

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -179,7 +179,7 @@ export function AppShell() {
 
   // Update browser tab title when workspace changes
   useEffect(() => {
-    const name = activeCwd ? getFileName(activeCwd) : null;
+    const name = activeCwd ? getFileName(activeCwd) || activeCwd : null;
     document.title = name ? `${name} — Pi Agent Web` : "Pi Agent Web";
   }, [activeCwd]);
 


### PR DESCRIPTION
## 问题

浏览器 tab 始终显示固定标题 "Pi Agent Web"，当同时打开多个 pi-web tab 对应不同工作目录时，无法通过标题区分，切换不便。

## 改动

监听 activeCwd 变化，将工作目录名称写入 document.title：

- 有活跃工作目录时，标题为 `{目录名} — Pi Agent Web`
- 无工作目录时（初始状态），回退为 "Pi Agent Web"

变更范围：components/AppShell.tsx（+6 行）

## 验证

在不同工作目录下打开 pi-web，浏览器 tab 标题随目录切换自动更新。