### PR TITLE
fix: remove hardcoded maxWidth from FileViewer markdown preview

### DIFF
--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -960,7 +960,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
         ) : isMarkdown && previewMode ? (
           <div
             className="markdown-body markdown-file-preview"
-            style={{ padding: "24px 32px", maxWidth: 800 }}
+            style={{ padding: "24px 32px" }}
           >
             <ReactMarkdown
               remarkPlugins={markdownPreviewRemarkPlugins}


### PR DESCRIPTION
目标: FileViewer 中 Markdown 预览不应被限制在 800px 宽度，应使用面板可用完整宽度。

实现方式:

FileViewer.tsx 第 963 行，移除 markdown 预览容器 style 中的 maxWidth: 800