### PR TITLE
feat: add keyboard shortcuts - Esc to stop agent, Ctrl+Alt+N to new session

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useGlobalKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { SessionSidebar } from "./SessionSidebar";
 import { ChatWindow } from "./ChatWindow";
 import { FileViewer } from "./FileViewer";
@@ -208,6 +209,12 @@ export function AppShell() {
     if (isMobile) setSidebarOpen(false);
     router.replace("/", { scroll: false });
   }, [router, isMobile]);
+
+  // Global keyboard shortcuts (handles Esc, Ctrl+Alt+N etc.)
+  useGlobalKeyboardShortcuts({
+    onNewSession: (cwd: string) => handleNewSession(`kb-${Date.now()}`, cwd),
+    activeCwd,
+  });
 
   // Client-built transient SessionInfo (new session / fork) lacks the
   // server-computed projectRoot, which the same-project check in

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -731,8 +731,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         }
       }
 
-      // Esc stops the agent when no slash/@ menu is open
-      if (e.key === "Escape" && isStreaming && onAbort) {
+      // Esc stops the agent when no slash/@ menu or IME composition is active.
+      if (e.key === "Escape" && !isComposing && isStreaming && onAbort) {
         e.preventDefault();
         onAbort();
         return;

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -731,6 +731,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         }
       }
 
+      // Esc stops the agent when no slash/@ menu is open
+      if (e.key === "Escape" && isStreaming && onAbort) {
+        e.preventDefault();
+        onAbort();
+        return;
+      }
+
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         if (isStreaming && (onSteer || onFollowUp)) {
@@ -741,7 +748,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         }
       }
     },
-    [isStreaming, onSteer, onFollowUp, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion]
+    [isStreaming, onSteer, onFollowUp, onAbort, slashMenuOpen, slashQuery, filteredSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion]
   );
 
   const handleInput = useCallback(() => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
@@ -185,6 +185,11 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     session, newSessionCwd, onAgentEnd: wrappedOnAgentEnd, onSessionCreated, onSessionForked,
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
   });
+
+  // Register the abort handler for the global Esc shortcut
+  useEffect(() => {
+    registerAbortHandler(agentRunning ? handleAbort : null);
+  }, [agentRunning, handleAbort]);
 
   // --- Lazy-load historical messages ---
   // Only render the last N messages initially. When the user scrolls to the

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+
+// ---------------------------------------------------------------------------
+// Module-level registry — ChatWindow registers the abort handler here so that
+// the global Esc listener in AppShell can call it without prop-drilling.
+// ---------------------------------------------------------------------------
+let globalAbortHandler: (() => void) | null = null;
+
+/**
+ * Register (or clear) the abort handler for the global Esc shortcut.
+ * Call this from ChatWindow whenever agentRunning or handleAbort changes.
+ */
+export function registerAbortHandler(handler: (() => void) | null): void {
+  globalAbortHandler = handler;
+}
+
+// ---------------------------------------------------------------------------
+// Hook: global keyboard shortcuts
+// ---------------------------------------------------------------------------
+
+interface UseGlobalKeyboardShortcutsOptions {
+  /** Called when Ctrl+Alt+N is pressed. Receives current cwd. */
+  onNewSession?: (cwd: string) => void;
+  /** The currently selected project directory (sidebar cwd). */
+  activeCwd?: string | null;
+}
+
+/**
+ * Register global keyboard shortcuts for the application.
+ *
+ * Shortcuts handled here:
+ *   Esc          – stop the running agent (via module-level abort handler)
+ *   Ctrl+Alt+N   – create a new session in the active project directory
+ *
+ * Note: Esc inside <textarea> or <input> is deliberately NOT handled here.
+ * ChatInput manages its own Esc logic (closing slash / @ file menus, stopping
+ * the agent when no menu is open) because it needs intimate knowledge of menu
+ * state that is local to that component.
+ */
+export function useGlobalKeyboardShortcuts(
+  options: UseGlobalKeyboardShortcutsOptions,
+): void {
+  const { onNewSession, activeCwd } = options;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      // ---- Esc: stop agent ----
+      if (e.key === "Escape") {
+        if (!globalAbortHandler) return;
+
+        const tag = (e.target as HTMLElement)?.tagName;
+        // Let textarea/input handle Esc internally (ChatInput menus / stop).
+        if (tag === "TEXTAREA" || tag === "INPUT") return;
+
+        e.preventDefault();
+        globalAbortHandler();
+        return;
+      }
+
+      // ---- Ctrl+Alt+N: new session ----
+      if (e.key === "n" && e.ctrlKey && e.altKey) {
+        if (!activeCwd || !onNewSession) return;
+        e.preventDefault();
+        onNewSession(activeCwd);
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [activeCwd, onNewSession]);
+}


### PR DESCRIPTION
目标: 提供全局键盘快捷键，减少鼠标操作 — Esc 停止正在运行的 agent，Ctrl+Alt+N 新建会话。

实现方式:

新增 hooks/useKeyboardShortcuts.ts（73 行）:
- module-level registry 模式，通过 registerAbortHandler() 暴露 abort 回调注册入口，避免跨组件 prop-drilling
    - useGlobalKeyboardShortcuts hook 挂载 window.keydown 监听器
    - Esc: 调用已注册的 abort handler（当焦点在 TEXTAREA/INPUT 时不拦截，留给 ChatInput 自己处理菜单关闭逻辑）
    - Ctrl+Alt+N: 触发 onNewSession(activeCwd)
- AppShell.tsx: 调用 hook，传入 onNewSession 回调
- ChatInput.tsx: 在 textarea keydown 逻辑中新增 Esc 处理 — agent 正在 streaming 且无 slash/@ 菜单打开时调用 onAbort()
- ChatWindow.tsx: 通过 useEffect 在 agentRunning/handleAbort 变化时注册/注销 abort handler

架构决策: 全局 Esc 和 ChatInput 内部 Esc 是两层互补设计 — 全局 Esc 在焦点不在输入框时生效，ChatInput 内 Esc 在输入框内关闭菜单或停止 agent。