### PR TITLE
feat(git-panel): add Git sidebar + per-file diff view

### DIFF
--- a/app/api/git-diff/route.ts
+++ b/app/api/git-diff/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "child_process";
+import fs from "fs";
+import path from "path";
+import { getAllowedFileRoots, isFilePathAllowed } from "@/lib/file-access";
+import { parseDiffSection, parseUntracked, type DiffSection } from "@/lib/git-diff-parse";
+
+export const dynamic = "force-dynamic";
+
+const GIT_TIMEOUT = 10_000;
+const MAX_BUF = 1024 * 1024;
+// Cap for the unstaged "new" side read straight from the worktree. /api/files
+// caps previews at 256KB; we raise it for diffs (one big file is the common
+// case, e.g. package-lock.json ~600KB) but still stop short of multi-MB
+// generated files, where the browser's O(n²) diff would lock up the tab.
+const MAX_READ_BYTES = 4 * 1024 * 1024;
+
+// Run a git command in cwd, resolving to stdout or "" on failure. execFile
+// (argv array) never spawns a shell, so file paths from the client are passed
+// as a single argv element and can't inject shell metacharacters. Async so
+// the Node event loop isn't blocked while git runs — a stuck git process can't
+// stall other in-flight requests. -c core.quotepath=false keeps non-ASCII
+// paths (e.g. Chinese) as UTF-8 instead of octal-escaping them; without it a
+// path like "测试指导文档.md" comes back quoted-escaped and `git show` + the
+// worktree read both miss it → blank diff.
+function git(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("git", ["-c", "core.quotepath=false", ...args], {
+      cwd,
+      timeout: GIT_TIMEOUT,
+      encoding: "utf-8",
+      maxBuffer: MAX_BUF,
+    }, (err, stdout) => {
+      resolve(err ? "" : stdout);
+    });
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const cwd = request.nextUrl.searchParams.get("cwd");
+  if (!cwd) return NextResponse.json({ error: "cwd required" }, { status: 400 });
+
+  const allowedRoots = await getAllowedFileRoots();
+  if (!isFilePathAllowed(cwd, allowedRoots)) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  // Not a git repo at all → distinct from "no changes".
+  if (!(await git(["rev-parse", "--git-dir"], cwd))) {
+    return NextResponse.json({ notGit: true, staged: [], unstaged: [] });
+  }
+
+  const filePath = request.nextUrl.searchParams.get("file");
+  const sectionParam = request.nextUrl.searchParams.get("section");
+  const section: DiffSection = sectionParam === "staged" ? "staged" : "unstaged";
+  // For renames (status R) the dest path may not exist on the baseline side;
+  // the source path does. Caller passes `source` for R entries.
+  const source = request.nextUrl.searchParams.get("source");
+
+  // File mode: return the content for both sides of a per-file diff.
+  if (filePath) {
+    // A path that escapes cwd via ../ would still be repo-scoped by git's own
+    // `git show`, but we reject it explicitly to mirror /api/files' rule.
+    if (!isFilePathAllowed(path.join(cwd, filePath), allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+    const baselinePath = source ?? filePath;
+    // Staged diff = index vs HEAD:  old = HEAD:baseline  new = :filePath
+    // Unstaged diff = worktree vs index: old = :baseline  new = worktree file
+    // A missing side reads as "" (untracked / deleted / new file).
+    if (section === "staged") {
+      const [oldContent, newContent] = await Promise.all([
+        git(["show", `HEAD:${baselinePath}`], cwd),
+        git(["show", `:${filePath}`], cwd),
+      ]);
+      return NextResponse.json({ oldContent, newContent });
+    }
+    // For unstaged, the worktree side is read directly so /api/files' 256KB
+    // preview cap doesn't blank out large files (e.g. package-lock.json).
+    // Cap it ourselves — past a few MB the browser diff would lock up.
+    let newContent = "";
+    const fullPath = path.join(cwd, filePath);
+    try {
+      const st = fs.statSync(fullPath);
+      if (st.size <= MAX_READ_BYTES) {
+        newContent = fs.readFileSync(fullPath, "utf-8");
+      } else {
+        const msg = `File too large for inline diff (${Math.round(st.size / 1024)}KB)`;
+        return NextResponse.json({ error: msg });
+      }
+    } catch {
+      // Deleted file (or unreadable): right side empty → pure-deletion diff.
+      newContent = "";
+    }
+    const oldContent = await git(["show", `:${baselinePath}`], cwd);
+    return NextResponse.json({ oldContent, newContent });
+  }
+
+  // List mode: two sections, mirroring VS Code's Source Control. All five
+  // spawns are independent → one concurrent round, not five serial ones.
+  const [stagedNs, stagedNum, unstagedNs, unstagedNum, untrackedRaw] = await Promise.all([
+    git(["diff", "--cached", "--name-status"], cwd),
+    git(["diff", "--cached", "--numstat"], cwd),
+    git(["diff", "--name-status"], cwd),
+    git(["diff", "--numstat"], cwd),
+    git(["ls-files", "--others", "--exclude-standard"], cwd),
+  ]);
+  const staged = parseDiffSection(stagedNs, stagedNum);
+  const unstagedTracked = parseDiffSection(unstagedNs, unstagedNum);
+  const untracked = parseUntracked(untrackedRaw);
+
+  return NextResponse.json({
+    staged,
+    unstaged: [...unstagedTracked, ...untracked].sort((a, b) => a.path.localeCompare(b.path)),
+  });
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
 import { BranchNavigator } from "./BranchNavigator";
+import { FilesChangedSidebar } from "./FilesChangedSidebar";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { copyText } from "@/lib/clipboard";
@@ -283,6 +284,35 @@ export function AppShell() {
     if (isMobile) setSidebarOpen(false);
   }, [isMobile]);
 
+  // Open (or refocus) a per-file diff tab. Staged and unstaged views of the
+  // same file are separate tabs (tabId carries the section) so their pinned
+  // baselines don't overwrite each other; re-opening an existing diff tab
+  // renews its baseline at click time.
+  const handleOpenDiffFile = useCallback(({
+    filePath, fileName, oldContent, newContent, section,
+  }: {
+    filePath: string;
+    fileName: string;
+    oldContent: string;
+    newContent: string | null;
+    section: "staged" | "unstaged";
+  }) => {
+    const tabId = `file:${filePath}#${section}`;
+    setFileTabs((prev) => {
+      const existing = prev.find((t) => t.id === tabId);
+      if (!existing) {
+        return [...prev, { id: tabId, label: fileName, filePath, diffOldContent: oldContent,
+          diffNewContent: newContent, diffSection: section }];
+      }
+      return prev.map((t) => t.id === tabId
+        ? { ...t, diffOldContent: oldContent, diffNewContent: newContent, diffSection: section }
+        : t);
+    });
+    setActiveFileTabId(tabId);
+    setRightPanelOpen(true);
+    if (isMobile) setSidebarOpen(false);
+  }, [isMobile]);
+
   const handleOpenLinkedFile = useCallback((filePath: string) => {
     handleOpenFile(filePath, getFileName(filePath), selectedSession?.id ?? null);
   }, [handleOpenFile, selectedSession?.id]);
@@ -332,6 +362,11 @@ export function AppShell() {
         onOpenFile={handleOpenFile}
         explorerRefreshKey={explorerRefreshKey}
         onAtMention={handleAtMention}
+      />
+      <FilesChangedSidebar
+        cwd={selectedSession?.cwd ?? newSessionCwd ?? activeCwd ?? null}
+        onOpenFile={(filePath, fileName) => handleOpenFile(filePath, fileName, selectedSession?.id ?? null)}
+        onOpenDiffFile={handleOpenDiffFile}
       />
       <div style={{ padding: "8px", flexShrink: 0, display: "flex", justifyContent: "space-between", gap: 4 }}>
         {([
@@ -1026,6 +1061,8 @@ export function AppShell() {
               filePath={activeFileTab.filePath}
               cwd={activeCwd ?? undefined}
               sourceSessionId={activeFileTab.sourceSessionId}
+              diffOldContent={activeFileTab.diffOldContent ?? null}
+              diffNewContent={activeFileTab.diffNewContent ?? null}
               onOpenFile={(filePath) => handleOpenFile(
                 filePath,
                 getFileName(filePath),

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -22,6 +22,12 @@ interface Props {
   cwd?: string;
   sourceSessionId?: string | null;
   onOpenFile?: (filePath: string) => void;
+  diffOldContent?: string | null;
+  // When set, the tab is a frozen per-file diff: left = diffOldContent,
+  // right = diffNewContent (no /api/files fetch, no live SSE watch). Both
+  // sides come from /api/git-diff, whose right side for the Unstaged section
+  // is read server-side (bypassing the 256KB preview cap, e.g. package-lock).
+  diffNewContent?: string | null;
 }
 
 interface FileData {
@@ -680,7 +686,7 @@ function DocumentViewer({ filePath, cwd, sourceSessionId }: Props) {
   );
 }
 
-export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
+export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, diffOldContent, diffNewContent }: Props) {
   if (isImagePath(filePath)) {
     return <ImageViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
@@ -690,17 +696,17 @@ export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props
   if (isDocumentPreviewPath(filePath)) {
     return <DocumentViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} diffOldContent={diffOldContent} diffNewContent={diffNewContent} />;
 }
 
-function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
+function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, diffOldContent, diffNewContent }: Props) {
   const { isDark } = useTheme();
   const [data, setData] = useState<FileData | null>(null);
   const [prevContent, setPrevContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [previewMode, setPreviewMode] = useState(false);
-  const [viewMode, setViewMode] = useState<"source" | "diff">("source");
+  const [viewMode, setViewMode] = useState<"source" | "diff">(diffOldContent != null ? "diff" : "source");
   const [wrapLines, setWrapLines] = useState(false);
   const [watching, setWatching] = useState(false);
   const [changeCount, setChangeCount] = useState(0);
@@ -736,9 +742,9 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
     setLoading(true);
     setError(null);
     setData(null);
-    setPrevContent(null);
+    setPrevContent(diffOldContent ?? null);
     setPreviewMode(false);
-    setViewMode("source");
+    setViewMode(diffOldContent != null ? "diff" : "source");
     setWrapLines(false);
     setChangeCount(0);
     setWatching(false);
@@ -746,6 +752,17 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
     if (esRef.current) {
       esRef.current.close();
       esRef.current = null;
+    }
+
+    // Frozen per-file diff: both sides come from /api/git-diff (no
+    // /api/files fetch, no live SSE watch). Covers BOTH sections — unstaged
+    // too, since the worktree right side is read server-side by the route,
+    // bypassing the 256KB preview cap (e.g. package-lock.json).
+    if (diffOldContent != null && diffNewContent != null) {
+      setData({ content: diffNewContent, language: "", size: diffNewContent.length });
+      setViewMode("diff");
+      setLoading(false);
+      return;
     }
 
     fetchContent(filePath).then((d) => {
@@ -776,7 +793,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
       es.close();
       esRef.current = null;
     };
-  }, [filePath, fetchContent, sourceSessionId]);
+  }, [filePath, fetchContent, sourceSessionId, diffOldContent, diffNewContent]);
 
   if (loading) {
     return (

--- a/components/FilesChangedSidebar.tsx
+++ b/components/FilesChangedSidebar.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { joinFilePath } from "@/lib/file-paths";
+import { getFileIcon } from "./FileIcons";
+import { sumChanges, type ChangedFile, type DiffSection } from "@/lib/git-diff-parse";
+
+interface DiffListPayload {
+  staged?: ChangedFile[];
+  unstaged?: ChangedFile[];
+  notGit?: boolean;
+  error?: string;
+}
+
+interface DiffFilePayload {
+  oldContent?: string;
+  newContent?: string;
+  error?: string;
+}
+
+interface OpenDiffArgs {
+  filePath: string;
+  fileName: string;
+  oldContent: string;
+  newContent: string;
+  section: DiffSection;
+}
+
+interface Props {
+  cwd: string | null;
+  onOpenFile: (filePath: string, fileName: string) => void;
+  onOpenDiffFile: (args: OpenDiffArgs) => void;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  M: "#eab308", // yellow — modified
+  A: "#4ade80", // green — added
+  D: "#f87171", // red — deleted
+  R: "#60a5fa", // blue — renamed/copied (destination shown as R)
+  U: "#9ca3af", // gray — untracked
+};
+
+function ChangeStat({ added, deleted }: { added: number; deleted: number }) {
+  const show = added > 0 || deleted > 0;
+  if (!show) return null;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 10, fontVariantNumeric: "tabular-nums" }}>
+      {added > 0 && <span style={{ color: "#4ade80" }}>+{added}</span>}
+      {deleted > 0 && <span style={{ color: "#f87171" }}>-{deleted}</span>}
+    </span>
+  );
+}
+
+const headerBtnStyle = {
+  display: "flex", alignItems: "center", justifyContent: "center",
+  width: 26, height: 26, padding: 0, marginRight: 6,
+  background: "none", border: "none", color: "var(--text-dim)",
+  cursor: "pointer", borderRadius: 5, flexShrink: 0,
+  transition: "color 0.3s, background 0.3s",
+} as const;
+
+// Section sub-header: one size smaller than the parent "Git" header
+// (11px uppercased vs 10px camelcase here) and shorter, so the panel reads
+// as parent → child rather than two sibling headers.
+const sectionHeaderStyle = {
+  display: "flex", alignItems: "center", flexShrink: 0,
+  padding: "2px 10px 2px 22px",
+  color: "var(--text-muted)", fontSize: 10, fontWeight: 600,
+  letterSpacing: 0,
+} as const;
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg width="9" height="9" viewBox="0 0 10 10" fill="none"
+      stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
+      style={{ transform: open ? "rotate(90deg)" : "none", transition: "transform 0.15s", flexShrink: 0 }}>
+      <polyline points="3 2 7 5 3 8" />
+    </svg>
+  );
+}
+
+function Section({
+  title, section, files, collapsed, onToggle, onOpen,
+}: {
+  title: string;
+  section: DiffSection;
+  files: ChangedFile[];
+  collapsed: boolean;
+  onToggle: () => void;
+  onOpen: (f: ChangedFile, section: DiffSection) => void;
+}) {
+  const totals = sumChanges(files);
+  return (
+    <div>
+      <button
+        onClick={onToggle}
+        style={{ ...sectionHeaderStyle, background: "none", border: "none", cursor: "pointer", textAlign: "left", width: "100%" }}
+        title={`${title} (${files.length})`}
+      >
+        <span style={{ display: "flex", alignItems: "center", gap: 5, flex: 1 }}>
+          <svg width="8" height="8" viewBox="0 0 10 10" fill="none"
+            stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
+            style={{ transform: !collapsed ? "rotate(90deg)" : "none", transition: "transform 0.15s", flexShrink: 0 }}>
+            <polyline points="3 2 7 5 3 8" />
+          </svg>
+          {title}
+          <span style={{ color: "var(--text-dim)", fontWeight: 400 }}>
+            {files.length}
+          </span>
+        </span>
+        <span style={{ display: "flex", marginLeft: "auto", paddingRight: 4 }}>
+          <ChangeStat added={totals.added} deleted={totals.deleted} />
+        </span>
+      </button>
+      {!collapsed && (
+        <div>
+          {files.length === 0 ? (
+            <div style={{ padding: "4px 12px 4px 22px", fontSize: 11, color: "var(--text-dim)" }}>
+              No changes
+            </div>
+          ) : (
+            files.map((file) => {
+              const fileName = file.path.split("/").pop() ?? file.path;
+              return (
+                <div
+                  key={`${file.path}#${section}`}
+                  onClick={() => onOpen(file, section)}
+                  title={`${file.path} (${file.status})`}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 4,
+                    paddingLeft: 22, paddingRight: 8, height: 24,
+                    cursor: "pointer", color: "var(--text)",
+                    userSelect: "none",
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; e.currentTarget.style.borderRadius = "4px"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                >
+                  <span style={{
+                    width: 12, textAlign: "center", fontSize: 11, fontWeight: 700, flexShrink: 0,
+                    color: STATUS_COLORS[file.status] || "var(--text-dim)", fontFamily: "var(--font-mono)",
+                  }}>
+                    {file.status}
+                  </span>
+                  <span style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
+                    {getFileIcon(fileName, 14)}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                      flex: 1,
+                    }}
+                    title={file.path}
+                  >
+                    {fileName}
+                  </span>
+                  <ChangeStat added={file.added} deleted={file.deleted} />
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FilesChangedSidebar({ cwd, onOpenFile, onOpenDiffFile }: Props) {
+  const [staged, setStaged] = useState<ChangedFile[]>([]);
+  const [unstaged, setUnstaged] = useState<ChangedFile[]>([]);
+  const [notGit, setNotGit] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+  const [collapsedStaged, setCollapsedStaged] = useState(false);
+  const [collapsedUnstaged, setCollapsedUnstaged] = useState(false);
+  const [loadKey, setLoadKey] = useState(0);
+  const [refreshDone, setRefreshDone] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevCwdRef = useRef<string | null>(null);
+
+  const fetchDiff = useCallback(async () => {
+    if (!cwd) { setStaged([]); setUnstaged([]); setNotGit(false); return; }
+    setLoading(true); setError(null);
+    try {
+      const res = await fetch(`/api/git-diff?cwd=${encodeURIComponent(cwd)}`);
+      if (!res.ok) { setError(`HTTP ${res.status}`); setNotGit(false); return; }
+      const data = await res.json() as DiffListPayload;
+      if (data.notGit) { setNotGit(true); setStaged([]); setUnstaged([]); return; }
+      setNotGit(false);
+      if (data.error) { setError(data.error); setStaged([]); setUnstaged([]); return; }
+      setStaged(data.staged ?? []);
+      setUnstaged(data.unstaged ?? []);
+    } catch (e) {
+      setError(String(e)); setStaged([]); setUnstaged([]); setNotGit(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [cwd]);
+
+  useEffect(() => {
+    if (cwd !== prevCwdRef.current) {
+      prevCwdRef.current = cwd;
+      setLoadKey((k) => k + 1);
+    }
+  }, [cwd]);
+
+  useEffect(() => {
+    fetchDiff();
+    if (!cwd || collapsed) return;
+    const id = setInterval(fetchDiff, 5000);
+    return () => clearInterval(id);
+  }, [loadKey, fetchDiff, cwd, collapsed]);
+
+  const triggerRefresh = useCallback(() => {
+    setLoadKey((k) => k + 1);
+    setRefreshDone(true);
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(() => setRefreshDone(false), 2000);
+  }, []);
+
+  useEffect(() => () => {
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+  }, []);
+
+  const handleFileClick = useCallback(
+    async (file: ChangedFile, section: DiffSection) => {
+      if (!cwd) return;
+      const fullPath = joinFilePath(cwd, file.path);
+      const fileName = file.path.split("/").pop() ?? file.path;
+      try {
+        const sourceParam = file.sourcePath ? `&source=${encodeURIComponent(file.sourcePath)}` : "";
+        const res = await fetch(
+          `/api/git-diff?cwd=${encodeURIComponent(cwd)}&file=${encodeURIComponent(file.path)}&section=${section}${sourceParam}`,
+        );
+        if (!res.ok) { onOpenFile(fullPath, fileName); return; }
+        const data = await res.json() as DiffFilePayload;
+        if (data.error || data.oldContent === undefined || data.newContent === undefined) {
+          onOpenFile(fullPath, fileName); return;
+        }
+        onOpenDiffFile({
+          filePath: fullPath,
+          fileName,
+          oldContent: data.oldContent,
+          newContent: data.newContent,
+          section,
+        });
+      } catch {
+        onOpenFile(fullPath, fileName);
+      }
+    },
+    [cwd, onOpenFile, onOpenDiffFile],
+  );
+
+  const renderRefresh = refreshDone
+    ? (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#4ade80" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    )
+    : (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+        <path d="M3 3v5h5" />
+      </svg>
+    );
+
+  // No working folder chosen → Git panel hidden, mirroring Explorer's guard.
+  if (!cwd) return null;
+
+  const showStaged = staged.length > 0;
+  const total = staged.length + unstaged.length;
+
+  return (
+    <div
+      style={{
+        borderTop: "1px solid var(--border)",
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: 0,
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
+        <button
+          onClick={() => setCollapsed((v) => !v)}
+          style={{
+            display: "flex", alignItems: "center", gap: 6, flex: 1,
+            padding: "6px 10px",
+            background: "none", border: "none", color: "var(--text-muted)",
+            cursor: "pointer", fontSize: 11, fontWeight: 600,
+            letterSpacing: "0.05em", textTransform: "uppercase", textAlign: "left",
+          }}
+        >
+          <ChevronIcon open={!collapsed} />
+          Git
+          {total > 0 && (
+            <span style={{ color: "var(--text-dim)", fontWeight: 400, letterSpacing: 0 }}>
+              {total}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={triggerRefresh}
+          title="Refresh git changes"
+          style={headerBtnStyle}
+          onMouseEnter={(e) => { if (refreshDone) return; e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "var(--bg-hover)"; }}
+          onMouseLeave={(e) => { if (refreshDone) return; e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.background = "none"; }}
+        >
+          {renderRefresh}
+        </button>
+      </div>
+      {!collapsed && (
+        <div style={{ maxHeight: "40vh", overflowY: "auto", overflowX: "hidden", padding: "2px 4px" }}>
+          {error && (
+            <div style={{ padding: "4px 12px 4px 22px", fontSize: 11, color: "#f87171" }}>
+              {error}
+            </div>
+          )}
+          {notGit ? (
+            <div style={{ padding: "4px 12px 4px 22px", fontSize: 11, color: "var(--text-dim)" }}>
+              Not a Git repository
+            </div>
+          ) : loading && total === 0 ? (
+            <div style={{ padding: "4px 12px 4px 22px", fontSize: 11, color: "var(--text-dim)" }}>
+              Loading...
+            </div>
+          ) : !error && total === 0 ? (
+            <div style={{ padding: "4px 12px 4px 22px", fontSize: 11, color: "var(--text-dim)" }}>
+              No uncommitted changes
+            </div>
+          ) : (
+            <>
+              {showStaged && (
+                <Section
+                  title="Staged Changes" section="staged" files={staged}
+                  collapsed={collapsedStaged} onToggle={() => setCollapsedStaged((v) => !v)}
+                  onOpen={handleFileClick}
+                />
+              )}
+              <Section
+                title="Changes" section="unstaged" files={unstaged}
+                collapsed={collapsedUnstaged} onToggle={() => setCollapsedUnstaged((v) => !v)}
+                onOpen={handleFileClick}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -8,6 +8,11 @@ export interface Tab {
   label: string;
   filePath: string;
   sourceSessionId?: string | null;
+  diffOldContent?: string | null;
+  // Frozen per-file diff: right side is the index (Staged) or worktree (Unstaged).
+  diffNewContent?: string | null;
+  // When set, the tab is a per-file diff and its label is annotated with the section.
+  diffSection?: import("@/lib/git-diff-parse").DiffSection | null;
 }
 
 interface Props {
@@ -69,7 +74,7 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab }: Props) {
               }}
               title={tab.filePath}
             >
-              {tab.label}
+              {tab.label}{tab.diffSection ? ` (${tab.diffSection})` : ""}
             </span>
             <button
               onClick={(e) => { e.stopPropagation(); onCloseTab(tab.id); }}

--- a/lib/git-diff-parse.ts
+++ b/lib/git-diff-parse.ts
@@ -1,0 +1,86 @@
+// Pure parsing for the Files Changed panel. Route handlers feed raw `git`
+// stdout through these functions so the rename/binary/untracked edge cases
+// stay in one testable place instead of inline in the Next route.
+
+export type DiffSection = "staged" | "unstaged";
+
+export interface ChangedFile {
+  path: string;
+  status: string; // single letter: M, A, D, R, U
+  added: number;
+  deleted: number;
+  // For renames/copies (status R): the source path, so the per-file diff can
+  // resolve a baseline from the side that still holds the file (HEAD:source
+  // for staged, :source for unstaged). Undefined for M/A/D/U.
+  sourcePath?: string;
+}
+
+// Parse one `git diff` scope (either staged via --cached or unstaged).
+// nameStatus comes from `git diff [--cached] --name-status`,
+// numstat comes from `git diff [--cached] --numstat`.
+//
+// Renames (R) and copies (C) report two paths ("R100\told\tnew"); they're
+// folded to the destination path with status "R", since numstat emits the
+// destination path and the two line up that way. numstat prints `-` (not a
+// number) for binary files; `parseInt("-") || 0` yields 0, the honest "we
+// can't count lines" value.
+export function parseDiffSection(nameStatus: string, numstat: string): ChangedFile[] {
+  const statusByPath = new Map<string, { letter: string; source?: string }>();
+  for (const line of nameStatus.split("\n")) {
+    if (!line.trim()) continue;
+    const [statusRaw, ...parts] = line.split("\t");
+    const segs = parts.filter(Boolean);
+    const letter = statusRaw.charAt(0);
+    const folded = letter === "C" ? "R" : letter; // Q14/Q2: copy displays as rename
+    const dst = segs[segs.length - 1];
+    // R/C lines carry two paths; the first is the rename source.
+    const source = (folded === "R" && segs.length >= 2) ? segs[0] : undefined;
+    if (dst) statusByPath.set(dst, { letter: folded, source });
+  }
+
+  const files: ChangedFile[] = [];
+  for (const line of numstat.split("\n")) {
+    if (!line.trim()) continue;
+    const [addedRaw, deletedRaw, pRaw] = line.split("\t");
+    if (!pRaw) continue;
+    // git prints renames in numstat as "src => dst"; we key on the destination
+    // to line up with `--name-status`'s R/C line (tab-separated src/ dst).
+    const p = pRaw.includes(" => ") ? pRaw.split(" => ").pop()!.trim() : pRaw;
+    const meta = statusByPath.get(p) || { letter: "M" };
+    files.push({
+      path: p,
+      status: meta.letter,
+      added: parseInt(addedRaw) || 0,
+      deleted: parseInt(deletedRaw) || 0,
+      ...(meta.source ? { sourcePath: meta.source } : {}),
+    });
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return files;
+}
+
+// Untracked files come from `git ls-files --others --exclude-standard`.
+// They only ever land in the Unstaged section, never Staged.
+export function parseUntracked(untracked: string): ChangedFile[] {
+  const files: ChangedFile[] = [];
+  for (const p of untracked.split("\n")) {
+    if (!p.trim()) continue;
+    files.push({ path: p, status: "U", added: 0, deleted: 0 });
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return files;
+}
+
+// Section/total counter. Untracked files carry no line counts (numstat
+// doesn't cover them), so the totals honestly count tracked files only.
+export function sumChanges(files: ChangedFile[]): { added: number; deleted: number } {
+  let added = 0;
+  let deleted = 0;
+  for (const f of files) {
+    if (f.status === "U") continue;
+    added += f.added;
+    deleted += f.deleted;
+  }
+  return { added, deleted };
+}


### PR DESCRIPTION
## Summary
- Add a Source-Control-style **Git** panel under the File Explorer (VS Code-like).
- List staged / unstaged / untracked changes; open per-file diffs in frozen Source/Diff tabs.
- `app/api/git-diff`: concurrent `execFile` (no shell), path allow-list, rename-aware, UTF-8 paths, 4MB worktree cap for large files.

## Changes
- `app/api/git-diff/route.ts` — list + per-file diff API
- `components/FilesChangedSidebar.tsx` — Git sidebar UI
- `components/FileViewer.tsx` / `AppShell.tsx` / `TabBar.tsx` — staged/unstaged tabs, frozen diff
- `lib/git-diff-parse.ts` — pure parser (R/C rename, numstat)

## Test plan
- [ ] Select a git working folder → Git panel appears under Explorer
- [ ] Stage/unstage files; staged section shows/hides correctly
- [ ] Click file → opens diff tab (Source/Diff toggle works)
- [ ] Same file staged + unstaged → two separate tabs
- [ ] Renamed file shows proper rename diff (not pure add)
- [ ] Non-ASCII path renders correctly
- [ ] Large untracked/worktree file (>4MB) falls back to plain source open
- [ ] No working folder selected → panel hidden

Closes #163