### PR TITLE
feat: support ! / !! shell command prefix in pi-web UI

### DIFF
--- a/app/api/agent/[id]/bash-output/route.ts
+++ b/app/api/agent/[id]/bash-output/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { resolve, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
+import { getRpcSession } from "@/lib/rpc-manager";
+
+// GET /api/agent/[id]/bash-output?path=<absPath>
+// Reads the full (truncated) bash output temp file for a session.
+// Guarded by a session-scoped allowlist + temp-prefix + path-traversal checks.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  let path: string | null = null;
+  try {
+    const url = new URL(_req.url);
+    path = url.searchParams.get("path");
+  } catch {
+    return NextResponse.json({ error: "invalid url" }, { status: 400 });
+  }
+
+  if (!path) {
+    return NextResponse.json({ error: "path required" }, { status: 400 });
+  }
+
+  const wrapper = getRpcSession(id);
+  if (!wrapper || !wrapper.isAlive() || !wrapper.isBashOutputPathAllowed(path)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  // Path traversal + temp-prefix guard. pi writes bash full output to
+  // `<tmpdir>/pi-bash-<id>.log` (see bash-executor.ts). Validate that the
+  // resolved path's directory is exactly tmpdir and its basename matches
+  // the pi-bash-*.log shape — this blocks traversal, arbitrary temp files,
+  // and prefix-cousin attacks like /tmp/pi-bash-evil.
+  const resolved = resolve(path);
+  const tmpDir = resolve(tmpdir());
+  const dir = dirname(resolved);
+  const base = basename(resolved);
+  if (dir !== tmpDir || !/^pi-bash-.*\.log$/.test(base)) {
+    return NextResponse.json({ error: "invalid path" }, { status: 400 });
+  }
+
+  try {
+    const content = await readFile(resolved, "utf-8");
+    return NextResponse.json({ success: true, data: { output: content } });
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -201,6 +201,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 }: Props, ref) {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(() => (draftKey ? getDraft(draftKey)?.value ?? "" : ""));
+  const trimmedValue = value.trimStart();
+  const bashMode = trimmedValue.startsWith("!");
+  const bashExcluded = trimmedValue.startsWith("!!");
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [modelDropdownRect, setModelDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
   const [toolDropdownOpen, setToolDropdownOpen] = useState(false);
@@ -1253,7 +1256,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
               gap: 8,
               alignItems: "center",
               background: "var(--bg)",
-              border: `1px solid ${isStreaming && (onSteer || onFollowUp)
+              border: `1px solid ${bashMode ? "var(--tool-bg)" : isStreaming && (onSteer || onFollowUp)
                 ? "rgba(234,179,8,0.4)"
                 : "color-mix(in srgb, var(--border) 70%, transparent)"}`,
               borderRadius: 14,
@@ -1388,6 +1391,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           )}
           </div>
         </div>
+
+        {/* Bash mode status label */}
+        {bashMode && (
+          <div className="text-xs px-2 py-1" style={{ color: bashExcluded ? "var(--text-muted)" : "var(--accent)", marginTop: 4 }}>
+            Shell · {bashExcluded ? "output stays local" : "output sent to model"}
+          </div>
+        )}
 
         {/* Bottom bar: left | center (context) | right */}
         <div style={{

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
-import type { AgentMessage, AssistantContentBlock, AssistantMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
+import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
 import { countToolCallBlocks, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
 import { MessageView } from "./MessageView";
@@ -166,7 +166,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
 
   const {
     loading, error, messages, entryIds, streamState,
-    agentRunning, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
+    agentRunning, bashRunning, pendingBash, modelNames, modelList, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
@@ -294,7 +294,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onSteer={agentRunning ? handleSteer : undefined}
       onFollowUp={agentRunning ? handleFollowUp : undefined}
       onPromptWithStreamingBehavior={agentRunning ? handlePromptWithStreamingBehavior : undefined}
-      isStreaming={agentRunning}
+      isStreaming={agentRunning || bashRunning}
       model={displayModelValue}
       isAutoModelSelection={isAutoModelSelection}
       modelNames={modelNames}
@@ -632,6 +632,18 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
               <div className="py-2 text-[13px] text-text-muted">
                 <span className="animate-[pulse_1.5s_infinite]">{phaseLabel(agentPhase)}</span>
               </div>
+            )}
+
+            {pendingBash && (
+              <MessageView
+                message={{
+                  role: "bashExecution",
+                  command: pendingBash.command,
+                  output: "",
+                  excludeFromContext: pendingBash.excludeFromContext,
+                } as BashExecutionMessage}
+                sessionId={session?.id ?? sessionIdRef.current ?? undefined}
+              />
             )}
 
             {agentRunning && (

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -12,6 +12,7 @@ import type {
   AssistantMessage,
   CustomMessage,
   ToolResultMessage,
+  BashExecutionMessage,
   AssistantContentBlock,
   TextContent,
   ImageContent,
@@ -112,6 +113,9 @@ export const MessageView = memo(function MessageView({ message, isStreaming, too
       return <CompactionMessageView message={message as CustomMessage} />;
     }
     return <CustomMessageView message={message as CustomMessage} cwd={cwd} onOpenFile={onOpenFile} />;
+  }
+  if (message.role === "bashExecution") {
+    return <BashExecutionView message={message as BashExecutionMessage} sessionId={sessionId} />;
   }
   return null;
 }, (prev, next) => {
@@ -1363,4 +1367,73 @@ function formatUsage(usage: {
   if (usage.cacheRead) parts.push(`${usage.cacheRead.toLocaleString()} cache`);
   if (usage.cost?.total) parts.push(`$${usage.cost.total.toFixed(4)}`);
   return parts.join(" · ");
+}
+
+function BashExecutionView({ message, sessionId }: { message: BashExecutionMessage; sessionId?: string }) {
+  const [fullOutput, setFullOutput] = useState<string | null>(null);
+  const [loadingFull, setLoadingFull] = useState(false);
+  const [fullError, setFullError] = useState<string | null>(null);
+
+  const isPending = !message.output && message.exitCode === undefined && !message.cancelled;
+  const isError = message.cancelled || (message.exitCode !== undefined && message.exitCode !== 0);
+  const showFullButton = message.truncated && message.fullOutputPath && !fullOutput;
+  const displayOutput = fullOutput ?? message.output;
+
+  async function loadFullOutput() {
+    if (!sessionId || !message.fullOutputPath) return;
+    setLoadingFull(true);
+    setFullError(null);
+    try {
+      const res = await fetch(`/api/agent/${encodeURIComponent(sessionId)}/bash-output?path=${encodeURIComponent(message.fullOutputPath)}`);
+      const d = await res.json();
+      if (d.success) {
+        setFullOutput(d.data.output);
+      } else {
+        setFullError(d.error ?? "failed");
+      }
+    } catch (e) {
+      setFullError(String(e));
+    } finally {
+      setLoadingFull(false);
+    }
+  }
+
+  // Reuse the existing ToolCallBlock so user-run bash looks identical to an
+  // agent-run bash tool call: same header, collapse behavior, result pane.
+  // Synthesize an equivalent ToolCallContent + ToolResultMessage pair.
+  const toolName = message.excludeFromContext ? "bash (local)" : "bash";
+  const block: ToolCallContent = {
+    type: "toolCall",
+    toolCallId: `bash-${message.timestamp ?? ""}`,
+    toolName,
+    input: { command: message.command },
+  };
+  const result: ToolResultMessage | undefined = isPending
+    ? undefined
+    : {
+        role: "toolResult",
+        toolCallId: block.toolCallId,
+        toolName,
+        content: displayOutput ? [{ type: "text", text: displayOutput }] : [],
+        isError,
+        timestamp: message.timestamp,
+      };
+
+  return (
+    <div style={{ margin: "6px 0" }}>
+      <ToolCallBlock block={block} result={result} />
+      {showFullButton && (
+        <div style={{ padding: "4px 10px", fontSize: 11, marginTop: -1 }}>
+          <button
+            onClick={loadFullOutput}
+            disabled={loadingFull}
+            style={{ background: "none", border: "none", color: "var(--accent)", cursor: loadingFull ? "default" : "pointer", fontSize: 11, padding: 0, textDecoration: "underline" }}
+          >
+            {loadingFull ? "loading…" : "view full output"}
+          </button>
+          {fullError && <span style={{ marginLeft: 6, color: "var(--text-dim)", fontSize: 11 }}>(full output unavailable)</span>}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "react";
 import type {
   AgentMessage,
+  BashExecutionMessage,
   ExtensionStatusItem,
   ExtensionUiRequest,
   ExtensionWidgetItem,
@@ -334,6 +335,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [entryIds, setEntryIds] = useState<string[]>([]);
   const [streamState, dispatch] = useReducer(streamReducer, { isStreaming: false, streamingMessage: null });
   const [agentRunning, setAgentRunning] = useState(false);
+  const [bashRunning, setBashRunning] = useState(false);
+  const [pendingBash, setPendingBash] = useState<{ command: string; excludeFromContext: boolean } | null>(null);
   const [modelNames, setModelNames] = useState<Record<string, string>>({});
   const [modelList, setModelList] = useState<ModelEntry[]>([]);
   const [modelThinkingLevels, setModelThinkingLevels] = useState<Record<string, string[]>>({});
@@ -370,6 +373,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const lastUserMsgRef = useRef<HTMLDivElement | null>(null);
   const pendingScrollToUserRef = useRef(false);
   const completionScrollAllowedRef = useRef(true);
+  const executeBashRef = useRef<(command: string, excludeFromContext: boolean) => Promise<void> | undefined>(undefined);
   const userScrollIntentUntilRef = useRef(0);
   const ignoreProgrammaticScrollUntilRef = useRef(0);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -993,8 +997,19 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
     const trimmedMessage = message.trim();
     if (!trimmedMessage && !images?.length) return;
-    if (agentRunning) return;
+    if (agentRunning || bashRunning) return;
     const isSlashCommandPrompt = !images?.length && trimmedMessage.startsWith("/");
+
+    const isBashCommand = !images?.length && trimmedMessage.startsWith("!");
+    if (isBashCommand) {
+      const isExcluded = trimmedMessage.startsWith("!!");
+      const bashCmd = (isExcluded ? trimmedMessage.slice(2) : trimmedMessage.slice(1)).trim();
+      if (!bashCmd) return;
+      if (agentRunning || bashRunning) return;
+      await executeBashRef.current?.(bashCmd, isExcluded);
+      return;
+    }
+
     const promptRunId = promptRunIdRef.current + 1;
 
     const imageBlocks = images?.map((img) => ({ type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } }));
@@ -1072,17 +1087,75 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, agentRunning, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice]);
+  }, [isNew, newSessionCwd, newSessionModel, session, agentRunning, bashRunning, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice]);
+
+  const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
+    const sid = sessionIdRef.current ?? session?.id;
+    if (!sid) return;
+    setPendingBash({ command, excludeFromContext });
+    setBashRunning(true);
+    agentRunningRef.current = true;
+    setAgentPhase({ kind: "running_command" });
+    dispatch({ type: "start" });
+    pendingScrollToUserRef.current = true;
+    try {
+      const result = await sendAgentCommand<{ output: string; exitCode?: number; cancelled?: boolean; truncated?: boolean; fullOutputPath?: string }>(sid, {
+        type: "bash",
+        command,
+        excludeFromContext,
+      });
+      const msg: BashExecutionMessage = {
+        role: "bashExecution",
+        command,
+        output: result.output ?? "",
+        exitCode: result.exitCode,
+        cancelled: result.cancelled,
+        truncated: result.truncated,
+        fullOutputPath: result.fullOutputPath,
+        excludeFromContext,
+        timestamp: Date.now(),
+      };
+      setMessages((prev) => [...prev, msg]);
+      // fullOutputPath allowlist registration happens server-side in
+      // AgentSessionWrapper.send() case "bash" — the client must not import
+      // rpc-manager (it is server-only and pulls in fs).
+    } catch (e) {
+      const msg: BashExecutionMessage = {
+        role: "bashExecution",
+        command,
+        output: String(e),
+        cancelled: true,
+        excludeFromContext,
+        timestamp: Date.now(),
+      };
+      setMessages((prev) => [...prev, msg]);
+    } finally {
+      setPendingBash(null);
+      setBashRunning(false);
+      agentRunningRef.current = false;
+      setAgentPhase(null);
+      dispatch({ type: "end" });
+    }
+  }, [session]);
+  executeBashRef.current = executeBash;
 
   const handleAbort = useCallback(async () => {
     const sid = sessionIdRef.current;
     if (!sid) return;
+    if (bashRunning) {
+      try {
+        await sendAgentCommand(sid, { type: "abort_bash" });
+      } catch (e) {
+        console.error("Failed to abort bash:", e);
+      }
+      return;
+    }
     try {
       await sendAgentCommand(sid, { type: "abort" });
     } catch (e) {
       console.error("Failed to abort:", e);
     }
-  }, []);
+  }, [bashRunning]);
 
   const handleFork = useCallback(async (entryId: string) => {
     const sid = sessionIdRef.current;
@@ -1547,6 +1620,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     handleBuiltinSlashCommand,
     handleToolPresetChange, handleThinkingLevelChange, loadTools, loadSlashCommands, setActiveLeafId, setData, setMessages,
     dispatch, setAgentRunning, setForkingEntryId,
+    bashRunning, pendingBash,
     // Subscriptions
     handleAgentEventRef,
   };

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -19,6 +19,8 @@ function normalizeToolCallBlock(block: unknown): ToolCallContent | null {
 }
 
 export function normalizeToolCalls(msg: AgentMessage): AgentMessage {
+  // Non-assistant roles (user, toolResult, bashExecution, custom) are returned
+  // unchanged — only assistant messages go through tool-call field normalization.
   if (msg.role !== "assistant") return msg;
   const content = (msg as AssistantMessage).content;
   if (!Array.isArray(content)) return msg;

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -138,6 +138,9 @@ export interface AgentSessionLike {
     source?: "interactive" | "rpc";
   }): Promise<void>;
   abort(): Promise<void>;
+  executeBash(command: string, onChunk?: (chunk: string) => void, options?: { excludeFromContext?: boolean }): Promise<{ output: string; exitCode?: number; cancelled?: boolean; truncated?: boolean; fullOutputPath?: string }>;
+  abortBash(): void;
+  readonly isBashRunning: boolean;
   setModel(model: ModelLike): Promise<void>;
   navigateTree(targetId: string, options?: { summarize?: boolean }): Promise<NavigateTreeResult>;
   setThinkingLevel(level: string): void;

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,6 +1,7 @@
 import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
+import { existsSync, readFileSync } from "fs";
 import { invalidateModelsCache } from "./models-cache";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
@@ -119,6 +120,7 @@ export class AgentSessionWrapper {
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private onDestroyCallback: (() => void) | null = null;
   private _alive = true;
+  private bashOutputPaths = new Set<string>();
 
   constructor(public readonly inner: AgentSessionLike) {}
 
@@ -134,8 +136,42 @@ export class AgentSessionWrapper {
     return this._alive;
   }
 
+  /** Register a bash full-output path as allowed for this session (called after bash execution returns). */
+  registerBashOutputPath(path: string): void {
+    if (!path) return;
+    this.bashOutputPaths.add(path);
+  }
+
+  /** Check whether a path is allowed for reading full bash output. Falls back to scanning the session file. */
+  isBashOutputPathAllowed(path: string): boolean {
+    if (!path) return false;
+    if (this.bashOutputPaths.has(path)) return true;
+    // Fallback: scan session file for bashExecution messages with this fullOutputPath
+    try {
+      const sessionFile = this.sessionFile;
+      if (!sessionFile || !existsSync(sessionFile)) return false;
+      const content = readFileSync(sessionFile, "utf-8");
+      const lines = content.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line);
+          if (entry?.message?.role === "bashExecution" && entry?.message?.fullOutputPath === path) {
+            this.bashOutputPaths.add(path);
+            return true;
+          }
+        } catch {
+          // skip malformed line
+        }
+      }
+    } catch {
+      // best-effort
+    }
+    return false;
+  }
+
   isRunning(): boolean {
-    return this._alive && (this.promptRunning || this.inner.isStreaming || this.inner.isCompacting);
+    return this._alive && (this.promptRunning || this.inner.isStreaming || this.inner.isCompacting || this.inner.isBashRunning);
   }
 
   start(): void {
@@ -524,6 +560,27 @@ export class AgentSessionWrapper {
 
       case "set_auto_retry": {
         this.inner.setAutoRetryEnabled(command.enabled as boolean);
+        return null;
+      }
+
+      case "bash": {
+        const result = await this.inner.executeBash(
+          command.command as string,
+          undefined,
+          { excludeFromContext: command.excludeFromContext as boolean | undefined },
+        );
+        // Register the full-output temp path in the session allowlist so the
+        // /api/agent/[id]/bash-output endpoint can read it later. Done here
+        // (server-side) because rpc-manager is server-only and must not be
+        // imported from client code.
+        if (result.fullOutputPath) {
+          this.registerBashOutputPath(result.fullOutputPath);
+        }
+        return result;
+      }
+
+      case "abort_bash": {
+        this.inner.abortBash();
         return null;
       }
 

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -286,6 +286,11 @@ function entryToUiMessage(
   entry: SessionEntry,
   options: { deferThinking?: boolean; deferToolResultImages?: boolean },
 ): AgentMessage | null {
+  // Supported message roles: user, assistant, toolResult, bashExecution.
+  // bashExecution messages enter the case "message" branch (entry.type === "message").
+  // The early return at line below ("!options.deferThinking || message.role !== "assistant"")
+  // passes non-assistant messages — including bashExecution — through unchanged.
+  // normalizeToolCalls is a secondary guard (returns non-assistant messages as-is).
   switch (entry.type) {
     case "message": {
       const message = options.deferToolResultImages

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -95,7 +95,19 @@ export interface CustomMessage {
   timestamp?: number;
 }
 
-export type AgentMessage = UserMessage | AssistantMessage | ToolResultMessage | CustomMessage;
+export interface BashExecutionMessage {
+  role: "bashExecution";
+  command: string;
+  output: string;
+  exitCode?: number;
+  cancelled?: boolean;
+  truncated?: boolean;
+  fullOutputPath?: string;
+  excludeFromContext?: boolean;
+  timestamp?: number;
+}
+
+export type AgentMessage = UserMessage | AssistantMessage | ToolResultMessage | CustomMessage | BashExecutionMessage;
 
 export type ExtensionUiRequest =
   | {


### PR DESCRIPTION

### Summary

Replicate pi CLI's `!command` / `!!command` shell prefix capability in the pi-web UI, so users can run shell commands directly from the chat input — output sent to the model (`!`) or kept local (`!!`).

- `!command` — runs a shell command, output **enters LLM context** (model can reference it next turn)
- `!!command` — runs a shell command, output **stays local** (model never sees it)

No pi CLI changes — the web layer reuses pi's existing `{ type: "bash" }` / `{ type: "abort_bash" }` RPC commands and `AgentSession.executeBash()`.

<img width="917" height="613" alt="Clipboard_Screenshot_1784288942" src="https://github.com/user-attachments/assets/f28a6bc1-d314-4820-9157-7b38fc0cbeac" />


### Changes

| Area | File | Change |
|---|---|---|
| Types | `lib/types.ts` | Add `BashExecutionMessage` to `AgentMessage` union |
| Types | `lib/pi-types.ts` | Declare `executeBash` / `abortBash` / `isBashRunning` on `AgentSessionLike` |
| Passthrough | `lib/session-reader.ts`, `lib/normalize.ts` | `bashExecution` messages pass through unchanged |
| RPC dispatch | `lib/rpc-manager.ts` | `AgentSessionWrapper.send()` handles `case "bash"` / `case "abort_bash"`; bash output path allowlist (register + session-file fallback check); `isRunning()` reflects bash |
| Client logic | `hooks/useAgentSession.ts` | `handleSend` dispatches `!`/`!!` to `executeBash`; `bashRunning` + `pendingBash` state; `handleAbort` sends `abort_bash`; mutual exclusion with agent runs |
| UI wiring | `components/ChatWindow.tsx` | Disable input during bash; render `pendingBash` placeholder |
| UI feedback | `components/ChatInput.tsx` | Shell-mode border color + status label |
| UI rendering | `components/MessageView.tsx` | `BashExecutionView` **reuses `ToolCallBlock`** so user-run bash looks identical to an agent-run bash tool call |
| New endpoint | `app/api/agent/[id]/bash-output/route.ts` | Controlled read of truncated full output, guarded by session allowlist + `tmpdir`/`pi-bash-*.log` path validation |

### How it works

1. User types `!ls` → `ChatInput` shows shell-mode feedback → `handleSend` detects `!` prefix → sends `{ type: "bash", command: "ls", excludeFromContext: false }` to `/api/agent/[id]`
2. `AgentSessionWrapper.send()` `case "bash"` → `inner.executeBash()` → returns `BashResult` (output, exitCode, cancelled, truncated, fullOutputPath)
3. Client appends a `BashExecutionMessage`; `MessageView` renders it via the same `ToolCallBlock` the agent uses for bash tool calls
4. For long output (`truncated`), a "view full output" button calls the controlled endpoint, which validates the path against a session-scoped allowlist + temp-file shape before reading

### Security

The `/api/agent/[id]/bash-output` endpoint has layered guards:
- **Session allowlist**: path must be registered by this session's bash execution (or found in the session `.jsonl`), blocking cross-session access
- **Temp dir + filename**: resolved path's directory must equal `tmpdir()` and basename must match `^pi-bash-.*\.log$` — blocks traversal (`../`) and prefix-cousin attacks (`/tmp/pi-bash-evil.log`)
- Missing path → 400; not allowed → 403; read failure → 500

### Verification

- `tsc --noEmit` clean; `npm run lint` shows only pre-existing `preserve-manual-memoization` warnings (unrelated)
- Docker-isolated `next build` + 11 end-to-end API smoke tests passed:
  - `!`/`!!` dispatch, exit codes, `abort_bash` (cancelled=true)
  - long output truncation + `fullOutputPath` generation
  - endpoint: valid read (588KB), traversal → 403, prefix-cousin → 403, cross-session → 403, missing-path → 400

### Notes

- `bashExecution` messages from existing sessions (written by pi CLI) load correctly via `session-reader` passthrough
- Bash result block visually matches agent tool calls (reuses `ToolCallBlock`); `!!` commands show `bash (local)` as the tool name to distinguish
- `registerBashOutputPath` is called server-side in `case "bash"` (not from client) — `rpc-manager` is server-only and must not be imported from client code (would break the client bundle)

