### PR TITLE
feat: add mermaid diagram rendering to FileViewer markdown preview with zoom modal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -422,6 +422,72 @@ pre, code {
   font-size: 12px;
 }
 
+/* Clickable mermaid preview — opens zoom modal on click */
+.mermaid-block-clickable {
+  transition: opacity 0.15s;
+}
+.mermaid-block-clickable:hover {
+  opacity: 0.85;
+}
+
+/* ---- Mermaid zoom modal ---- */
+.mermaid-zoom-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 60px 20px 20px;
+}
+.mermaid-zoom-toolbar {
+  position: fixed;
+  top: 12px;
+  right: 16px;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(30, 30, 30, 0.85);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #eee;
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+.mermaid-zoom-toolbar button {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #eee;
+  border-radius: 5px;
+  padding: 3px 10px;
+  font-size: 14px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  transition: background 0.15s;
+}
+.mermaid-zoom-toolbar button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.22);
+}
+.mermaid-zoom-toolbar button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.mermaid-zoom-canvas {
+  transform-origin: top center;
+  transition: transform 0.2s ease;
+}
+.mermaid-zoom-canvas svg {
+  display: block;
+  max-width: none;
+  background: #fff;
+  border-radius: 4px;
+}
+
 /* File viewer markdown preview — larger headings */
 .markdown-file-preview h1 { font-size: 1.8em; }
 .markdown-file-preview h2 { font-size: 1.4em; }

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -16,6 +16,7 @@ import {
 import { encodeFilePathForApi, getFileDirectory, getFileName, getRelativeFilePath } from "@/lib/file-paths";
 import { resolveLocalFileHref } from "@/lib/file-links";
 import { markdownPreviewRehypePlugins, markdownPreviewRemarkPlugins } from "@/lib/markdown";
+import { CodeBlock, MermaidBlock } from "./MermaidBlock";
 
 interface Props {
   filePath: string;
@@ -966,6 +967,27 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile }: Props) {
               remarkPlugins={markdownPreviewRemarkPlugins}
               rehypePlugins={markdownPreviewRehypePlugins}
               components={{
+                code({ className, children, ...props }) {
+                  const lang = className?.replace("language-", "").toLowerCase() ?? "";
+                  const raw = String(children);
+                  const isBlock = className?.includes("language-") || raw.includes("\n");
+                  if (isBlock) {
+                    if (lang === "mermaid") {
+                      return <MermaidBlock code={raw.replace(/\n$/, "")} />;
+                    }
+                    return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} />;
+                  }
+                  return (
+                    <code className={className} {...props}>
+                      {children}
+                    </code>
+                  );
+                },
+                pre({ children }) {
+                  // Render the code block directly — CodeBlock provides its own wrapping.
+                  // For non-mermaid blocks, pass through to default pre rendering.
+                  return <>{children}</>;
+                },
                 a({ href, children, ...props }) {
                   delete props.node;
                   const linkedFile = onOpenFile

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import { useMemo, type MouseEvent } from "react";
 import ReactMarkdown from "react-markdown";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import { useTheme } from "@/hooks/useTheme";
-import { copyText } from "@/lib/clipboard";
 import { resolveLocalFileHref } from "@/lib/file-links";
 import { markdownRehypePlugins, markdownRemarkPlugins } from "@/lib/markdown";
+import { MermaidBlock, CodeBlock } from "./MermaidBlock";
 
 interface MarkdownBodyProps {
   children: string;
@@ -121,132 +117,4 @@ function normalizeDisplayMath(markdown: string): string {
     .join(lineBreak);
 }
 
-function MermaidBlock({ code, isStreaming }: { code: string; isStreaming?: boolean }) {
-  const { isDark } = useTheme();
-  const [showPreview, setShowPreview] = useState(false);
-  const [svg, setSvg] = useState<string | null>(null);
-  const [renderedKey, setRenderedKey] = useState("");
-  const [failedKey, setFailedKey] = useState<string | null>(null);
-  const currentKey = `${isDark ? "dark" : "light"}\n${code}`;
 
-  useEffect(() => {
-    if (!showPreview || isStreaming) return;
-
-    let cancelled = false;
-    setFailedKey(null);
-
-    const render = async () => {
-      const { default: mermaid } = await import("mermaid");
-      mermaid.initialize({
-        startOnLoad: false,
-        securityLevel: "strict",
-        suppressErrorRendering: true,
-        theme: isDark ? "dark" : "default",
-      });
-
-      const parsed = await mermaid.parse(code, { suppressErrors: true });
-      if (!parsed) throw new Error("Invalid Mermaid diagram");
-
-      const id =
-        typeof crypto !== "undefined" && "randomUUID" in crypto
-          ? `mermaid-${crypto.randomUUID()}`
-          : `mermaid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const result = await mermaid.render(id, code);
-      if (!cancelled) {
-        setSvg(result.svg);
-        setRenderedKey(currentKey);
-      }
-    };
-
-    render().catch(() => {
-      if (!cancelled) setFailedKey(currentKey);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [code, currentKey, isDark, isStreaming, showPreview]);
-
-  const previewButton = (
-    <button
-      onClick={() => setShowPreview((v) => !v)}
-      disabled={isStreaming}
-      title={isStreaming ? "Preview available after streaming" : (showPreview ? "Show Mermaid source" : "Preview Mermaid diagram")}
-      className={["markdown-code-action", showPreview ? "is-active" : ""].filter(Boolean).join(" ")}
-    >
-      {showPreview ? "Source" : "Preview"}
-    </button>
-  );
-
-  if (!showPreview || isStreaming) {
-    return <CodeBlock code={code} lang="mermaid" headerAction={previewButton} />;
-  }
-
-  const body =
-    failedKey === currentKey ? (
-      <div className="mermaid-block mermaid-block-error">Invalid Mermaid diagram</div>
-    ) : !svg || renderedKey !== currentKey ? (
-      <div className="mermaid-block mermaid-block-loading" aria-label="Rendering Mermaid diagram" />
-    ) : (
-      <div
-        className="mermaid-block"
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
-    );
-
-  return (
-    <div className="markdown-code-block">
-      <div className="markdown-code-header">
-        <span className="markdown-code-lang">mermaid</span>
-        {previewButton}
-      </div>
-      {body}
-    </div>
-  );
-}
-
-function CodeBlock({ code, lang, headerAction }: { code: string; lang: string; headerAction?: ReactNode }) {
-  const { isDark } = useTheme();
-  const [copied, setCopied] = useState(false);
-
-  const copy = () => {
-    copyText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  };
-
-  return (
-    <div className="markdown-code-block">
-      <div className="markdown-code-header">
-        <span className="markdown-code-lang">{lang || "text"}</span>
-        <div className="markdown-code-actions">
-          {headerAction}
-          <button
-            onClick={copy}
-            className="markdown-code-action"
-          >
-            {copied ? "copied" : "copy"}
-          </button>
-        </div>
-      </div>
-      <SyntaxHighlighter
-        language={lang || "text"}
-        style={isDark ? vscDarkPlus : vs}
-        showLineNumbers
-        lineNumberStyle={{ color: "var(--text-dim)", fontStyle: "normal" }}
-        customStyle={{
-          margin: 0,
-          padding: "11px 13px",
-          fontSize: 12.5,
-          lineHeight: 1.62,
-          borderRadius: 0,
-          background: "color-mix(in srgb, var(--bg) 92%, var(--bg-panel))",
-        }}
-        codeTagProps={{ style: { fontFamily: "var(--font-mono)" } }}
-      >
-        {code}
-      </SyntaxHighlighter>
-    </div>
-  );
-}

--- a/components/MermaidBlock.test.mjs
+++ b/components/MermaidBlock.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { MermaidBlock } = await jiti.import("./MermaidBlock.tsx");
+
+// Simple sequenceDiagram for testing
+const mermaidSrc = `sequenceDiagram
+    Alice->>Bob: Hello
+    Bob-->>Alice: Hi`;
+
+test("MermaidBlock renders preview view by default (loading placeholder in SSR)", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MermaidBlock, { code: mermaidSrc }),
+  );
+
+  // Defaults to preview mode; SSR can't run useEffect so we see the loading
+  // placeholder (not source code and not error).
+  assert.match(html, /mermaid-block-loading/);
+  assert.doesNotMatch(html, /mermaid-block-error/);
+  // Source code should NOT appear since we are in preview mode.
+  assert.doesNotMatch(html, /Alice/);
+});
+
+test("MermaidBlock shows 'Source' toggle when preview is default", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MermaidBlock, { code: mermaidSrc }),
+  );
+
+  assert.match(html, />Source</);
+  assert.doesNotMatch(html, />Preview</);
+});
+
+test("MermaidBlock with isStreaming falls back to source view", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MermaidBlock, { code: mermaidSrc, isStreaming: true }),
+  );
+
+  // Streaming forces source view. Button reflects current showPreview state
+  // (true by default → shows "Source"), and is disabled.
+  assert.match(html, /disabled/);
+  // Mermaid source code must be visible in the syntax-highlighted block.
+  assert.match(html, /Alice/);
+  assert.match(html, /-&gt;&gt;/);
+});
+
+test("MermaidBlock renders empty graph without error", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MermaidBlock, { code: "graph TD" }),
+  );
+
+  // Should fall through to loading placeholder, never crash.
+  assert.doesNotMatch(html, /mermaid-block-error/);
+});
+
+test("MermaidBlock handles Chinese characters in diagram", () => {
+  const chineseMermaid = `sequenceDiagram
+    participant PC as PC客户端
+    PC->>SV: 请求登录`;
+
+  const html = renderToStaticMarkup(
+    React.createElement(MermaidBlock, { code: chineseMermaid }),
+  );
+
+  // In preview-default mode (SSR), content is in loading state, not source.
+  // Verify we didn't crash on Chinese text.
+  assert.doesNotMatch(html, /mermaid-block-error/);
+  assert.match(html, /mermaid-block/);
+});

--- a/components/MermaidBlock.tsx
+++ b/components/MermaidBlock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type MouseEvent, type ReactNode, type WheelEvent } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
@@ -17,13 +17,61 @@ interface MermaidBlockProps {
  * Shows source code by default with a "Preview" toggle.
  * When preview is active, dynamically imports mermaid and renders to SVG.
  */
+const ZOOM_STEP = 0.25;
+const ZOOM_MIN = 0.25;
+const FIT_PADDING = 0.9; // 90% of viewport reserved for the diagram when fitting
+
 export function MermaidBlock({ code, isStreaming }: MermaidBlockProps) {
   const { isDark } = useTheme();
   const [showPreview, setShowPreview] = useState(true);
   const [svg, setSvg] = useState<string | null>(null);
   const [renderedKey, setRenderedKey] = useState("");
   const [failedKey, setFailedKey] = useState<string | null>(null);
+  const [zoomOpen, setZoomOpen] = useState(false);
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const dragRef = useRef({ active: false, startX: 0, startY: 0, panStartX: 0, panStartY: 0 });
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const fitDoneRef = useRef(false);
   const currentKey = `${isDark ? "dark" : "light"}\n${code}`;
+
+  // Fit-to-screen: measure SVG natural size and scale to fit viewport.
+  useEffect(() => {
+    if (!zoomOpen || !canvasRef.current || fitDoneRef.current) return;
+    const raf = requestAnimationFrame(() => {
+      const svgEl = canvasRef.current?.querySelector("svg");
+      if (!svgEl) return;
+      const vw = window.innerWidth * FIT_PADDING;
+      const vh = window.innerHeight * FIT_PADDING;
+      const rect = svgEl.getBoundingClientRect();
+      const sw = rect.width || 800;
+      const sh = rect.height || 600;
+      // Fit the smaller axis; no upper bound — let the diagram fill the viewport.
+      const fit = Math.min(vw / sw, vh / sh);
+      const scale = Math.max(ZOOM_MIN, fit);
+      setZoomLevel(scale);
+      setPan({ x: 0, y: 0 });
+      fitDoneRef.current = true;
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [zoomOpen, svg]);
+
+  // Zoom modal: lock body scroll and handle Escape key.
+  useEffect(() => {
+    if (!zoomOpen) return;
+
+    document.body.style.overflow = "hidden";
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeZoom();
+    };
+    window.addEventListener("keydown", onKey);
+
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [zoomOpen]);
 
   useEffect(() => {
     if (!showPreview || isStreaming) return;
@@ -78,16 +126,122 @@ export function MermaidBlock({ code, isStreaming }: MermaidBlockProps) {
     return <CodeBlock code={code} lang="mermaid" headerAction={previewButton} />;
   }
 
+  const closeZoom = () => {
+    setZoomOpen(false);
+    setZoomLevel(1);
+    setPan({ x: 0, y: 0 });
+  };
+
+  const resetZoom = () => {
+    setZoomLevel(1);
+    setPan({ x: 0, y: 0 });
+  };
+
+  // Wheel zoom inside the modal — no upper bound.
+  const handleWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    setZoomLevel((z) => Math.max(ZOOM_MIN, z - e.deltaY * 0.002));
+  };
+
+  // Drag-to-pan inside the modal.
+  const handleMouseDown = (e: MouseEvent) => {
+    // Only left button.
+    if (e.button !== 0) return;
+    e.preventDefault();
+    dragRef.current = {
+      active: true,
+      startX: e.clientX,
+      startY: e.clientY,
+      panStartX: pan.x,
+      panStartY: pan.y,
+    };
+  };
+
+  useEffect(() => {
+    if (!zoomOpen) return;
+    const onMove = (e: globalThis.MouseEvent) => {
+      if (!dragRef.current.active) return;
+      setPan({
+        x: dragRef.current.panStartX + (e.clientX - dragRef.current.startX),
+        y: dragRef.current.panStartY + (e.clientY - dragRef.current.startY),
+      });
+    };
+    const onUp = () => {
+      dragRef.current.active = false;
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [zoomOpen, pan.x, pan.y]);
+
   const body =
     failedKey === currentKey ? (
       <div className="mermaid-block mermaid-block-error">Invalid Mermaid diagram</div>
     ) : !svg || renderedKey !== currentKey ? (
       <div className="mermaid-block mermaid-block-loading" aria-label="Rendering Mermaid diagram" />
     ) : (
-      <div
-        className="mermaid-block"
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
+      <>
+        {/* Clickable inline preview — opens zoom modal */}
+        <div
+          className="mermaid-block mermaid-block-clickable"
+          style={{ cursor: "pointer" }}
+          title="Click to zoom"
+          onClick={() => { setZoomOpen(true); fitDoneRef.current = false; }}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+        {/* Zoom modal */}
+        {zoomOpen && (
+          <div
+            className="mermaid-zoom-backdrop"
+            onClick={(e) => {
+              // Close only when clicking the backdrop, not the SVG inside.
+              if (e.target === e.currentTarget) closeZoom();
+            }}
+          >
+            <div className="mermaid-zoom-toolbar">
+              <button
+                style={{ touchAction: "manipulation" }}
+                onClick={() => setZoomLevel((z) => Math.max(ZOOM_MIN, z - ZOOM_STEP))}
+                disabled={zoomLevel <= ZOOM_MIN}
+                title="Zoom out"
+              >
+                -
+              </button>
+              <span style={{ fontSize: 12, minWidth: 48, textAlign: "center", userSelect: "none" }}>
+                {Math.round(zoomLevel * 100)}%
+              </span>
+              <button
+                style={{ touchAction: "manipulation" }}
+                onClick={() => setZoomLevel((z) => z + ZOOM_STEP)}
+                title="Zoom in"
+              >
+                +
+              </button>
+              <button
+                style={{ touchAction: "manipulation", marginLeft: 8 }}
+                onClick={resetZoom}
+                title="Reset zoom & pan"
+              >
+                reset
+              </button>
+            </div>
+            <div
+              ref={canvasRef}
+              className="mermaid-zoom-canvas"
+              onWheel={handleWheel}
+              onMouseDown={handleMouseDown}
+              style={{
+                transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoomLevel})`,
+                cursor: dragRef.current.active ? "grabbing" : "grab",
+              }}
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </div>
+        )}
+      </>
     );
 
   return (

--- a/components/MermaidBlock.tsx
+++ b/components/MermaidBlock.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { vs } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { useTheme } from "@/hooks/useTheme";
+import { copyText } from "@/lib/clipboard";
+
+interface MermaidBlockProps {
+  code: string;
+  isStreaming?: boolean;
+}
+
+/**
+ * Renders a Mermaid diagram from a fenced code block.
+ * Shows source code by default with a "Preview" toggle.
+ * When preview is active, dynamically imports mermaid and renders to SVG.
+ */
+export function MermaidBlock({ code, isStreaming }: MermaidBlockProps) {
+  const { isDark } = useTheme();
+  const [showPreview, setShowPreview] = useState(true);
+  const [svg, setSvg] = useState<string | null>(null);
+  const [renderedKey, setRenderedKey] = useState("");
+  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const currentKey = `${isDark ? "dark" : "light"}\n${code}`;
+
+  useEffect(() => {
+    if (!showPreview || isStreaming) return;
+
+    let cancelled = false;
+    setFailedKey(null);
+
+    const render = async () => {
+      const { default: mermaid } = await import("mermaid");
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "strict",
+        suppressErrorRendering: true,
+        theme: isDark ? "dark" : "default",
+      });
+
+      const parsed = await mermaid.parse(code, { suppressErrors: true });
+      if (!parsed) throw new Error("Invalid Mermaid diagram");
+
+      const id =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? `mermaid-${crypto.randomUUID()}`
+          : `mermaid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const result = await mermaid.render(id, code);
+      if (!cancelled) {
+        setSvg(result.svg);
+        setRenderedKey(currentKey);
+      }
+    };
+
+    render().catch(() => {
+      if (!cancelled) setFailedKey(currentKey);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, isDark, isStreaming, showPreview]);
+
+  const previewButton = (
+    <button
+      onClick={() => setShowPreview((v) => !v)}
+      disabled={isStreaming}
+      title={isStreaming ? "Preview available after streaming" : (showPreview ? "Show Mermaid source" : "Preview Mermaid diagram")}
+      className={["markdown-code-action", showPreview ? "is-active" : ""].filter(Boolean).join(" ")}
+    >
+      {showPreview ? "Source" : "Preview"}
+    </button>
+  );
+
+  if (!showPreview || isStreaming) {
+    return <CodeBlock code={code} lang="mermaid" headerAction={previewButton} />;
+  }
+
+  const body =
+    failedKey === currentKey ? (
+      <div className="mermaid-block mermaid-block-error">Invalid Mermaid diagram</div>
+    ) : !svg || renderedKey !== currentKey ? (
+      <div className="mermaid-block mermaid-block-loading" aria-label="Rendering Mermaid diagram" />
+    ) : (
+      <div
+        className="mermaid-block"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    );
+
+  return (
+    <div className="markdown-code-block">
+      <div className="markdown-code-header">
+        <span className="markdown-code-lang">mermaid</span>
+        {previewButton}
+      </div>
+      {body}
+    </div>
+  );
+}
+
+interface CodeBlockProps {
+  code: string;
+  lang: string;
+  headerAction?: ReactNode;
+}
+
+/**
+ * Syntax-highlighted code block with copy button.
+ * Used as the "source" view for mermaid blocks and for all non-mermaid code fences.
+ */
+export function CodeBlock({ code, lang, headerAction }: CodeBlockProps) {
+  const { isDark } = useTheme();
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    copyText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className="markdown-code-block">
+      <div className="markdown-code-header">
+        <span className="markdown-code-lang">{lang || "text"}</span>
+        <div className="markdown-code-actions">
+          {headerAction}
+          <button
+            onClick={copy}
+            className="markdown-code-action"
+          >
+            {copied ? "copied" : "copy"}
+          </button>
+        </div>
+      </div>
+      <SyntaxHighlighter
+        language={lang || "text"}
+        style={isDark ? vscDarkPlus : vs}
+        showLineNumbers
+        lineNumberStyle={{ color: "var(--text-dim)", fontStyle: "normal" }}
+        customStyle={{
+          margin: 0,
+          padding: "11px 13px",
+          fontSize: 12.5,
+          lineHeight: 1.62,
+          borderRadius: 0,
+          background: "color-mix(in srgb, var(--bg) 92%, var(--bg-panel))",
+        }}
+        codeTagProps={{ style: { fontFamily: "var(--font-mono)" } }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}


### PR DESCRIPTION
改动:

1. FileViewer markdown 预览支持 mermaid 渲染 — 将 MermaidBlock 和 CodeBlock 从 MarkdownBody 提取为共享组件。FileViewer 的 markdown 预览现在以和聊天消息一致的方式渲染 mermaid 图表，包括预览模式和一致的代码块样式。

2. Mermaid 缩放弹窗 — 点击已渲染的 mermaid SVG 打开全屏缩放弹窗，支持:
   - 滚轮缩放 (无上限) 和拖拽平移
   - 打开时自动适配屏幕 (auto-scale to fill viewport)
   - 重置按钮、Escape / 点击背景关闭
   - 页面滚动锁定和移动端 touch-action

测试覆盖:

- 5 个单元测试 (MermaidBlock.test.mjs)，覆盖 SSR 初始状态、流式模式和渲染边界情况

文件变更:

  components/MermaidBlock.tsx — 新增共享组件 (从 MarkdownBody 提取)
  components/MermaidBlock.test.mjs — 5 个单测
  components/MarkdownBody.tsx — 重构: 提取 mermaid/code block 逻辑
  components/FileViewer.tsx — 在 markdown 预览中使用 MermaidBlock
  app/globals.css — 缩放弹窗样式