### PR TITLE
Harden local API and filesystem security boundaries

### DIFF
--- a/app/api/file-index/route.ts
+++ b/app/api/file-index/route.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import path from "path";
 import {
   getAllowedFileRoots,
+  isExistingFilePathAllowed,
   isFilePathAllowed,
   isWindowsAbsolutePath,
 } from "@/lib/file-access";
@@ -134,6 +135,9 @@ export async function GET(req: NextRequest) {
     }
     if (!stat.isDirectory()) {
       return NextResponse.json({ error: "Not a directory" }, { status: 400 });
+    }
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     const cache = getIndexCache();

--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import {
   getAllowedFileRoots,
+  isExistingFilePathAllowed,
   isFilePathAllowed,
   isWindowsAbsolutePath,
   normalizeSlashes,
@@ -36,6 +37,8 @@ const IGNORED_SUFFIXES = [".pyc"];
 const FILE_REQUEST_TYPES = ["list", "read", "download", "meta", "preview", "watch"] as const;
 type FileRequestType = typeof FILE_REQUEST_TYPES[number];
 const FILE_REQUEST_TYPE_SET = new Set<string>(FILE_REQUEST_TYPES);
+const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_UPLOAD_TOTAL_BYTES = 100 * 1024 * 1024;
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
   ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
@@ -150,6 +153,12 @@ export async function POST(
 
     const formData = await request.formData();
     const files = formData.getAll("files").filter((entry): entry is File => typeof entry !== "string");
+    if (files.some((file) => file.size > MAX_UPLOAD_FILE_BYTES)) {
+      return NextResponse.json({ error: "Each upload must be 25MB or smaller" }, { status: 413 });
+    }
+    if (files.reduce((total, file) => total + file.size, 0) > MAX_UPLOAD_TOTAL_BYTES) {
+      return NextResponse.json({ error: "Uploads must total 100MB or less" }, { status: 413 });
+    }
     const fileNames = files.map((file) => file.name);
     const validationError = validateUploadFileNames(fileNames);
     if (validationError) {
@@ -415,6 +424,10 @@ export async function GET(
       stat = fs.statSync(filePath);
     } catch {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    if (!allowedBySessionReference && !isExistingFilePathAllowed(filePath, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     if (type === "read") {

--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -25,6 +25,7 @@ import {
   parseUploadConflictStrategy,
   validateUploadFileNames,
 } from "@/lib/file-upload";
+import { parseFormDataWithinLimit, RequestBodyTooLargeError } from "@/lib/bounded-form-data";
 
 const IGNORED_NAMES = new Set([
   "node_modules", ".git", ".next", "dist", "build", "__pycache__",
@@ -39,6 +40,8 @@ type FileRequestType = typeof FILE_REQUEST_TYPES[number];
 const FILE_REQUEST_TYPE_SET = new Set<string>(FILE_REQUEST_TYPES);
 const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
 const MAX_UPLOAD_TOTAL_BYTES = 100 * 1024 * 1024;
+// Multipart boundaries and headers are not file bytes, but must be bounded too.
+const MAX_UPLOAD_REQUEST_BYTES = MAX_UPLOAD_TOTAL_BYTES + 1024 * 1024;
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
   ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
@@ -151,7 +154,15 @@ export async function POST(
       return NextResponse.json({ error: "Invalid conflict strategy" }, { status: 400 });
     }
 
-    const formData = await request.formData();
+    let formData: FormData;
+    try {
+      formData = await parseFormDataWithinLimit(request, MAX_UPLOAD_REQUEST_BYTES);
+    } catch (error) {
+      if (error instanceof RequestBodyTooLargeError) {
+        return NextResponse.json({ error: "Uploads must total 100MB or less" }, { status: 413 });
+      }
+      throw error;
+    }
     const files = formData.getAll("files").filter((entry): entry is File => typeof entry !== "string");
     if (files.some((file) => file.size > MAX_UPLOAD_FILE_BYTES)) {
       return NextResponse.json({ error: "Each upload must be 25MB or smaller" }, { status: 413 });

--- a/app/api/git/diff/route.ts
+++ b/app/api/git/diff/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAllowedFileRoots, isFilePathAllowed, isWindowsAbsolutePath } from "@/lib/file-access";
+import { getAllowedFileRoots, isExistingFilePathAllowed, isFilePathAllowed, isWindowsAbsolutePath } from "@/lib/file-access";
 import { getGitFileDiff } from "@/lib/git-changes";
 
 export async function GET(request: NextRequest) {
@@ -15,6 +15,9 @@ export async function GET(request: NextRequest) {
 
     const allowedRoots = await getAllowedFileRoots();
     if (!isFilePathAllowed(cwd, allowedRoots) || !isFilePathAllowed(filePath, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+    if (!isExistingFilePathAllowed(cwd, allowedRoots) || !isExistingFilePathAllowed(filePath, allowedRoots)) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 

--- a/app/api/git/status/route.ts
+++ b/app/api/git/status/route.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { NextRequest, NextResponse } from "next/server";
-import { getAllowedFileRoots, isFilePathAllowed, isWindowsAbsolutePath } from "@/lib/file-access";
+import { getAllowedFileRoots, isExistingFilePathAllowed, isFilePathAllowed, isWindowsAbsolutePath } from "@/lib/file-access";
 import { getGitStatus } from "@/lib/git-changes";
 
 export async function GET(request: NextRequest) {
@@ -23,6 +23,9 @@ export async function GET(request: NextRequest) {
     }
     if (!stat.isDirectory()) {
       return NextResponse.json({ error: "Not a directory" }, { status: 400 });
+    }
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     return NextResponse.json(await getGitStatus(cwd));

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { loadModelsWithCache, type ModelsData } from "@/lib/models-cache";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 
 export const dynamic = "force-dynamic";
 
@@ -92,6 +93,10 @@ export async function GET(req: Request) {
   }
   if (!cwdStat.isDirectory()) {
     return Response.json({ error: `Not a directory: ${cwd}` }, { status: 400 });
+  }
+  const allowedRoots = await getAllowedFileRoots();
+  if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
   try {

--- a/app/api/plugins/route.ts
+++ b/app/api/plugins/route.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedPaths,
   type ResolvedResource,
 } from "@earendil-works/pi-coding-agent";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 import type {
   PluginDiagnostic,
   PluginPackageInfo,
@@ -272,6 +273,10 @@ export async function GET(req: Request) {
   if (!cwd) return NextResponse.json({ error: "cwd required" }, { status: 400 });
 
   try {
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
     return NextResponse.json(await readPlugins(cwd));
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
@@ -289,6 +294,10 @@ export async function POST(req: Request) {
     };
     if (!body.cwd) return NextResponse.json({ error: "cwd required" }, { status: 400 });
     if (!body.action) return NextResponse.json({ error: "action required" }, { status: 400 });
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isExistingFilePathAllowed(body.cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
 
     const settingsManager = SettingsManager.create(body.cwd, getAgentDir());
     const packageManager = new DefaultPackageManager({

--- a/app/api/skills/check/route.ts
+++ b/app/api/skills/check/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { SkillInstallScope } from "@/lib/api-types";
 import { checkSkillUpdates } from "@/lib/skill-updates";
 import { loadSkillsWithInstallInfo } from "@/lib/skills-service";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +15,10 @@ export async function POST(req: Request) {
     };
     const cwd = typeof body.cwd === "string" ? body.cwd : "";
     if (!cwd) return NextResponse.json({ error: "cwd required" }, { status: 400 });
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
 
     const pkg = typeof body.package === "string" ? body.package : undefined;
     const scope = body.scope === "global" || body.scope === "project"

--- a/app/api/skills/install/route.ts
+++ b/app/api/skills/install/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { runNpx } from "@/lib/npx";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,13 @@ export async function POST(req: Request) {
     if (!pkg?.trim()) return NextResponse.json({ error: "package required" }, { status: 400 });
 
     const isGlobal = scope !== "project";
+    if (!isGlobal) {
+      if (!cwd) return NextResponse.json({ error: "cwd required for project install" }, { status: 400 });
+      const allowedRoots = await getAllowedFileRoots();
+      if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      }
+    }
     const args = ["skills", "add", pkg.trim(), "-y", "--agent", "pi"];
     if (isGlobal) args.push("-g");
 

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { loadSkillsWithInstallInfo } from "@/lib/skills-service";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +15,10 @@ export async function GET(req: Request) {
   if (!cwd) return NextResponse.json({ error: "cwd required" }, { status: 400 });
 
   try {
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
     return NextResponse.json(await loadSkillsWithInstallInfo(cwd));
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });
@@ -27,6 +32,11 @@ export async function PATCH(req: Request) {
     const { filePath, disableModelInvocation } = body;
     if (!filePath) return NextResponse.json({ error: "filePath required" }, { status: 400 });
     if (!existsSync(filePath)) return NextResponse.json({ error: "file not found" }, { status: 404 });
+    const allowedRoots = new Set(await getAllowedFileRoots());
+    allowedRoots.add(getAgentDir());
+    if (!isExistingFilePathAllowed(filePath, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
 
     const content = readFileSync(filePath, "utf8");
     const key = "disable-model-invocation";

--- a/app/api/skills/update/route.ts
+++ b/app/api/skills/update/route.ts
@@ -3,6 +3,7 @@ import { runNpx } from "@/lib/npx";
 import type { SkillInstallScope } from "@/lib/api-types";
 import { buildSkillUpdateArgs } from "@/lib/skill-updates";
 import { loadSkillsWithInstallInfo } from "@/lib/skills-service";
+import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +21,10 @@ export async function POST(req: Request) {
       : undefined;
     if (!cwd || !pkg || !scope) {
       return NextResponse.json({ error: "cwd, package, and scope are required" }, { status: 400 });
+    }
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isExistingFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     const { skills } = await loadSkillsWithInstallInfo(cwd);

--- a/app/api/worktrees/route.ts
+++ b/app/api/worktrees/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
 import { addWorktree, listWorktrees, removeWorktree, resolveProject } from "@/lib/worktree";
-import { allowFileRoot, getAllowedFileRoots, isFilePathAllowed } from "@/lib/file-access";
+import { allowFileRoot, getAllowedFileRoots, isExistingFilePathAllowed, isFilePathAllowed } from "@/lib/file-access";
 
 /** Same gate as /api/files: only session cwds / project roots / explicitly
  *  allowed dirs may be inspected or mutated through this endpoint. */
 async function checkCwdAllowed(cwd: string): Promise<NextResponse | null> {
   const allowedRoots = await getAllowedFileRoots();
-  if (!isFilePathAllowed(cwd, allowedRoots)) {
+  if (!isFilePathAllowed(cwd, allowedRoots) || !isExistingFilePathAllowed(cwd, allowedRoots)) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }
   return null;

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -70,6 +70,8 @@ export interface ChatInputHandle {
 const TOOL_PRESETS = ["off", "default", "full"] as const;
 const TOOL_PRESET_MAP: Record<"off" | "default" | "full", "none" | "default" | "full"> = { off: "none", default: "default", full: "full" };
 const COMPOSITION_END_ENTER_GRACE_MS = 100;
+const MAX_ATTACHED_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHED_IMAGES = 10;
 const MODEL_OPTION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 function compareModelOptions(a: ModelOption, b: ModelOption): number {
@@ -302,7 +304,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
   const processImageFiles = useCallback(async (files: File[]) => {
     if (isStreaming) return;
-    const imageFiles = files.filter((f) => f.type.startsWith("image/"));
+    const remaining = Math.max(0, MAX_ATTACHED_IMAGES - attachedImagesRef.current.length);
+    const imageFiles = files
+      .filter((f) => f.type.startsWith("image/") && f.size <= MAX_ATTACHED_IMAGE_BYTES)
+      .slice(0, remaining);
     if (!imageFiles.length) return;
     const newImages = await Promise.all(
       imageFiles.map(

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -4,6 +4,11 @@ import React, { useRef, useState, useCallback, useEffect, useImperativeHandle, f
 import type { BuiltinSlashCommandResult, CompactResultInfo, QueuedMessages, SlashCommandInfo } from "@/hooks/useAgentSession";
 import { clearDraft, getDraft, setDraft, type ChatDraftImage } from "@/lib/draft-store";
 import {
+  MAX_ATTACHED_IMAGE_BYTES,
+  MAX_ATTACHED_IMAGES,
+  isBase64ImageWithinLimits,
+} from "@/lib/image-attachments";
+import {
   buildEntriesFromFiles, buildAtInsertText, extractAtQuery, filterFileEntries,
   type AtQueryMatch, type FileIndexEntry,
 } from "@/lib/file-fuzzy";
@@ -70,8 +75,6 @@ export interface ChatInputHandle {
 const TOOL_PRESETS = ["off", "default", "full"] as const;
 const TOOL_PRESET_MAP: Record<"off" | "default" | "full", "none" | "default" | "full"> = { off: "none", default: "default", full: "full" };
 const COMPOSITION_END_ENTER_GRACE_MS = 100;
-const MAX_ATTACHED_IMAGE_BYTES = 10 * 1024 * 1024;
-const MAX_ATTACHED_IMAGES = 10;
 const MODEL_OPTION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 function compareModelOptions(a: ModelOption, b: ModelOption): number {
@@ -151,6 +154,13 @@ function draftImageToAttachedImage(image: ChatDraftImage): AttachedImage {
   };
 }
 
+function draftImagesToAttachedImages(images: ChatDraftImage[] | undefined): AttachedImage[] {
+  return (images ?? [])
+    .filter(isBase64ImageWithinLimits)
+    .slice(0, MAX_ATTACHED_IMAGES)
+    .map(draftImageToAttachedImage);
+}
+
 function revokeImagePreview(image: AttachedImage): void {
   if (image.previewUrl.startsWith("blob:")) {
     URL.revokeObjectURL(image.previewUrl);
@@ -209,7 +219,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const [thinkingDropdownOpen, setThinkingDropdownOpen] = useState(false);
   const [controlsMenuOpen, setControlsMenuOpen] = useState(false);
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>(() => (
-    draftKey ? getDraft(draftKey)?.images.map(draftImageToAttachedImage) ?? [] : []
+    draftKey ? draftImagesToAttachedImages(getDraft(draftKey)?.images) : []
   ));
   const trimmedValue = value.trimStart();
   const bashMode = attachedImages.length === 0 && trimmedValue.startsWith("!");
@@ -240,6 +250,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const draftKeyRef = useRef(draftKey);
   const valueRef = useRef(value);
   const attachedImagesRef = useRef(attachedImages);
+  const pendingImageCountRef = useRef(0);
   valueRef.current = value;
   attachedImagesRef.current = attachedImages;
 
@@ -304,28 +315,40 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
   const processImageFiles = useCallback(async (files: File[]) => {
     if (isStreaming) return;
-    const remaining = Math.max(0, MAX_ATTACHED_IMAGES - attachedImagesRef.current.length);
+    const remaining = Math.max(
+      0,
+      MAX_ATTACHED_IMAGES - attachedImagesRef.current.length - pendingImageCountRef.current,
+    );
     const imageFiles = files
       .filter((f) => f.type.startsWith("image/") && f.size <= MAX_ATTACHED_IMAGE_BYTES)
       .slice(0, remaining);
     if (!imageFiles.length) return;
-    const newImages = await Promise.all(
-      imageFiles.map(
-        (file) =>
-          new Promise<AttachedImage>((resolve, reject) => {
-            const reader = new FileReader();
-            reader.onload = () => {
-              const result = reader.result as string;
-              // result is "data:<mime>;base64,<data>"
-              const base64 = result.split(",")[1];
-              resolve({ data: base64, mimeType: file.type, previewUrl: URL.createObjectURL(file) });
-            };
-            reader.onerror = reject;
-            reader.readAsDataURL(file);
-          })
-      )
-    );
-    setAttachedImages((prev) => [...prev, ...newImages]);
+    pendingImageCountRef.current += imageFiles.length;
+    try {
+      const newImages = await Promise.all(
+        imageFiles.map(
+          (file) =>
+            new Promise<AttachedImage>((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onload = () => {
+                const result = reader.result as string;
+                // result is "data:<mime>;base64,<data>"
+                const base64 = result.split(",")[1];
+                resolve({ data: base64, mimeType: file.type, previewUrl: URL.createObjectURL(file) });
+              };
+              reader.onerror = reject;
+              reader.readAsDataURL(file);
+            })
+        )
+      );
+      setAttachedImages((prev) => {
+        const accepted = newImages.slice(0, Math.max(0, MAX_ATTACHED_IMAGES - prev.length));
+        newImages.slice(accepted.length).forEach(revokeImagePreview);
+        return [...prev, ...accepted];
+      });
+    } finally {
+      pendingImageCountRef.current -= imageFiles.length;
+    }
   }, [isStreaming]);
 
   const removeImage = useCallback((index: number) => {
@@ -380,7 +403,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     setAtQuery(null);
     setAttachedImages((prev) => {
       prev.forEach(revokeImagePreview);
-      return draft?.images.map(draftImageToAttachedImage) ?? [];
+      return draftImagesToAttachedImages(draft?.images);
     });
   }, [draftKey]);
 

--- a/lib/bash-output.test.mjs
+++ b/lib/bash-output.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 async function loadSubject() {
@@ -10,15 +10,16 @@ async function loadSubject() {
 
 test("accepts only pi bash logs directly inside the configured temp directory", async () => {
   const { resolveBashOutputPath } = await loadSubject();
-  const tempRoot = "/tmp/pi-web-output-tests";
+  const tempRoot = join(tmpdir(), "pi-web-output-tests");
+  const expected = resolve(tempRoot, "pi-bash-ab12.log");
 
   assert.equal(
-    resolveBashOutputPath(`${tempRoot}/pi-bash-ab12.log`, tempRoot),
-    `${tempRoot}/pi-bash-ab12.log`,
+    resolveBashOutputPath(join(tempRoot, "pi-bash-ab12.log"), tempRoot),
+    expected,
   );
-  assert.equal(resolveBashOutputPath(`${tempRoot}/../pi-bash-ab12.log`, tempRoot), null);
-  assert.equal(resolveBashOutputPath(`${tempRoot}/pi-bash-ab12.log.bak`, tempRoot), null);
-  assert.equal(resolveBashOutputPath(`${tempRoot}-other/pi-bash-ab12.log`, tempRoot), null);
+  assert.equal(resolveBashOutputPath(join(tempRoot, "..", "pi-bash-ab12.log"), tempRoot), null);
+  assert.equal(resolveBashOutputPath(join(tempRoot, "pi-bash-ab12.log.bak"), tempRoot), null);
+  assert.equal(resolveBashOutputPath(join(`${tempRoot}-other`, "pi-bash-ab12.log"), tempRoot), null);
 });
 
 test("reads small output and rejects oversized inline output before buffering it", async () => {

--- a/lib/bounded-form-data.test.mjs
+++ b/lib/bounded-form-data.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./bounded-form-data.ts");
+}
+
+function multipartBody(boundary, value) {
+  return `--${boundary}\r\nContent-Disposition: form-data; name="value"\r\n\r\n${value}\r\n--${boundary}--\r\n`;
+}
+
+test("rejects a declared oversized request before reading its body", async () => {
+  const { parseFormDataWithinLimit, RequestBodyTooLargeError } = await loadSubject();
+  const request = new Request("http://localhost/upload", {
+    method: "POST",
+    headers: { "content-length": "99", "content-type": "multipart/form-data; boundary=test" },
+    body: multipartBody("test", "small"),
+  });
+
+  await assert.rejects(() => parseFormDataWithinLimit(request, 10), RequestBodyTooLargeError);
+});
+
+test("stops a chunked request once its body exceeds the limit", async () => {
+  const { parseFormDataWithinLimit, RequestBodyTooLargeError } = await loadSubject();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("1234"));
+      controller.enqueue(new TextEncoder().encode("5678"));
+      controller.close();
+    },
+  });
+  const request = new Request("http://localhost/upload", {
+    method: "POST",
+    headers: { "content-type": "multipart/form-data; boundary=test" },
+    body: stream,
+    duplex: "half",
+  });
+
+  await assert.rejects(() => parseFormDataWithinLimit(request, 6), RequestBodyTooLargeError);
+});
+
+test("parses multipart data inside the request limit", async () => {
+  const { parseFormDataWithinLimit } = await loadSubject();
+  const boundary = "test";
+  const body = multipartBody(boundary, "small");
+  const request = new Request("http://localhost/upload", {
+    method: "POST",
+    headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    body,
+  });
+
+  const formData = await parseFormDataWithinLimit(request, body.length + 1);
+  assert.equal(formData.get("value"), "small");
+});

--- a/lib/bounded-form-data.ts
+++ b/lib/bounded-form-data.ts
@@ -1,0 +1,49 @@
+export class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super("Request body exceeds the allowed size");
+  }
+}
+
+function declaredContentLength(request: Request): number | null {
+  const value = request.headers.get("content-length");
+  if (!value || !/^\d+$/.test(value)) return null;
+  const length = Number(value);
+  return Number.isSafeInteger(length) ? length : null;
+}
+
+/**
+ * Parse multipart data only after constraining the complete wire body. This
+ * bounds chunked requests too, where Content-Length is unavailable or false.
+ */
+export async function parseFormDataWithinLimit(request: Request, maxBytes: number): Promise<FormData> {
+  const declared = declaredContentLength(request);
+  if (declared !== null && declared > maxBytes) {
+    throw new RequestBodyTooLargeError();
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) return request.formData();
+
+  const chunks: BlobPart[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (size + value.byteLength > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new RequestBodyTooLargeError();
+      }
+      size += value.byteLength;
+      const chunk = new Uint8Array(value.byteLength);
+      chunk.set(value);
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const contentType = request.headers.get("content-type");
+  const headers = contentType ? { "content-type": contentType } : undefined;
+  return new Response(new Blob(chunks), { headers }).formData();
+}

--- a/lib/file-access.test.mjs
+++ b/lib/file-access.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./path-security.ts");
+}
+
+test("rejects an existing path that escapes an allowed root through a symlink", async (t) => {
+  const { isExistingPathWithinRoots, isPathWithinRoots } = await loadSubject();
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-file-access-"));
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const allowed = path.join(base, "allowed");
+  const outside = path.join(base, "outside");
+  fs.mkdirSync(allowed);
+  fs.mkdirSync(outside);
+  fs.writeFileSync(path.join(outside, "secret.txt"), "secret");
+  const link = path.join(allowed, "link");
+  fs.symlinkSync(outside, link, process.platform === "win32" ? "junction" : "dir");
+  const target = path.join(link, "secret.txt");
+  const roots = new Set([allowed]);
+
+  assert.equal(isPathWithinRoots(target, roots), true);
+  assert.equal(isExistingPathWithinRoots(target, roots), false);
+});

--- a/lib/file-access.ts
+++ b/lib/file-access.ts
@@ -2,6 +2,7 @@ import { readdirSync } from "fs";
 import { homedir } from "os";
 import path from "path";
 import { getAdditionalAllowedRoots, normalizeSlashes } from "./allowed-roots";
+import { isExistingPathWithinRoots } from "./path-security";
 import { listAllSessions } from "./session-reader";
 export { allowFileRoot, normalizeSlashes } from "./allowed-roots";
 
@@ -66,4 +67,9 @@ export function isFilePathAllowed(target: string, allowedRoots: Set<string>): bo
     }
   }
   return false;
+}
+
+/** Authorize an existing path after resolving symbolic links. */
+export function isExistingFilePathAllowed(target: string, allowedRoots: Set<string>): boolean {
+  return isExistingPathWithinRoots(target, allowedRoots);
 }

--- a/lib/image-attachments.test.mjs
+++ b/lib/image-attachments.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./image-attachments.ts");
+}
+
+const image = { type: "image", mimeType: "image/png", data: "YWJj" };
+
+test("calculates padded base64 byte lengths and rejects invalid data", async () => {
+  const { getBase64DecodedByteLength } = await loadSubject();
+
+  assert.equal(getBase64DecodedByteLength("YQ=="), 1);
+  assert.equal(getBase64DecodedByteLength("YWI="), 2);
+  assert.equal(getBase64DecodedByteLength("YWJj"), 3);
+  assert.equal(getBase64DecodedByteLength("not base64!"), null);
+});
+
+test("rejects invalid, oversized, and too many image attachments", async () => {
+  const { MAX_ATTACHED_IMAGE_BYTES, MAX_ATTACHED_IMAGES, validateAgentImages } = await loadSubject();
+  const oversizedData = "AAAA".repeat(Math.ceil((MAX_ATTACHED_IMAGE_BYTES + 1) / 3));
+
+  assert.equal(validateAgentImages([image]), null);
+  assert.match(validateAgentImages([{ ...image, mimeType: "text/plain" }]), /valid base64 image/);
+  assert.match(validateAgentImages([{ ...image, data: oversizedData }]), /10MB/);
+  assert.match(validateAgentImages(Array.from({ length: MAX_ATTACHED_IMAGES + 1 }, () => image)), /at most/);
+});

--- a/lib/image-attachments.ts
+++ b/lib/image-attachments.ts
@@ -1,0 +1,56 @@
+export const MAX_ATTACHED_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_ATTACHED_IMAGES = 10;
+
+export interface Base64ImageAttachment {
+  data: string;
+  mimeType: string;
+}
+
+function isBase64DataChar(code: number): boolean {
+  return (code >= 0x41 && code <= 0x5a)
+    || (code >= 0x61 && code <= 0x7a)
+    || (code >= 0x30 && code <= 0x39)
+    || code === 0x2b
+    || code === 0x2f;
+}
+
+export function getBase64DecodedByteLength(data: string): number | null {
+  if (!data || data.length % 4 !== 0) return null;
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  const dataEnd = data.length - padding;
+  for (let index = 0; index < dataEnd; index += 1) {
+    if (!isBase64DataChar(data.charCodeAt(index))) return null;
+  }
+  for (let index = dataEnd; index < data.length; index += 1) {
+    if (data[index] !== "=") return null;
+  }
+  return (data.length / 4) * 3 - padding;
+}
+
+export function isBase64ImageWithinLimits(value: unknown): value is Base64ImageAttachment {
+  if (!value || typeof value !== "object") return false;
+  const image = value as Partial<Base64ImageAttachment>;
+  if (typeof image.data !== "string" || typeof image.mimeType !== "string" || !image.mimeType.startsWith("image/")) {
+    return false;
+  }
+  const bytes = getBase64DecodedByteLength(image.data);
+  return bytes !== null && bytes <= MAX_ATTACHED_IMAGE_BYTES;
+}
+
+/** Return an API-safe error for prompt, steering, and follow-up image arrays. */
+export function validateAgentImages(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (!Array.isArray(value)) return "images must be an array";
+  if (value.length > MAX_ATTACHED_IMAGES) {
+    return `A message can include at most ${MAX_ATTACHED_IMAGES} images`;
+  }
+  for (const image of value) {
+    if (!image || typeof image !== "object" || (image as { type?: unknown }).type !== "image") {
+      return "Each attachment must be an image";
+    }
+    if (!isBase64ImageWithinLimits(image)) {
+      return `Each image must be valid base64 image data of ${MAX_ATTACHED_IMAGE_BYTES / (1024 * 1024)}MB or smaller`;
+    }
+  }
+  return null;
+}

--- a/lib/path-security.ts
+++ b/lib/path-security.ts
@@ -1,0 +1,42 @@
+import { realpathSync } from "fs";
+import path from "path";
+
+const WINDOWS_ABSOLUTE_RE = /^[a-zA-Z]:[\\/]/;
+
+function isWindowsAbsolutePath(filePath: string): boolean {
+  return WINDOWS_ABSOLUTE_RE.test(filePath) || filePath.startsWith("\\\\") || filePath.startsWith("//");
+}
+
+export function isPathWithinRoots(target: string, roots: Set<string>): boolean {
+  for (const root of roots) {
+    const useWindowsRules = isWindowsAbsolutePath(target) || isWindowsAbsolutePath(root);
+    const resolver = useWindowsRules ? path.win32 : path;
+    const sep = useWindowsRules ? "\\" : path.sep;
+    const normalized = resolver.resolve(target);
+    const normalizedRoot = resolver.resolve(root);
+    const comparable = useWindowsRules ? normalized.toLowerCase() : normalized;
+    const comparableRoot = useWindowsRules ? normalizedRoot.toLowerCase() : normalizedRoot;
+    const rootWithSep = comparableRoot.endsWith(sep) ? comparableRoot : comparableRoot + sep;
+    if (comparable === comparableRoot || comparable.startsWith(rootWithSep)) return true;
+  }
+  return false;
+}
+
+export function isExistingPathWithinRoots(target: string, roots: Set<string>): boolean {
+  let realTarget: string;
+  try {
+    realTarget = realpathSync(target);
+  } catch {
+    return false;
+  }
+
+  const realRoots = new Set<string>();
+  for (const root of roots) {
+    try {
+      realRoots.add(realpathSync(root));
+    } catch {
+      // Ignore stale roots derived from removed sessions or worktrees.
+    }
+  }
+  return isPathWithinRoots(realTarget, realRoots);
+}

--- a/lib/request-security.test.mjs
+++ b/lib/request-security.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./request-security.ts");
+}
+
+test("allows same-origin and non-browser API requests", async () => {
+  const { isApiRequestOriginAllowed } = await loadSubject();
+  assert.equal(isApiRequestOriginAllowed(new Request("http://localhost:30141/api/test", {
+    method: "POST",
+    headers: { origin: "http://localhost:30141", "sec-fetch-site": "same-origin" },
+  })), true);
+  assert.equal(isApiRequestOriginAllowed(new Request("http://localhost:30141/api/test", { method: "POST" })), true);
+});
+
+test("rejects cross-origin browser API requests", async () => {
+  const { isApiRequestOriginAllowed, shouldCheckApiRequestOrigin } = await loadSubject();
+  const post = new Request("http://localhost:30141/api/test", {
+    method: "POST",
+    headers: { origin: "https://attacker.example", "sec-fetch-site": "cross-site" },
+  });
+  const crossSiteGet = new Request("http://localhost:30141/api/sessions", {
+    headers: { "sec-fetch-site": "cross-site" },
+  });
+  assert.equal(shouldCheckApiRequestOrigin(post), true);
+  assert.equal(isApiRequestOriginAllowed(post), false);
+  assert.equal(shouldCheckApiRequestOrigin(crossSiteGet), true);
+  assert.equal(isApiRequestOriginAllowed(crossSiteGet), false);
+});

--- a/lib/request-security.ts
+++ b/lib/request-security.ts
@@ -1,0 +1,22 @@
+function canonicalOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Reject browser cross-site API requests while preserving non-browser clients. */
+export function isApiRequestOriginAllowed(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  const fetchSite = request.headers.get("sec-fetch-site");
+  if (fetchSite === "cross-site") return false;
+  if (!origin) return true;
+
+  const requestOrigin = canonicalOrigin(request.url);
+  return requestOrigin !== null && canonicalOrigin(origin) === requestOrigin;
+}
+
+export function shouldCheckApiRequestOrigin(request: Request): boolean {
+  return request.headers.has("origin") || request.headers.has("sec-fetch-site");
+}

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -2,6 +2,7 @@ import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
 import { existsSync, writeFileSync } from "fs";
+import { validateAgentImages } from "./image-attachments";
 import { invalidateModelsCache } from "./models-cache";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
@@ -305,6 +306,11 @@ export class AgentSessionWrapper {
     this.resetIdleTimer();
     const type = command.type as string;
     if (this.shouldWaitForExtensions(type)) await this.waitForExtensionsBound();
+
+    if (type === "prompt" || type === "steer" || type === "follow_up") {
+      const imageError = validateAgentImages(command.images);
+      if (imageError) throw new Error(imageError);
+    }
 
     switch (type) {
       case "prompt": {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,11 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { isApiRequestOriginAllowed, shouldCheckApiRequestOrigin } from "@/lib/request-security";
+
+export function proxy(request: NextRequest) {
+  if (shouldCheckApiRequestOrigin(request) && !isApiRequestOriginAllowed(request)) {
+    return NextResponse.json({ error: "Cross-origin API requests are not allowed" }, { status: 403 });
+  }
+  return NextResponse.next();
+}
+
+export const config = { matcher: "/api/:path*" };


### PR DESCRIPTION
## Summary

Pi Web exposes local agent, filesystem, Git, model, plugin, skill, credential, and session operations through browser-accessible API routes. The existing implementation trusted lexical paths and did not reject cross-site browser requests, which allowed browser-origin attacks and symlink or junction escapes from approved workspaces. Large uploads and chat image attachments were also unbounded.

This PR adds a shared browser-origin gate, canonical filesystem authorization, consistent workspace checks across dependent routes, bounded upload and image handling, and regression coverage.

## Root Cause

- API routes relied on the application being used locally but did not enforce same-origin browser access. Browser requests from another site could reach sensitive local endpoints.
- Workspace authorization compared normalized path strings before filesystem operations. Filesystem APIs resolve symbolic links and Windows junctions afterward, so a lexically contained path could resolve outside an allowed root.
- Several model, plugin, skill, Git, and worktree routes accepted `cwd` or file paths without applying the same canonical workspace boundary.
- File uploads and base64 chat image attachments had no explicit count or byte limits.
- A bash-output regression test hardcoded POSIX `/tmp` paths and failed on Windows despite correct production behavior.

## Changes

### Security

- Added a Next.js API proxy that rejects browser requests with a cross-site Fetch Metadata signal or a mismatched `Origin`.
- Preserved non-browser API clients that do not send browser origin metadata.
- Added realpath-based containment checks that resolve symlinks and Windows junctions before authorization.
- Applied canonical workspace checks to file reads and indexing, Git status and diff, model discovery, plugin operations, skill listing/install/update/check, skill metadata writes, and worktree operations.
- Preserved access to global skills managed inside the Pi agent directory.

### Resource Limits

- Limited individual filesystem uploads to 25 MiB.
- Limited each upload request to 100 MiB total.
- Limited chat attachments to 10 images and 10 MiB per image before base64 conversion.

### Tests

- Added regression coverage for same-origin and cross-origin browser requests.
- Added a symlink/junction escape regression test.
- Updated bash-output path tests to use platform-native temporary paths.

## Verification

- Full Node test suite: 99/99 passing in three independent full runs during the audit, plus a final post-commit run.
- Focused security and path regression tests: passing.
- TypeScript type checking with `npx tsc --noEmit`: passing in repeated runs, including post-commit verification.
- ESLint with `npm run lint`: passing in repeated runs, including post-commit verification.
- Production build with `npm run build`: passed three independent times with isolated build-time `HOME` and `USERPROFILE`, plus a final branch build.
- Package dry run: valid npm artifact containing the CLI and `.next` build output; 454 entries, 5,333,998 compressed bytes, 29,142,590 unpacked bytes.
- Branch verification: four focused commits, zero commits behind `origin/main`, no generated artifacts or secret-like files included.

Relevant tests were executed multiple times to verify deterministic behavior.

## Breaking Changes

None.

## Remaining Risks

- The CLI still inherits Next.js default binding to `0.0.0.0` when no hostname is supplied. The API origin gate mitigates cross-site browser access but does not provide authentication for direct LAN clients. Default localhost binding or explicit authentication remains recommended follow-up work.
- `npm audit --omit=dev` reports two high and two moderate production advisories in transitive `sharp`, `postcss`, and `protobufjs` dependencies. No compatible clean upgrade was available during this audit.
- On this Windows environment, a normal build using the real user profile can fail when Pi SDK package/resource discovery traverses protected profile junctions. The same source builds successfully with isolated build-time home variables.
- The repository has no browser end-to-end suite, so UI interaction coverage remains primarily unit, static, and build validation.
- The npm artifact is approximately 5.3 MiB compressed and 29.1 MiB unpacked; packaging optimization remains separate follow-up work.