### PR TITLE
fix: collapse post-compaction messages when compaction drops the user prompt

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { Fragment, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
+import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
 import { asBracketedPaste, toTerminalKeyData } from "@/lib/terminal-input";
 import { countToolCallBlocks, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
@@ -86,6 +86,19 @@ function hasDisplayableProcessMessage(message: AgentMessage): boolean {
     return getDisplayableAssistantBlocks(message as AssistantMessage).length > 0;
   }
   return message.role === "custom";
+}
+
+// A user message normally anchors a turn (user prompt → process → final
+// answer), and the process messages in between get folded into a collapsed
+// ProcessDetailsGroup. When compaction fires mid-turn, pi drops the original
+// user prompt and inserts a compaction summary (role "custom", customType
+// "compaction") in its place; the agent then keeps producing tool calls and a
+// final answer with no user message left to anchor them. Treat a compaction
+// summary as an anchor too, otherwise every post-compaction message renders
+// standalone and never collapses.
+function isGroupAnchor(message: AgentMessage): boolean {
+  if (message.role === "user") return true;
+  return message.role === "custom" && (message as CustomMessage).customType === "compaction";
 }
 
 function withAssistantBlocks(
@@ -469,6 +482,15 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
               for (let i = messages.length - 1; i >= 0; i--) {
                 if (messages[i].role === "user") { lastUserIdx = i; break; }
               }
+              // Anchor for live-tail detection: the last user message, or a
+              // compaction summary when compaction has replaced it mid-turn.
+              // Computed independently from lastUserIdx (which is kept for the
+              // scroll-to-user ref) because a compaction summary can sit after
+              // the last user message and anchor the still-streaming segment.
+              let lastAnchorIdx = -1;
+              for (let i = messages.length - 1; i >= 0; i--) {
+                if (isGroupAnchor(messages[i])) { lastAnchorIdx = i; break; }
+              }
 
               const visibleRefIndexByMessage = new Map<number, number>();
               let refIdx = 0;
@@ -536,7 +558,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
               const rendered: ReactNode[] = [];
               for (let idx = 0; idx < messages.length;) {
                 const msg = messages[idx];
-                if (msg.role !== "user") {
+                if (!isGroupAnchor(msg)) {
                   rendered.push(renderMessage(idx));
                   idx += 1;
                   continue;
@@ -544,7 +566,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
 
                 const userIdx = idx;
                 let endIdx = userIdx + 1;
-                while (endIdx < messages.length && messages[endIdx].role !== "user") endIdx += 1;
+                while (endIdx < messages.length && !isGroupAnchor(messages[endIdx])) endIdx += 1;
 
                 const finalAssistantIdx = findFinalAssistantIndex(messages, userIdx, endIdx);
 
@@ -556,7 +578,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                   continue;
                 }
 
-                const isLiveTail = (sessionBusy || streamState.isStreaming) && endIdx === messages.length && userIdx === lastUserIdx;
+                const isLiveTail = (sessionBusy || streamState.isStreaming) && endIdx === messages.length && userIdx === lastAnchorIdx;
                 if (isLiveTail) {
                   for (let renderIdx = userIdx; renderIdx < endIdx; renderIdx++) {
                     rendered.push(renderMessage(renderIdx));


### PR DESCRIPTION
## Problem

During a long agentic turn, auto-compaction can fire mid-turn. When it does, pi replaces the compacted history — including the original user prompt — with a compaction summary and the agent keeps producing tool calls and a final answer. There is no user message left to anchor the rest of the turn.

`ChatWindow`'s message grouping only treated `role === \"user\"` as a turn anchor. After a mid-turn compaction, every subsequent tool call and assistant reply rendered **standalone** and never folded into a collapsed `ProcessDetailsGroup`. The whole post-compaction tail stayed expanded even after the run ended — the auto-collapse that normally happens when a turn completes was lost.

### Repro

Real session data confirms it: a compaction entry whose `firstKeptEntryId` points at an `assistant` message, followed by `assistant`/`toolResult` entries with no `user` message after it. The loaded message list is `[compaction(custom), assistant, toolResult, …]`, so the grouping loop never enters the user-anchored branch and renders everything standalone.

## Fix

Treat a compaction summary (`role: \"custom\"`, `customType: \"compaction\"`) as a group anchor too:

- It renders as the compaction block (unchanged).
- The process messages after it fold into a `ProcessDetailsGroup` (collapsed by default).
- The final assistant renders as the answer.

Live-tail detection now uses the **last anchor** (user or compaction) instead of only the last user message, so a compaction summary that sits after the last user message still anchors the currently-streaming segment.

## Verification

- `tsc --noEmit` — no new errors in the touched file.
- Simulated the grouping loop on the real post-compaction message sequence:
  - Before: `standalone × N` (nothing collapses).
  - After: compaction anchors the segment → process messages grouped, final assistant rendered as answer.

## Scope

Single-file, ~26-line change in `components/ChatWindow.tsx`. No behavior change for sessions without mid-turn compaction (`lastAnchorIdx === lastUserIdx` in the normal case).