### PR TITLE
support markdown image preview

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -155,6 +155,13 @@ pre, code {
   text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent);
 }
 .markdown-body a:hover { text-decoration-color: var(--accent); }
+.markdown-body img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 8px 0;
+  border-radius: 6px;
+}
 .markdown-body .markdown-inline-code {
   background: var(--bg-subtle);
   border-radius: 5px;

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -970,6 +970,18 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
 
                   return <a href={href} {...props} onClick={handleClick}>{children}</a>;
                 },
+                img({ src, alt, ...props }) {
+                  delete props.node;
+                  const imagePath = typeof src === "string"
+                    ? resolveLocalFileHref(src, markdownDirectory, cwd ?? markdownDirectory)
+                    : null;
+                  const imageSrc = imagePath
+                    ? getFileApiUrl(imagePath, "read", sourceSessionId)
+                    : src;
+                  // Dynamic local paths are served directly by the file API.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  return <img src={imageSrc} alt={alt ?? ""} loading="lazy" {...props} />;
+                },
               }}
             >
               {data.content}

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -8,6 +8,7 @@ import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { useTheme } from "@/hooks/useTheme";
 import { copyText } from "@/lib/clipboard";
 import { resolveLocalFileHref } from "@/lib/file-links";
+import { encodeFilePathForApi } from "@/lib/file-paths";
 import { markdownRehypePlugins, markdownRemarkPlugins } from "@/lib/markdown";
 
 interface MarkdownBodyProps {
@@ -76,6 +77,16 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
                 {children}
               </a>
             );
+          },
+          img({ src, alt, ...props }) {
+            delete props.node;
+            const filePath = typeof src === "string" ? resolveLocalFileHref(src, cwd) : null;
+            const imageSrc = filePath
+              ? `/api/files/${encodeFilePathForApi(filePath)}?type=read`
+              : src;
+            // Dynamic local paths are served directly by the file API.
+            // eslint-disable-next-line @next/next/no-img-element
+            return <img src={imageSrc} alt={alt ?? ""} loading="lazy" {...props} />;
           },
           table({ children }) {
             return (


### PR DESCRIPTION
Support markdown image preview.

提醒llm，image按照markdown的语法写相对路径：`![image_title](images/img.png)`，即可实现image preview

<img width="1554" height="1528" alt="image" src="https://github.com/user-attachments/assets/79b9f177-cd4a-4b7d-a211-3363e88e9a72" />
