### PR TITLE
feat: mention selected file lines with Cmd+I

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -458,13 +458,13 @@ pre, code {
   flex-shrink: 0;
 }
 
-.file-viewer-action-slot {
+.file-viewer-actions {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 24px;
   height: 24px;
-  flex: 0 0 24px;
+  gap: 4px;
+  flex-shrink: 0;
+  order: -1;
 }
 
 .file-viewer-mode-switch {
@@ -516,6 +516,17 @@ pre, code {
 .file-viewer-icon-button:hover {
   background: var(--bg-hover) !important;
   color: var(--text);
+}
+
+.file-viewer-icon-button:disabled {
+  color: var(--text-dim);
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.file-viewer-icon-button:disabled:hover {
+  background: transparent !important;
+  color: var(--text-dim);
 }
 
 .file-viewer-mode-button:focus-visible,

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { copyText } from "@/lib/clipboard";
 import { getFileName } from "@/lib/file-paths";
-import { buildAtMentionText, buildFileAtMentionsText } from "@/lib/file-fuzzy";
+import { buildAtMentionText, buildFileAtMentionsText, buildFileLineMentionText } from "@/lib/file-fuzzy";
 import { getInitialNavigation } from "@/lib/initial-navigation";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ChatInputHandle } from "./ChatInput";
@@ -160,6 +160,10 @@ export function AppShell() {
   const handleAtMentions = useCallback((relativePaths: string[]) => {
     const mentions = buildFileAtMentionsText(relativePaths);
     if (mentions) chatInputRef.current?.insertText(mentions);
+  }, []);
+
+  const handleFileLineMention = useCallback((relativePath: string, startLine: number, endLine: number) => {
+    chatInputRef.current?.insertText(buildFileLineMentionText(relativePath, startLine, endLine));
   }, []);
 
   const initialSessionId = initialNavigation.sessionId;
@@ -1239,6 +1243,7 @@ export function AppShell() {
               cwd={activeCwd ?? undefined}
               sourceSessionId={activeFileTab.sourceSessionId}
               gitRefreshKey={explorerRefreshKey}
+              onMentionLines={rightPanelOpen ? handleFileLineMention : undefined}
               onOpenFile={(filePath) => handleOpenFile(
                 filePath,
                 getFileName(filePath),

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -79,6 +79,15 @@ interface SelectedLineRange {
   endLine: number;
 }
 
+function MentionIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-4 8" />
+    </svg>
+  );
+}
+
 function closestSourceLine(node: Node): HTMLElement | null {
   const element = node.nodeType === Node.ELEMENT_NODE
     ? node as Element
@@ -791,6 +800,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionL
   const esRef = useRef<EventSource | null>(null);
   const gitDiffRequestRef = useRef(0);
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const [selectedLineRange, setSelectedLineRange] = useState<SelectedLineRange | null>(null);
 
   const fetchContent = useCallback((filePath: string) => {
     return fetch(getFileApiUrl(filePath, "read", sourceSessionId))
@@ -885,6 +895,36 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionL
   }, [displayMode, hasGitDiff]);
 
   useEffect(() => {
+    const updateSelectedLineRange = () => {
+      const root = contentRef.current;
+      setSelectedLineRange(
+        onMentionLines && displayMode === "source" && root
+          ? getSelectedSourceLineRange(root, window.getSelection())
+          : null,
+      );
+    };
+
+    updateSelectedLineRange();
+    if (!onMentionLines || displayMode !== "source") return;
+
+    document.addEventListener("selectionchange", updateSelectedLineRange);
+    return () => document.removeEventListener("selectionchange", updateSelectedLineRange);
+  }, [data?.content, displayMode, onMentionLines]);
+
+  const mentionLineRange = useCallback((lineRange: SelectedLineRange | null) => {
+    if (!onMentionLines || !lineRange) return;
+    onMentionLines(
+      getRelativeFilePath(filePath, cwd),
+      lineRange.startLine,
+      lineRange.endLine,
+    );
+  }, [cwd, filePath, onMentionLines]);
+
+  const handleMentionSelectedLines = useCallback(() => {
+    mentionLineRange(selectedLineRange);
+  }, [mentionLineRange, selectedLineRange]);
+
+  useEffect(() => {
     if (!onMentionLines || displayMode !== "source") return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -894,21 +934,16 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionL
       if (target instanceof Element && target.closest("input, textarea, [contenteditable='true']")) return;
 
       const root = contentRef.current;
-      if (!root) return;
-      const selectedLines = getSelectedSourceLineRange(root, window.getSelection());
-      if (!selectedLines) return;
+      const lineRange = root ? getSelectedSourceLineRange(root, window.getSelection()) : null;
+      if (!lineRange) return;
 
       event.preventDefault();
-      onMentionLines(
-        getRelativeFilePath(filePath, cwd),
-        selectedLines.startLine,
-        selectedLines.endLine,
-      );
+      mentionLineRange(lineRange);
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [cwd, displayMode, filePath, onMentionLines]);
+  }, [displayMode, mentionLineRange, onMentionLines]);
 
   if (loading) {
     return (
@@ -996,27 +1031,40 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionL
             </div>
           )}
 
-          <div className="file-viewer-action-slot">
+          <div className="file-viewer-actions">
             {displayMode === "source" && (
-              <button
-                type="button"
-                onClick={() => setWrapLines((value) => !value)}
-                title={wrapLines ? "Disable word wrap" : "Enable word wrap"}
-                aria-label={wrapLines ? "Disable word wrap" : "Enable word wrap"}
-                aria-pressed={wrapLines}
-                className="file-viewer-icon-button"
-                style={{
-                  background: wrapLines ? "var(--bg-selected)" : "transparent",
-                  color: wrapLines ? "var(--text)" : "var(--text-muted)",
-                }}
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M3 6h18" />
-                  <path d="M3 12h15a3 3 0 1 1 0 6h-4" />
-                  <path d="m16 16-2 2 2 2" />
-                  <path d="M3 18h7" />
-                </svg>
-              </button>
+              <>
+                <button
+                  type="button"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={handleMentionSelectedLines}
+                  title="Mention selected lines"
+                  aria-label="Mention selected lines"
+                  disabled={!selectedLineRange}
+                  className="file-viewer-icon-button"
+                >
+                  <MentionIcon />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setWrapLines((value) => !value)}
+                  title={wrapLines ? "Disable word wrap" : "Enable word wrap"}
+                  aria-label={wrapLines ? "Disable word wrap" : "Enable word wrap"}
+                  aria-pressed={wrapLines}
+                  className="file-viewer-icon-button"
+                  style={{
+                    background: wrapLines ? "var(--bg-selected)" : "transparent",
+                    color: wrapLines ? "var(--text)" : "var(--text-muted)",
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M3 6h18" />
+                    <path d="M3 12h15a3 3 0 1 1 0 6h-4" />
+                    <path d="m16 16-2 2 2 2" />
+                    <path d="M3 18h7" />
+                  </svg>
+                </button>
+              </>
             )}
           </div>
 

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -28,6 +28,7 @@ interface Props {
   cwd?: string;
   sourceSessionId?: string | null;
   onOpenFile?: (filePath: string) => void;
+  onMentionLines?: (relativePath: string, startLine: number, endLine: number) => void;
   gitRefreshKey?: number;
 }
 
@@ -73,6 +74,69 @@ type SourceCodeRendererProps = Parameters<NonNullable<SyntaxHighlighterProps["re
   wrapLines: boolean;
 };
 
+interface SelectedLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+function closestSourceLine(node: Node): HTMLElement | null {
+  const element = node.nodeType === Node.ELEMENT_NODE
+    ? node as Element
+    : node.parentElement;
+  return element?.closest<HTMLElement>(".file-source-line[data-line-number]") ?? null;
+}
+
+function getSelectedSourceLineRange(root: HTMLElement, selection: Selection | null): SelectedLineRange | null {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null;
+
+  let startElement = closestSourceLine(range.startContainer);
+  let endElement = closestSourceLine(range.endContainer);
+  if (!startElement || !endElement || !root.contains(startElement) || !root.contains(endElement)) return null;
+
+  let startLine = Number(startElement.dataset.lineNumber);
+  let endLine = Number(endElement.dataset.lineNumber);
+  if (!Number.isInteger(startLine) || !Number.isInteger(endLine)) return null;
+
+  if (startLine < endLine) {
+    // Browser ranges can start at the end of the preceding line or end at the
+    // start of the following line. Exclude either boundary line when none of
+    // its source text is actually selected.
+    const startContent = startElement.querySelector<HTMLElement>(".file-source-line-content");
+    if (startContent?.contains(range.startContainer)) {
+      const selectedSuffix = document.createRange();
+      selectedSuffix.selectNodeContents(startContent);
+      selectedSuffix.setStart(range.startContainer, range.startOffset);
+      if (selectedSuffix.toString().length === 0) {
+        const nextLine = startElement.nextElementSibling;
+        if (nextLine instanceof HTMLElement && nextLine.matches(".file-source-line[data-line-number]")) {
+          startElement = nextLine;
+          startLine = Number(startElement.dataset.lineNumber);
+        }
+      }
+    }
+
+    const endContent = endElement.querySelector<HTMLElement>(".file-source-line-content");
+    if (endContent?.contains(range.endContainer)) {
+      const selectedPrefix = document.createRange();
+      selectedPrefix.selectNodeContents(endContent);
+      selectedPrefix.setEnd(range.endContainer, range.endOffset);
+      if (selectedPrefix.toString().length === 0) {
+        const previousLine = endElement.previousElementSibling;
+        if (previousLine instanceof HTMLElement && previousLine.matches(".file-source-line[data-line-number]")) {
+          endElement = previousLine;
+          endLine = Number(endElement.dataset.lineNumber);
+        }
+      }
+    }
+  }
+
+  if (startLine > endLine) return null;
+  return { startLine, endLine };
+}
+
 function SourceCodeRenderer({ rows, stylesheet, useInlineStyles, wrapLines }: SourceCodeRendererProps) {
   return rows.map((row, lineIndex) => {
     const children = row.children ?? [];
@@ -85,6 +149,7 @@ function SourceCodeRenderer({ rows, stylesheet, useInlineStyles, wrapLines }: So
     return (
       <span
         className="file-source-line"
+        data-line-number={lineIndex + 1}
         key={`source-line-${lineIndex}`}
         style={{ display: "flex", minWidth: "100%" }}
       >
@@ -701,7 +766,7 @@ function DocumentViewer({ filePath, cwd, sourceSessionId }: Props) {
   );
 }
 
-export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey }: Props) {
+export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionLines, gitRefreshKey }: Props) {
   if (isImagePath(filePath)) {
     return <ImageViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
@@ -711,10 +776,10 @@ export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefr
   if (isDocumentPreviewPath(filePath)) {
     return <DocumentViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} gitRefreshKey={gitRefreshKey} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} onMentionLines={onMentionLines} gitRefreshKey={gitRefreshKey} />;
 }
 
-function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey }: Props) {
+function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, onMentionLines, gitRefreshKey }: Props) {
   const { isDark } = useTheme();
   const [data, setData] = useState<FileData | null>(null);
   const [gitDiff, setGitDiff] = useState<GitFileDiffResponse | null>(null);
@@ -725,6 +790,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
   const [watching, setWatching] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const gitDiffRequestRef = useRef(0);
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   const fetchContent = useCallback((filePath: string) => {
     return fetch(getFileApiUrl(filePath, "read", sourceSessionId))
@@ -817,6 +883,32 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
   useEffect(() => {
     if (!hasGitDiff && displayMode === "diff") setDisplayMode("source");
   }, [displayMode, hasGitDiff]);
+
+  useEffect(() => {
+    if (!onMentionLines || displayMode !== "source") return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.key.toLowerCase() !== "i" || (!event.metaKey && !event.ctrlKey) || event.altKey || event.shiftKey) return;
+
+      const target = event.target;
+      if (target instanceof Element && target.closest("input, textarea, [contenteditable='true']")) return;
+
+      const root = contentRef.current;
+      if (!root) return;
+      const selectedLines = getSelectedSourceLineRange(root, window.getSelection());
+      if (!selectedLines) return;
+
+      event.preventDefault();
+      onMentionLines(
+        getRelativeFilePath(filePath, cwd),
+        selectedLines.startLine,
+        selectedLines.endLine,
+      );
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [cwd, displayMode, filePath, onMentionLines]);
 
   if (loading) {
     return (
@@ -933,7 +1025,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
       </div>
 
       {/* Content area */}
-      <div className="file-viewer-content" style={{ flex: 1, overflow: "auto", background: "var(--bg)" }}>
+      <div ref={contentRef} className="file-viewer-content" style={{ flex: 1, overflow: "auto", background: "var(--bg)" }}>
         {displayMode === "diff" && hasGitDiff ? (
           <DiffView patch={gitDiff.patch!} />
         ) : isHtml && displayMode === "preview" ? (

--- a/lib/file-fuzzy.test.mjs
+++ b/lib/file-fuzzy.test.mjs
@@ -15,3 +15,15 @@ test("builds closed file mentions and quotes paths containing spaces", async () 
     "@notes/todo.md @\"project files/design brief.md\" ",
   );
 });
+
+test("builds line-scoped file mentions", async () => {
+  const { buildFileLineMentionText } = await loadSubject();
+
+  assert.equal(buildFileLineMentionText("src/app.ts", 12, 12), "@src/app.ts:12 ");
+  assert.equal(buildFileLineMentionText("src/app.ts", 18, 12), "@src/app.ts:12-18 ");
+  assert.equal(
+    buildFileLineMentionText("project files/app.ts", 3, 9),
+    "@\"project files/app.ts\":3-9 ",
+  );
+  assert.equal(buildFileLineMentionText("src/app.ts", 0, 0), "@src/app.ts:1 ");
+});

--- a/lib/file-fuzzy.ts
+++ b/lib/file-fuzzy.ts
@@ -175,6 +175,15 @@ export function buildAtMentionText(entryPath: string, isDir: boolean): string {
   return p.includes(" ") ? `@"${p}" ` : `@${p} `;
 }
 
+/** Closed file @mention scoped to one logical line or an inclusive line range. */
+export function buildFileLineMentionText(entryPath: string, startLine: number, endLine: number): string {
+  const firstLine = Math.max(1, Math.min(startLine, endLine));
+  const lastLine = Math.max(1, Math.max(startLine, endLine));
+  const pathMention = entryPath.includes(" ") ? `@"${entryPath}"` : `@${entryPath}`;
+  const lineSuffix = firstLine === lastLine ? `:${firstLine}` : `:${firstLine}-${lastLine}`;
+  return `${pathMention}${lineSuffix} `;
+}
+
 export function buildFileAtMentionsText(entryPaths: string[]): string {
   return entryPaths.map((entryPath) => buildAtMentionText(entryPath, false)).join("");
 }


### PR DESCRIPTION
## Summary

- Add `Cmd+I` on macOS and `Ctrl+I` on Windows/Linux to mention the currently selected source lines in the chat prompt.
- Reuse the existing chat-input insertion path and `@mention` formatting, including quoted paths with spaces and inclusive single-line or multi-line ranges.
- Map native browser selections back to logical source lines, including exact line-boundary selections and wrapped lines.
- Ignore the shortcut outside the visible Source view, inside editable controls, and for repeated keydown events.

Examples:

```text
@components/AppShell.tsx:154
@components/FileViewer.tsx:80-120
@"project files/app.ts":3-9
```

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `node --test lib/*.test.mjs components/*.test.mjs` — 102 tests passed
- `git diff --check origin/main...HEAD`

## Notes

- Preview, Diff, image, audio, and document views do not handle this shortcut because they do not expose source-line selections.
- `next build` was intentionally not run, following the repository's development guidance.
