### PR TITLE
fix: preserve chat input when a prompt fails to send (#214)

### DIFF
--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1110,6 +1110,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           });
         }
         addNotice({ type: "error", message: e.message });
+        // The prompt never reached the agent, so restore the user's text into
+        // the input instead of losing it. Mirrors the shell-command recovery in
+        // executeBash; insertIfEmpty avoids clobbering anything typed since.
+        if (message) opts.chatInputRef?.current?.insertIfEmpty(message);
       }
       optimisticUserMessageKeyRef.current = null;
       agentRunningRef.current = false;
@@ -1117,7 +1121,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice]);
+  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, opts.chatInputRef]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;


### PR DESCRIPTION
## Summary

Fixes #214.

When a prompt fails to send because the agent event stream can't be connected, the UI shows a "connection error" notice and the typed message is lost — the user has to retype everything before retrying.

### Root cause

In `ChatInput.handleSend`, the input is cleared immediately after calling `onSend` (fire-and-forget):

```ts
onSend(msg, attachedImages.length ? attachedImages : undefined);
clearInput();
```

`onSend` ultimately runs `useAgentSession.handleSend`, which calls `ensureEventsConnected(...)` **before** the prompt is dispatched. On failure it throws `EventStreamConnectionError`, and the catch block already rolls back the optimistic user message — but by then the input has already been cleared, so the text is gone.

### Fix

Restore the message text into the input when the send fails with `EventStreamConnectionError`, in the same block that rolls back the optimistic message. This mirrors the existing shell-command recovery path in `executeBash`, which already does:

```ts
opts.chatInputRef?.current?.insertIfEmpty(inputText);
```

`insertIfEmpty` only restores when the input is empty, so anything the user has typed since is never clobbered. The prompt genuinely never reached the agent in this path, so restoring is safe.

### Testing

- `tsc --noEmit` passes
- `eslint` passes
- Manual: trigger a prompt while the event stream can't connect → the "connection error" notice appears and the typed text remains in the input, ready to resend.

### Notes / scope

Scoped intentionally to the connection-error rollback path that issue #214 describes. Restoring attached **images** is out of scope (the imperative handle only exposes text restore); only the text is preserved, which is what the issue asks for.