### PR TITLE
feat: review agent changes by file or hunk

### DIFF
--- a/app/api/git/review/route.ts
+++ b/app/api/git/review/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllowedFileRoots, isWindowsAbsolutePath } from "@/lib/file-access";
+import { activateGitReview, cancelGitReview, decideGitReview, finishGitReview, getGitReview, getGitReviewCwd, startGitReview } from "@/lib/git-review";
+import { resolveAllowedDirectory } from "@/lib/path-security";
+import type { GitReviewDecision } from "@/lib/git-types";
+
+type ReviewRequest =
+  | { action: "start"; cwd: string; runId: number }
+  | { action: "activate"; reviewId: string }
+  | { action: "finish"; reviewId: string }
+  | { action: "get"; reviewId: string }
+  | { action: "cancel"; reviewId: string }
+  | { action: "decide"; reviewId: string; revision: number; decision: GitReviewDecision; fileId?: string; hunkId?: string; all?: boolean };
+
+function errorResponse(error: unknown) {
+  const status = typeof error === "object" && error && "status" in error && typeof error.status === "number" ? error.status : 500;
+  return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as ReviewRequest;
+    if (body.action === "start") {
+      const cwd = body.cwd?.trim() ?? "";
+      if (!cwd || (!cwd.startsWith("/") && !isWindowsAbsolutePath(cwd))) {
+        return NextResponse.json({ error: "cwd must be an absolute path" }, { status: 400 });
+      }
+      if (!Number.isSafeInteger(body.runId) || body.runId < 1) {
+        return NextResponse.json({ error: "runId must be a positive integer" }, { status: 400 });
+      }
+      const canonicalCwd = resolveAllowedDirectory(cwd, await getAllowedFileRoots());
+      if (!canonicalCwd) return NextResponse.json({ error: "Directory is not within an allowed canonical root" }, { status: 403 });
+      return NextResponse.json(await startGitReview(canonicalCwd, body.runId, true));
+    }
+    if (!body.reviewId) return NextResponse.json({ error: "reviewId is required" }, { status: 400 });
+    // Re-authorize the canonical cwd for every operation. Review ids are
+    // opaque capabilities, but they must not outlive file-root access or an
+    // ancestor path being replaced by a symlink.
+    const storedCwd = getGitReviewCwd(body.reviewId);
+    const canonicalCwd = resolveAllowedDirectory(storedCwd, await getAllowedFileRoots());
+    if (!canonicalCwd || canonicalCwd !== storedCwd) {
+      return NextResponse.json({ error: "Review workspace is no longer accessible" }, { status: 403 });
+    }
+    if (body.action === "get") return NextResponse.json(getGitReview(body.reviewId));
+    if (body.action === "activate") {
+      await activateGitReview(body.reviewId);
+      return NextResponse.json({ ok: true });
+    }
+    if (body.action === "finish") return NextResponse.json(await finishGitReview(body.reviewId));
+    if (body.action === "cancel") {
+      await cancelGitReview(body.reviewId);
+      return NextResponse.json({ ok: true });
+    }
+    if (body.action === "decide") {
+      if (!Number.isSafeInteger(body.revision) || body.revision < 0) {
+        return NextResponse.json({ error: "revision must be a non-negative integer" }, { status: 400 });
+      }
+      return NextResponse.json(await decideGitReview(body.reviewId, {
+        decision: body.decision, revision: body.revision, fileId: body.fileId, hunkId: body.hunkId, all: body.all,
+      }));
+    }
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -934,6 +934,19 @@ span.linenumber {
   }
 }
 
+/* Visually hidden but available to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Mobile sidebar: slide in/out as overlay */
 @media (max-width: 640px) {
   .chat-stats-center {

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,14 @@
   --assistant-bg: #ffffff;
   --tool-bg: #f9fafb;
   --bg-subtle: rgba(0,0,0,0.03);
+  --diff-added-bg: #e8f8ee;
+  --diff-added-text: #176b3a;
+  --diff-removed-bg: #ffeded;
+  --diff-removed-text: #a42b32;
+  --review-pending: #8a5b12;
+  --review-accepted: #17713d;
+  --review-rejected: #b0333a;
+  --review-current: #2563eb;
 }
 
 html.dark {
@@ -50,6 +58,14 @@ html.dark {
   --assistant-bg: #1a1a1a;
   --tool-bg: #1f2937;
   --bg-subtle: rgba(255,255,255,0.04);
+  --diff-added-bg: #183729;
+  --diff-added-text: #82d9a5;
+  --diff-removed-bg: #452326;
+  --diff-removed-text: #ff9a9f;
+  --review-pending: #e5b85c;
+  --review-accepted: #79d49d;
+  --review-rejected: #ff969c;
+  --review-current: #60a5fa;
 }
 
 /* Theme toggle: circular wipe via View Transitions API.
@@ -539,6 +555,211 @@ pre, code {
   .file-viewer-mode-button {
     padding-inline: 6px;
   }
+}
+
+/* Prompt-scoped code review */
+.code-review-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+.review-toolbar {
+  flex: 0 0 auto;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.review-title-row,
+.review-nav-row,
+.review-file-header,
+.review-file-summary,
+.review-hunk-actions,
+.review-decision-buttons,
+.review-global-actions {
+  display: flex;
+  align-items: center;
+}
+.review-title-row { justify-content: space-between; gap: 12px; }
+.review-title-row > div:first-child { display: flex; flex-direction: column; min-width: 0; }
+.review-title-row strong { font-size: 13px; font-weight: 650; }
+.review-title-row span { color: var(--text-muted); font-size: 11px; }
+.review-global-actions { gap: 6px; flex-shrink: 0; }
+.review-global-actions button,
+.review-nav-row button {
+  min-height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+.review-global-actions button { padding: 3px 8px; }
+.review-global-actions button:hover:not(:disabled),
+.review-nav-row button:hover:not(:disabled) { background: var(--bg-hover); color: var(--text); }
+.review-global-actions button:disabled,
+.review-nav-row button:disabled { cursor: not-allowed; opacity: 0.5; }
+.review-nav-row { gap: 6px; margin-top: 9px; }
+.review-nav-row label { min-width: 0; flex: 1; }
+.review-nav-row select {
+  width: 100%;
+  height: 28px;
+  padding: 0 26px 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.review-position { color: var(--text-muted); font-family: var(--font-mono); font-size: 11px; white-space: nowrap; }
+.review-nav-row button { width: 28px; padding: 0; }
+.review-error {
+  margin-top: 8px;
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--review-rejected) 38%, var(--border));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--review-rejected) 9%, var(--bg));
+  color: var(--review-rejected);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.review-scroll-area { flex: 1; min-height: 0; overflow: auto; }
+.review-file-header { justify-content: space-between; gap: 8px; min-height: 42px; padding: 7px 12px; border-bottom: 1px solid var(--border); }
+.review-file-summary { min-width: 0; gap: 8px; }
+.review-status-badge {
+  flex: 0 0 auto;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: var(--bg-selected);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+.review-file-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 12px; }
+.review-decision-state { flex: 0 0 auto; font-size: 10px; font-weight: 600; }
+.review-decision-state.is-pending { color: var(--review-pending); }
+.review-decision-state.is-accepted { color: var(--review-accepted); }
+.review-decision-state.is-rejected { color: var(--review-rejected); }
+.review-decision-state.is-mixed { color: var(--accent); }
+.review-decision-buttons { gap: 4px; }
+.review-decision-button {
+  min-height: 26px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  white-space: nowrap;
+}
+.review-decision-button:hover:not(:disabled) { background: var(--bg-hover); color: var(--text); }
+.review-decision-button:disabled { cursor: not-allowed; opacity: 0.5; }
+.review-decision-button.review-accept.is-active { border-color: color-mix(in srgb, var(--review-accepted) 55%, var(--border)); background: color-mix(in srgb, var(--review-accepted) 12%, var(--bg)); color: var(--review-accepted); }
+.review-decision-button.review-reject.is-active { border-color: color-mix(in srgb, var(--review-rejected) 55%, var(--border)); background: color-mix(in srgb, var(--review-rejected) 12%, var(--bg)); color: var(--review-rejected); }
+.review-file-note,
+.review-file-level,
+.review-unsupported { margin: 0; padding: 10px 12px; color: var(--text-muted); font-size: 11px; line-height: 1.5; }
+.review-file-note { border-bottom: 1px solid var(--border); }
+.review-unsupported { color: var(--review-rejected); }
+.review-hunk-list { padding: 10px; }
+.review-hunk { margin-bottom: 10px; overflow: hidden; border: 1px solid var(--border); border-radius: 7px; background: var(--bg); }
+.review-hunk.is-current { border-color: var(--review-current); box-shadow: 0 0 0 1px color-mix(in srgb, var(--review-current) 28%, transparent); }
+.review-hunk-actions { min-height: 34px; gap: 8px; padding: 4px 6px 4px 9px; border-bottom: 1px solid var(--border); background: var(--bg-panel); }
+.review-hunk-actions > span:first-child { margin-right: auto; color: var(--text-muted); font-size: 10px; font-weight: 600; }
+.review-diff { width: max-content; min-width: 100%; overflow: hidden; font-family: var(--font-mono); font-size: 11px; line-height: 1.55; }
+.review-hunk-header { padding: 3px 9px; background: color-mix(in srgb, var(--accent) 7%, var(--bg)); color: var(--text-muted); white-space: pre; }
+.review-diff-line { display: grid; grid-template-columns: 38px 38px 18px minmax(max-content, 1fr); min-width: 100%; }
+.review-diff-line.is-added { background: var(--diff-added-bg); color: var(--diff-added-text); }
+.review-diff-line.is-removed { background: var(--diff-removed-bg); color: var(--diff-removed-text); }
+.review-diff-line.is-meta { color: var(--text-dim); }
+.review-line-number { padding: 0 6px; border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent); color: var(--text-dim); text-align: right; user-select: none; }
+.review-line-prefix { padding-left: 6px; font-weight: 700; user-select: none; }
+.review-diff-line code { padding-right: 12px; color: inherit; white-space: pre; }
+.review-empty { display: flex; height: 100%; align-items: center; justify-content: center; padding: 20px; color: var(--text-muted); font-size: 12px; text-align: center; }
+.review-tab-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 10px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.review-tab-count { min-width: 17px; padding: 1px 4px; border-radius: 9px; background: color-mix(in srgb, var(--review-pending) 18%, var(--bg)); color: var(--review-pending); font-size: 10px; text-align: center; }
+.review-reopen-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--review-pending);
+  color: var(--bg);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+}
+.review-lifecycle-error {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.review-lifecycle-error strong { color: var(--review-rejected); font-size: 13px; }
+.review-lifecycle-error button {
+  min-height: 28px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg-panel);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+}
+.review-hunk:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.review-global-actions button:focus-visible,
+.review-nav-row button:focus-visible,
+.review-nav-row select:focus-visible,
+.review-decision-button:focus-visible,
+.review-tab-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+@media (max-width: 480px) {
+  .review-title-row { align-items: flex-start; }
+  .review-global-actions { flex-direction: column; align-items: stretch; }
+  .review-global-actions button { min-height: 24px; }
+  .review-file-header { align-items: flex-start; flex-direction: column; }
+  .review-hunk-actions { flex-wrap: wrap; }
+  .review-hunk-actions .review-decision-buttons { width: 100%; }
+  .review-hunk-actions .review-decision-button { flex: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-hunk,
+  .review-decision-button,
+  .review-tab-button { transition: none !important; }
 }
 
 /* File viewer markdown preview — larger headings */

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -11,6 +11,7 @@ import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
 import { BranchNavigator } from "./BranchNavigator";
+import { CodeReviewPanel } from "./CodeReviewPanel";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { copyText } from "@/lib/clipboard";
@@ -20,6 +21,7 @@ import { getInitialNavigation } from "@/lib/initial-navigation";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ChatInputHandle } from "./ChatInput";
 import type { SessionStatsInfo } from "@/lib/pi-types";
+import type { GitReviewResponse } from "@/lib/git-types";
 
 type SessionCopyField = "file" | "id";
 type AutoNameStatus =
@@ -146,10 +148,17 @@ export function AppShell() {
     return () => ro.disconnect();
   }, [activeTopPanel]);
 
-  // Right panel — file tabs only
+  // Right panel — file tabs plus prompt-scoped code review.
   const [fileTabs, setFileTabs] = useState<Tab[]>([]);
   const [activeFileTabId, setActiveFileTabId] = useState<string | null>(null);
   const [rightPanelOpen, setRightPanelOpen] = useState(false);
+  const [rightPanelMode, setRightPanelMode] = useState<"files" | "review">("files");
+  const [codeReview, setCodeReview] = useState<GitReviewResponse | null>(null);
+  const [reviewLifecycleError, setReviewLifecycleError] = useState<{ message: string; runId: number; retryFinish: boolean } | null>(null);
+  const reviewRunsRef = useRef(new Map<number, { reviewId: string; scopeRevision: number }>());
+  const reviewScopeRevisionRef = useRef(0);
+  const visibleReviewIdRef = useRef<string | null>(null);
+  const finishingReviewRunsRef = useRef(new Set<number>());
 
   // Same @mention format as the chat input's @ autocomplete, so the agent's
   // read tool resolves it the same way (it strips the @ prefix).
@@ -168,6 +177,23 @@ export function AppShell() {
   const [initialSessionRestored, setInitialSessionRestored] = useState<boolean>(() => !initialSessionId);
   // Suppresses sessionKey bump in handleCwdChange during the initial URL restore
   const suppressCwdBumpRef = useRef(false);
+
+  const clearReviewScope = useCallback(() => {
+    reviewScopeRevisionRef.current += 1;
+    for (const { reviewId } of reviewRunsRef.current.values()) {
+      void fetch("/api/git/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "cancel", reviewId }),
+      }).catch(() => {});
+    }
+    reviewRunsRef.current.clear();
+    finishingReviewRunsRef.current.clear();
+    visibleReviewIdRef.current = null;
+    setCodeReview(null);
+    setReviewLifecycleError(null);
+    setRightPanelMode("files");
+  }, []);
 
   useEffect(() => {
     const requestedCwd = initialNavigation.requestedCwd;
@@ -221,6 +247,7 @@ export function AppShell() {
     }
     // Close any session that belongs to a different project — it no longer
     // matches the selected project directory.
+    clearReviewScope();
     setSelectedSession(null);
     setNewSessionCwd((prev) => {
       if (prev && prev !== cwd) return null;
@@ -232,9 +259,10 @@ export function AppShell() {
     setSystemPrompt(null);
     setActiveTopPanel(null);
     router.replace("/", { scroll: false });
-  }, [router, selectedSession]);
+  }, [clearReviewScope, router, selectedSession]);
 
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
+    if (selectedSession?.id !== session.id) clearReviewScope();
     setNewSessionCwd(null);
     setSelectedSession(session);
     setSessionKey((k) => k + 1);
@@ -252,9 +280,10 @@ export function AppShell() {
     if (!isRestore) {
       router.replace(`?session=${encodeURIComponent(session.id)}`, { scroll: false });
     }
-  }, [router, isMobile]);
+  }, [clearReviewScope, router, isMobile, selectedSession?.id]);
 
   const handleNewSession = useCallback((_sessionId: string, cwd: string) => {
+    clearReviewScope();
     setSelectedSession(null);
     setNewSessionCwd(cwd);
     setSessionKey((k) => k + 1);
@@ -264,7 +293,7 @@ export function AppShell() {
     setActiveTopPanel(null);
     if (isMobile) setSidebarOpen(false);
     router.replace("/", { scroll: false });
-  }, [router, isMobile]);
+  }, [clearReviewScope, router, isMobile]);
 
   // Global keyboard shortcuts (handles Esc, Ctrl+Alt+N etc.)
   useGlobalKeyboardShortcuts({
@@ -296,9 +325,112 @@ export function AppShell() {
     router.replace(`?session=${encodeURIComponent(session.id)}`, { scroll: false });
   }, [router, hydrateSelectedSession]);
 
-  const handleAgentEnd = useCallback(() => {
+  const handlePromptStart = useCallback(async (runId: number) => {
+    const cwd = selectedSession?.cwd ?? newSessionCwd ?? activeCwd;
+    if (!cwd) return;
+    const scopeRevision = reviewScopeRevisionRef.current;
+    for (const [olderRunId, { reviewId }] of reviewRunsRef.current) {
+      reviewRunsRef.current.delete(olderRunId);
+      void fetch("/api/git/review", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "cancel", reviewId }),
+      }).catch(() => {});
+    }
+    visibleReviewIdRef.current = null;
+    setCodeReview(null);
+    setReviewLifecycleError(null);
+    if (rightPanelMode === "review") setRightPanelMode("files");
+    try {
+      const response = await fetch("/api/git/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "start", cwd, runId }),
+      });
+      const body = await response.json() as { supported?: boolean; reviewId?: string; reason?: string; error?: string };
+      if (!response.ok || !body.supported || !body.reviewId) throw new Error(body.error || body.reason || `HTTP ${response.status}`);
+      if (scopeRevision !== reviewScopeRevisionRef.current) {
+        void fetch("/api/git/review", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "cancel", reviewId: body.reviewId }),
+        }).catch(() => {});
+        return;
+      }
+      reviewRunsRef.current.set(runId, { reviewId: body.reviewId, scopeRevision });
+    } catch (error) {
+      if (scopeRevision === reviewScopeRevisionRef.current) {
+        setReviewLifecycleError({ message: error instanceof Error ? error.message : String(error), runId, retryFinish: false });
+      }
+    }
+  }, [activeCwd, newSessionCwd, rightPanelMode, selectedSession?.cwd]);
+
+  const handlePromptAccepted = useCallback(async (runId: number) => {
+    const entry = reviewRunsRef.current.get(runId);
+    if (!entry || entry.scopeRevision !== reviewScopeRevisionRef.current) return;
+    try {
+      const response = await fetch("/api/git/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "activate", reviewId: entry.reviewId }),
+      });
+      const body = await response.json().catch(() => ({})) as { error?: string };
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+    } catch (error) {
+      if (reviewRunsRef.current.get(runId)?.reviewId === entry.reviewId) {
+        setReviewLifecycleError({ message: error instanceof Error ? error.message : String(error), runId, retryFinish: false });
+      }
+    }
+  }, []);
+
+  const handlePromptCancel = useCallback((runId: number) => {
+    const entry = reviewRunsRef.current.get(runId);
+    reviewRunsRef.current.delete(runId);
+    if (!entry) return;
+    void fetch("/api/git/review", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "cancel", reviewId: entry.reviewId }),
+    }).catch(() => {});
+  }, []);
+
+  const finishReviewForRun = useCallback(async (runId: number) => {
+    const entry = reviewRunsRef.current.get(runId);
+    if (!entry || entry.scopeRevision !== reviewScopeRevisionRef.current || finishingReviewRunsRef.current.has(runId)) return;
+    finishingReviewRunsRef.current.add(runId);
+    try {
+      const response = await fetch("/api/git/review", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "finish", reviewId: entry.reviewId }),
+      });
+      const body = await response.json() as GitReviewResponse & { error?: string };
+      if (!response.ok) {
+        throw Object.assign(new Error(body.error || `HTTP ${response.status}`), { retryable: response.status === 409 || response.status >= 500 });
+      }
+      const current = reviewRunsRef.current.get(runId);
+      if (!current || current.reviewId !== entry.reviewId || current.scopeRevision !== reviewScopeRevisionRef.current || body.runId !== runId) return;
+      setReviewLifecycleError(null);
+      if (body.files.length === 0) return;
+      visibleReviewIdRef.current = body.id;
+      setCodeReview(body);
+      setRightPanelMode("review");
+      setRightPanelOpen(true);
+    } catch (error) {
+      if (entry.scopeRevision === reviewScopeRevisionRef.current && reviewRunsRef.current.get(runId)?.reviewId === entry.reviewId) {
+        const retryable = !(typeof error === "object" && error && "retryable" in error) || error.retryable === true;
+        setReviewLifecycleError({ message: error instanceof Error ? error.message : String(error), runId, retryFinish: retryable });
+      }
+    } finally {
+      finishingReviewRunsRef.current.delete(runId);
+    }
+  }, []);
+
+  const handleAgentEnd = useCallback((runId: number) => {
     setRefreshKey((k) => k + 1);
     setExplorerRefreshKey((k) => k + 1);
+    void finishReviewForRun(runId);
+  }, [finishReviewForRun]);
+
+  const handleReviewChange = useCallback((next: GitReviewResponse) => {
+    if (visibleReviewIdRef.current !== next.id) return;
+    setCodeReview((current) => current?.id === next.id && next.revision >= current.revision ? next : current);
   }, []);
 
   const handleAutoName = useCallback(async () => {
@@ -342,6 +474,7 @@ export function AppShell() {
   }, []);
 
   const handleSessionForked = useCallback((newSessionId: string) => {
+    clearReviewScope();
     setRefreshKey((k) => k + 1);
     setSessionKey((k) => k + 1);
     setNewSessionCwd(null);
@@ -351,7 +484,7 @@ export function AppShell() {
     }));
     hydrateSelectedSession(newSessionId);
     router.replace(`?session=${encodeURIComponent(newSessionId)}`, { scroll: false });
-  }, [router, hydrateSelectedSession]);
+  }, [clearReviewScope, router, hydrateSelectedSession]);
 
   const handleInitialRestoreDone = useCallback(() => {
     setInitialSessionRestored(true);
@@ -360,6 +493,7 @@ export function AppShell() {
   const handleSessionDeleted = useCallback((sessionId: string) => {
     setRefreshKey((k) => k + 1);
     if (selectedSession?.id === sessionId) {
+      clearReviewScope();
       const cwd = selectedSession.cwd;
       setSelectedSession(null);
       setNewSessionCwd(cwd ?? null);
@@ -370,7 +504,7 @@ export function AppShell() {
       setActiveTopPanel(null);
       router.replace("/", { scroll: false });
     }
-  }, [selectedSession, router]);
+  }, [clearReviewScope, selectedSession, router]);
 
   const handleOpenFile = useCallback((filePath: string, fileName: string, sourceSessionId?: string | null) => {
     const tabId = `file:${filePath}`;
@@ -381,6 +515,7 @@ export function AppShell() {
       return prev.map((t) => t.id === tabId ? { ...t, sourceSessionId } : t);
     });
     setActiveFileTabId(tabId);
+    setRightPanelMode("files");
     setRightPanelOpen(true);
     // On mobile the file panel is full-screen; close the drawer so it shows.
     if (isMobile) setSidebarOpen(false);
@@ -393,7 +528,7 @@ export function AppShell() {
   const handleCloseFileTab = useCallback((tabId: string) => {
     setFileTabs((prev) => {
       const next = prev.filter((t) => t.id !== tabId);
-      if (next.length === 0) setRightPanelOpen(false);
+      if (next.length === 0 && !codeReview) setRightPanelOpen(false);
       return next;
     });
     setActiveFileTabId((cur) => {
@@ -401,7 +536,7 @@ export function AppShell() {
       const remaining = fileTabs.filter((t) => t.id !== tabId);
       return remaining.length > 0 ? remaining[remaining.length - 1].id : null;
     });
-  }, [fileTabs]);
+  }, [codeReview, fileTabs]);
 
   const handleViewFullHistory = useCallback(() => {
     if (!selectedSession) return;
@@ -1153,6 +1288,9 @@ export function AppShell() {
               session={selectedSession}
               newSessionCwd={effectiveNewSessionCwd}
               onAgentEnd={handleAgentEnd}
+              onPromptStart={handlePromptStart}
+              onPromptAccepted={handlePromptAccepted}
+              onPromptCancel={handlePromptCancel}
               onSessionCreated={handleSessionCreated}
               onSessionForked={handleSessionForked}
               modelsRefreshKey={modelsRefreshKey}
@@ -1220,20 +1358,51 @@ export function AppShell() {
       >
         {/* Right panel tab bar */}
         <div style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", height: 36 }}>
-          <div style={{ flex: 1, overflow: "hidden" }}>
-            <TabBar
-              tabs={fileTabs}
-              activeTabId={activeFileTabId ?? ""}
-              onSelectTab={setActiveFileTabId}
-              onCloseTab={handleCloseFileTab}
-            />
+          <div style={{ flex: 1, minWidth: 0, overflow: "hidden", display: "flex" }}>
+            {(codeReview || reviewLifecycleError) && (
+              <button
+                type="button"
+                className="review-tab-button"
+                aria-pressed={rightPanelMode === "review"}
+                style={{ background: rightPanelMode === "review" ? "var(--bg)" : "var(--bg-panel)", color: rightPanelMode === "review" ? "var(--text)" : "var(--text-muted)" }}
+                onClick={() => { setRightPanelMode("review"); setRightPanelOpen(true); }}
+                title={reviewLifecycleError ? "Code review needs attention" : "Review changes from the latest prompt"}
+              >
+                <span aria-hidden="true">±</span>
+                <span>Review</span>
+                <span className="review-tab-count">{reviewLifecycleError ? "!" : codeReview?.files.length ?? 0}</span>
+              </button>
+            )}
+            <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+              <TabBar
+                tabs={fileTabs}
+                activeTabId={rightPanelMode === "files" ? activeFileTabId ?? "" : ""}
+                onSelectTab={(id) => { setActiveFileTabId(id); setRightPanelMode("files"); }}
+                onCloseTab={handleCloseFileTab}
+              />
+            </div>
           </div>
 
         </div>
 
         {/* File content */}
         <div style={{ flex: 1, overflow: "hidden" }}>
-          {activeFileTab?.filePath ? (
+          {rightPanelMode === "review" && codeReview ? (
+            <CodeReviewPanel
+              review={codeReview}
+              onReviewChange={handleReviewChange}
+              onClose={() => setRightPanelOpen(false)}
+              onFilesChanged={() => setExplorerRefreshKey((key) => key + 1)}
+            />
+          ) : rightPanelMode === "review" && reviewLifecycleError ? (
+            <div className="review-lifecycle-error" role="alert">
+              <strong>Code review unavailable</strong>
+              <span>{reviewLifecycleError.message}</span>
+              {reviewLifecycleError.retryFinish && (
+                <button type="button" onClick={() => void finishReviewForRun(reviewLifecycleError.runId)}>Retry review</button>
+              )}
+            </div>
+          ) : activeFileTab?.filePath ? (
             <FileViewer
               filePath={activeFileTab.filePath}
               cwd={activeCwd ?? undefined}
@@ -1255,9 +1424,12 @@ export function AppShell() {
     </div>
     {/* File panel toggle — always visible at top-right */}
     <button
-      onClick={() => setRightPanelOpen((v) => !v)}
-      title={rightPanelOpen ? "Hide file panel" : "Show file panel"}
-      aria-label={rightPanelOpen ? "Hide file panel" : "Show file panel"}
+      onClick={() => setRightPanelOpen((open) => {
+        if (!open && (codeReview || reviewLifecycleError)) setRightPanelMode("review");
+        return !open;
+      })}
+      title={rightPanelOpen ? "Hide right panel" : codeReview || reviewLifecycleError ? "Show code review panel" : "Show file panel"}
+      aria-label={rightPanelOpen ? "Hide right panel" : codeReview || reviewLifecycleError ? "Show code review panel" : "Show file panel"}
       style={{
         position: "fixed", top: 0, right: 0, zIndex: 300,
         display: "flex", alignItems: "center", justifyContent: "center",
@@ -1272,6 +1444,9 @@ export function AppShell() {
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="15" y1="3" x2="15" y2="21" />
       </svg>
+      {(codeReview || reviewLifecycleError) && !rightPanelOpen && (
+        <span className="review-reopen-badge" aria-label="Code review available">{reviewLifecycleError ? "!" : codeReview?.files.length}</span>
+      )}
     </button>
     {modelsConfigOpen && <ModelsConfig onClose={() => { setModelsConfigOpen(false); setModelsRefreshKey((k) => k + 1); }} />}
     {skillsConfigOpen && (activeCwd ?? selectedSession?.cwd ?? newSessionCwd) && (

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -24,7 +24,10 @@ import {
 interface Props {
   session: SessionInfo | null;
   newSessionCwd: string | null;
-  onAgentEnd?: () => void;
+  onAgentEnd?: (runId: number) => void;
+  onPromptStart?: (runId: number) => Promise<void>;
+  onPromptAccepted?: (runId: number) => Promise<void>;
+  onPromptCancel?: (runId: number) => void;
   onSessionCreated?: (session: SessionInfo) => void;
   onSessionForked?: (newSessionId: string) => void;
   modelsRefreshKey?: number;
@@ -141,7 +144,7 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, children }: { messag
   );
 }
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onPromptStart, onPromptAccepted, onPromptCancel, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
   const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
   const isMobile = useIsMobile();
 
@@ -153,11 +156,11 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   playDoneSoundRef.current = playDoneSound;
   const soundEnabledRef = useRef(soundEnabled);
   soundEnabledRef.current = soundEnabled;
-  const wrappedOnAgentEnd = useCallback(() => {
+  const wrappedOnAgentEnd = useCallback((runId: number) => {
     if (soundEnabledRef.current) {
       playDoneSoundRef.current();
     }
-    onAgentEnd?.();
+    onAgentEnd?.(runId);
   }, [onAgentEnd]);
 
   // 稳定化 onEditContent 引用，配合 React.memo 防止历史消息重渲染
@@ -183,7 +186,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     handleBuiltinSlashCommand,
     handleToolPresetChange, handleThinkingLevelChange, loadSlashCommands,
   } = useAgentSession({
-    session, newSessionCwd, onAgentEnd: wrappedOnAgentEnd, onSessionCreated, onSessionForked,
+    session, newSessionCwd, onAgentEnd: wrappedOnAgentEnd, onPromptStart, onPromptAccepted, onPromptCancel, onSessionCreated, onSessionForked,
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
   });
   const sessionBusy = agentRunning || bashRunning;

--- a/components/CodeReviewPanel.tsx
+++ b/components/CodeReviewPanel.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { findReviewFile, getReviewNavigationItems, nextReviewItemKey, reviewCounts } from "@/lib/code-review";
+import type { GitReviewDecision, GitReviewFile, GitReviewHunk, GitReviewResponse } from "@/lib/git-types";
+
+interface Props {
+  review: GitReviewResponse;
+  onReviewChange: (review: GitReviewResponse) => void;
+  onClose: () => void;
+  onFilesChanged?: () => void;
+}
+
+type FinalDecision = Exclude<GitReviewDecision, "pending" | "mixed">;
+type DecisionRequest = { decision: FinalDecision; fileId?: string; hunkId?: string; all?: boolean };
+
+function decisionLabel(decision: GitReviewDecision): string {
+  if (decision === "accepted") return "Accepted";
+  if (decision === "rejected") return "Rejected";
+  if (decision === "mixed") return "Mixed";
+  return "Pending";
+}
+
+function DecisionButtons({ decision, context, disabled, busy, onDecide, compact = false }: {
+  decision: GitReviewDecision;
+  context: string;
+  disabled?: boolean;
+  busy?: boolean;
+  compact?: boolean;
+  onDecide: (decision: FinalDecision) => void;
+}) {
+  return (
+    <div className="review-decision-buttons" data-compact={compact || undefined}>
+      <button
+        type="button"
+        className={`review-decision-button review-accept${decision === "accepted" ? " is-active" : ""}`}
+        aria-label={`Accept ${context}`}
+        aria-pressed={decision === "accepted"}
+        disabled={disabled || busy}
+        onClick={() => onDecide("accepted")}
+      >
+        <span aria-hidden="true">✓</span> Accept
+      </button>
+      <button
+        type="button"
+        className={`review-decision-button review-reject${decision === "rejected" ? " is-active" : ""}`}
+        aria-label={`Reject ${context}`}
+        aria-pressed={decision === "rejected"}
+        disabled={disabled || busy}
+        onClick={() => onDecide("rejected")}
+      >
+        <span aria-hidden="true">×</span> Reject
+      </button>
+    </div>
+  );
+}
+
+function parseHunkStart(header: string): { old: number; next: number } {
+  const match = header.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)?/);
+  return { old: Number(match?.[1] ?? 0), next: Number(match?.[2] ?? 0) };
+}
+
+function HunkDiff({ hunk }: { hunk: GitReviewHunk }) {
+  const start = parseHunkStart(hunk.header);
+  let oldLine = start.old;
+  let newLine = start.next;
+  return (
+    <div className="review-diff" aria-label={`Diff ${hunk.header}`}>
+      <div className="review-hunk-header">{hunk.header}</div>
+      {hunk.lines.map((line, index) => {
+        const prefix = line[0] ?? " ";
+        const text = line.slice(1);
+        const type = prefix === "+" ? "added" : prefix === "-" ? "removed" : prefix === "\\" ? "meta" : "context";
+        const oldNo = type === "added" || type === "meta" ? null : oldLine++;
+        const newNo = type === "removed" || type === "meta" ? null : newLine++;
+        const spokenType = type === "added" ? "Added" : type === "removed" ? "Removed" : type === "meta" ? "Metadata" : "Unchanged";
+        return (
+          <div className={`review-diff-line is-${type}`} key={`${index}:${line}`} aria-label={`${spokenType} line: ${text}`}>
+            <span className="review-line-number" aria-hidden="true">{oldNo ?? ""}</span>
+            <span className="review-line-number" aria-hidden="true">{newNo ?? ""}</span>
+            <span className="review-line-prefix" aria-hidden="true">{prefix}</span>
+            <code>{text || "\u00a0"}</code>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function FileSummary({ file }: { file: GitReviewFile }) {
+  return (
+    <div className="review-file-summary">
+      <span className={`review-status-badge is-${file.status}`}>{file.status}</span>
+      <span className="review-file-path" title={file.path}>{file.path}</span>
+      <span className={`review-decision-state is-${file.decision}`}>{decisionLabel(file.decision)}</span>
+    </div>
+  );
+}
+
+export function CodeReviewPanel({ review, onReviewChange, onClose, onFilesChanged }: Props) {
+  const items = useMemo(() => getReviewNavigationItems(review), [review]);
+  const [currentKey, setCurrentKey] = useState<string | null>(() => nextReviewItemKey(review, null, { pendingOnly: true }));
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const currentFile = findReviewFile(review, currentKey);
+  const currentItem = items.find((item) => item.key === currentKey) ?? items[0] ?? null;
+  const currentIndex = currentItem ? items.findIndex((item) => item.key === currentItem.key) : -1;
+  const counts = reviewCounts(review);
+  const liveRef = useRef<HTMLDivElement>(null);
+  const hunkRefs = useRef(new Map<string, HTMLElement>());
+  const reviewRef = useRef(review);
+  reviewRef.current = review;
+
+  useEffect(() => {
+    if (currentKey && items.some((item) => item.key === currentKey)) return;
+    setCurrentKey(nextReviewItemKey(review, null, { pendingOnly: true }) ?? items[0]?.key ?? null);
+  }, [currentKey, items, review]);
+
+  useEffect(() => {
+    if (!currentKey) return;
+    const target = hunkRefs.current.get(currentKey);
+    target?.scrollIntoView({ block: "nearest", behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth" });
+    target?.focus({ preventScroll: true });
+  }, [currentKey]);
+
+  const decide = async (request: DecisionRequest, advanceFrom: string | null) => {
+    if (busyKey) return;
+    const operationKey = request.all ? "all" : `${request.fileId}:${request.hunkId ?? "file"}`;
+    setBusyKey(operationKey);
+    setError(null);
+    try {
+      const response = await fetch("/api/git/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "decide", reviewId: review.id, revision: review.revision, ...request }),
+      });
+      const body = await response.json() as GitReviewResponse & { error?: string };
+      if (!response.ok) {
+        const message = body.error || `HTTP ${response.status}`;
+        if (response.status === 409) {
+          const reloadResponse = await fetch("/api/git/review", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "get", reviewId: review.id }),
+          });
+          const reloaded = await reloadResponse.json() as GitReviewResponse & { error?: string };
+          if (reloadResponse.ok && reloaded.id === reviewRef.current.id) {
+            onReviewChange(reloaded);
+            onFilesChanged?.();
+            setError(`${message} The latest review state has been reloaded.`);
+            return;
+          }
+        }
+        throw new Error(message);
+      }
+      const current = reviewRef.current;
+      if (body.id !== current.id || body.revision <= current.revision) return;
+      onReviewChange(body);
+      onFilesChanged?.();
+      const next = nextReviewItemKey(body, advanceFrom, { pendingOnly: true });
+      if (next) setCurrentKey(next);
+      liveRef.current?.focus({ preventScroll: true });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const selectFile = (fileId: string) => {
+    const item = items.find((candidate) => candidate.fileId === fileId && candidate.pending)
+      ?? items.find((candidate) => candidate.fileId === fileId);
+    setCurrentKey(item?.key ?? fileId);
+  };
+
+  if (!currentFile) {
+    return <div className="review-empty">No code changes were captured for this prompt.</div>;
+  }
+
+  return (
+    <section className="code-review-panel" aria-label="Code changes review">
+      <header className="review-toolbar">
+        <div className="review-title-row">
+          <div>
+            <strong>Review changes</strong>
+            <span>{counts.pending > 0 ? `${counts.pending} of ${counts.total} pending` : "Review complete"}</span>
+          </div>
+          <div className="review-global-actions">
+            <button type="button" aria-label="Accept all changes in this review" disabled={Boolean(busyKey) || counts.total === 0} onClick={() => void decide({ decision: "accepted", all: true }, currentKey)}>Accept all</button>
+            <button type="button" aria-label="Reject all changes in this review" disabled={Boolean(busyKey) || counts.total === 0} onClick={() => void decide({ decision: "rejected", all: true }, currentKey)}>Reject all</button>
+            <button type="button" aria-label="Close code review panel" title="Close review" onClick={onClose}>×</button>
+          </div>
+        </div>
+        <div className="review-nav-row">
+          <label>
+            <span className="sr-only">Review file</span>
+            <select value={currentFile.id} onChange={(event) => selectFile(event.target.value)}>
+              {review.files.map((file) => (
+                <option key={file.id} value={file.id}>{decisionLabel(file.decision)} · {file.path}</option>
+              ))}
+            </select>
+          </label>
+          <span className="review-position">{Math.max(0, currentIndex) + 1} / {items.length}</span>
+          <button type="button" aria-label="Previous change" title="Previous change" disabled={items.length < 2} onClick={() => setCurrentKey(nextReviewItemKey(review, currentKey, { direction: -1 }))}>←</button>
+          <button type="button" aria-label="Next change" title="Next change" disabled={items.length < 2} onClick={() => setCurrentKey(nextReviewItemKey(review, currentKey, { direction: 1 }))}>→</button>
+        </div>
+        {error && <div className="review-error" role="alert">{error}</div>}
+        <div ref={liveRef} className="sr-only" tabIndex={-1} aria-live="polite">{counts.pending > 0 ? `${counts.pending} changes pending` : "All changes reviewed"}</div>
+      </header>
+
+      <div className="review-scroll-area">
+        <div className="review-file-header">
+          <FileSummary file={currentFile} />
+          <DecisionButtons
+            compact
+            context={`all changes in ${currentFile.path}`}
+            decision={currentFile.decision}
+            disabled={!currentFile.actionable}
+            busy={Boolean(busyKey)}
+            onDecide={(decision) => void decide({ decision, fileId: currentFile.id }, currentKey)}
+          />
+        </div>
+        {currentFile.reason && <p className="review-file-note">{currentFile.reason}</p>}
+        {!currentFile.actionable ? (
+          <div className="review-unsupported">This file cannot be safely changed from the review panel. Inspect it manually before continuing.</div>
+        ) : currentFile.granular ? (
+          <div className="review-hunk-list">
+            {currentFile.hunks.map((hunk, index) => {
+              const key = `${currentFile.id}:${hunk.id}`;
+              return (
+                <article
+                  className={`review-hunk${currentKey === key ? " is-current" : ""}`}
+                  key={hunk.id}
+                  tabIndex={-1}
+                  ref={(element) => { if (element) hunkRefs.current.set(key, element); else hunkRefs.current.delete(key); }}
+                  onClick={() => setCurrentKey(key)}
+                >
+                  <div className="review-hunk-actions">
+                    <span>Block {index + 1} of {currentFile.hunks.length}</span>
+                    <span className={`review-decision-state is-${hunk.decision}`}>{decisionLabel(hunk.decision)}</span>
+                    <DecisionButtons
+                      compact
+                      context={`block ${index + 1} in ${currentFile.path}`}
+                      decision={hunk.decision}
+                      busy={Boolean(busyKey)}
+                      onDecide={(decision) => void decide({ decision, fileId: currentFile.id, hunkId: hunk.id }, key)}
+                    />
+                  </div>
+                  <HunkDiff hunk={hunk} />
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="review-file-level">
+            <p>This change is available for whole-file review. Use Accept to keep it or Reject to restore the pre-prompt version.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -77,6 +77,7 @@ type AgentStateResponse = {
   extensionStatuses?: ExtensionStatusItem[];
   extensionWidgets?: ExtensionWidgetItem[];
   queuedMessages?: { steering?: string[]; followUp?: string[] } | null;
+  activeRunId?: number | null;
 };
 
 export interface QueuedMessages {
@@ -141,7 +142,10 @@ export type BuiltinSlashCommandResult =
 export interface UseAgentSessionOptions {
   session: SessionInfo | null;
   newSessionCwd: string | null;
-  onAgentEnd?: () => void;
+  onAgentEnd?: (runId: number) => void;
+  onPromptStart?: (runId: number) => Promise<void>;
+  onPromptAccepted?: (runId: number) => Promise<void>;
+  onPromptCancel?: (runId: number) => void;
   onSessionCreated?: (session: SessionInfo) => void;
   onSessionForked?: (newSessionId: string) => void;
   modelsRefreshKey?: number;
@@ -322,7 +326,7 @@ type SlashCommandsResponse = {
 
 export function useAgentSession(opts: UseAgentSessionOptions) {
   const {
-    session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked,
+    session, newSessionCwd, onAgentEnd, onPromptStart, onPromptAccepted, onPromptCancel, onSessionCreated, onSessionForked,
     modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onSessionStatsPanelOpen,
   } = opts;
 
@@ -740,14 +744,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [addNotice, opts.chatInputRef]);
 
-  const finishPromptWithoutStream = useCallback(async (sid: string | null = sessionIdRef.current, runId?: number) => {
+  const finishPromptWithoutStream = useCallback(async (sid: string | null = sessionIdRef.current, runId = promptRunIdRef.current) => {
     // Bail out before loadSession too: a stale finish for a previous run
     // must not overwrite the messages of the run currently streaming.
-    if (runId !== undefined && promptRunIdRef.current !== runId) return;
+    if (promptRunIdRef.current !== runId) return;
     try {
       if (sid) await loadSession(sid);
     } finally {
-      if (runId !== undefined && promptRunIdRef.current !== runId) return;
+      if (promptRunIdRef.current !== runId) return;
       optimisticUserMessageKeyRef.current = null;
       if (!agentRunningRef.current) return;
       agentRunningRef.current = false;
@@ -755,7 +759,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setAgentPhase(null);
       setRetryInfo(null);
       dispatch({ type: "end" });
-      onAgentEnd?.();
+      onAgentEnd?.(runId);
     }
   }, [loadSession, onAgentEnd]);
 
@@ -827,6 +831,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // flight) — everything in it is stale, drop it.
       if (promptRunIdRef.current !== runId) return;
       const state = data.state;
+      if (typeof state?.activeRunId === "number" && state.activeRunId !== runId) return;
       // Mirror compaction state unconditionally: a missed compaction_end
       // would otherwise leave the "Stop compaction" UI stuck. No state
       // (wrapper destroyed) means nothing is compacting.
@@ -883,10 +888,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         setAgentPhase({ kind: "waiting_model" });
         dispatch({ type: "start" });
         break;
-      case "agent_end":
-        // A late agent_end can arrive over SSE after reconcileAgentState
-        // already finished this run — don't re-trigger completion.
-        if (!agentRunningRef.current) break;
+      case "agent_end": {
+        const eventRunId = typeof event.runId === "number" ? event.runId : promptRunIdRef.current;
+        // A server-tagged run prevents a buffered completion from run A
+        // from finishing a newer run B.
+        if (eventRunId !== promptRunIdRef.current || !agentRunningRef.current) break;
         agentRunningRef.current = false;
         setAgentRunning(false);
         setAgentPhase(null);
@@ -907,12 +913,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             })
             .catch(() => {});
         }
-        onAgentEnd?.();
+        onAgentEnd?.(eventRunId);
         break;
-      case "prompt_done":
-        if (!agentRunningRef.current) break;
-        void finishPromptWithoutStream(sessionIdRef.current);
+      }
+      case "prompt_done": {
+        const eventRunId = typeof event.runId === "number" ? event.runId : promptRunIdRef.current;
+        if (eventRunId !== promptRunIdRef.current || !agentRunningRef.current) break;
+        void finishPromptWithoutStream(sessionIdRef.current, eventRunId);
         break;
+      }
       case "prompt_error":
         addNotice({ type: "error", message: (event.errorMessage as string | undefined) ?? "Command failed" });
         break;
@@ -1040,7 +1049,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       return;
     }
 
-    const promptRunId = promptRunIdRef.current + 1;
+    // Use a wall-clock floor as well as local monotonicity so a remount or a
+    // second browser tab cannot easily reuse an old run id still buffered in SSE.
+    const promptRunId = Math.max(promptRunIdRef.current + 1, Date.now());
 
     const imageBlocks = images?.map((img) => ({ type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } }));
     const userMsg: AgentMessage = {
@@ -1062,7 +1073,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
     const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
 
+    let promptAccepted = false;
     try {
+      // The review baseline must exist before the prompt can execute tools.
+      // The callback resolves quietly when Git review is unavailable.
+      await onPromptStart?.(promptRunId);
       let sentSessionId: string | null = null;
       if (isNew && newSessionCwd) {
         const selectedModel = newSessionModel;
@@ -1082,7 +1097,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             type: "prompt",
             message,
             ...(piImages?.length ? { images: piImages } : {}),
+            runId: promptRunId,
           });
+          promptAccepted = true;
+          try { await onPromptAccepted?.(promptRunId); }
+          catch (error) { console.error("Failed to activate code review:", error); }
           promoteNewSession(1, message);
         }
       } else if (session) {
@@ -1092,12 +1111,18 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           type: "prompt",
           message,
           ...(piImages?.length ? { images: piImages } : {}),
+          runId: promptRunId,
         });
+        promptAccepted = true;
+        try { await onPromptAccepted?.(promptRunId); }
+        catch (error) { console.error("Failed to activate code review:", error); }
       }
+      if (!promptAccepted) throw new Error("Unable to start the prompt");
       if (isSlashCommandPrompt && sentSessionId) {
         void waitForPromptSettlement(sentSessionId, promptRunId);
       }
     } catch (e) {
+      if (!promptAccepted) onPromptCancel?.(promptRunId);
       console.error("Failed to send message:", e);
       if (e instanceof EventStreamConnectionError) {
         const optimisticKey = optimisticUserMessageKeyRef.current;
@@ -1117,7 +1142,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice]);
+  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, onPromptStart, onPromptAccepted, onPromptCancel]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;

--- a/lib/code-review.test.mjs
+++ b/lib/code-review.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function subject() {
+  return import("./code-review.ts");
+}
+
+function fixture() {
+  return {
+    id: "review",
+    repositoryRoot: "/repo",
+    sealed: false,
+    finished: true,
+    files: [
+      {
+        id: "a",
+        path: "a.ts",
+        status: "modified",
+        decision: "pending",
+        actionable: true,
+        granular: true,
+        hunks: [
+          { id: "0", header: "@@ -1 +1 @@", lines: ["-a", "+b"], decision: "accepted" },
+          { id: "1", header: "@@ -9 +9 @@", lines: ["-x", "+y"], decision: "pending" },
+        ],
+      },
+      {
+        id: "b",
+        path: "image.png",
+        status: "modified",
+        decision: "pending",
+        actionable: true,
+        granular: false,
+        hunks: [],
+      },
+      {
+        id: "c",
+        path: "unsafe",
+        status: "type-changed",
+        decision: "pending",
+        actionable: false,
+        granular: false,
+        hunks: [],
+      },
+    ],
+  };
+}
+
+test("builds file/hunk navigation and advances to the next pending item", async () => {
+  const { getReviewNavigationItems, nextReviewItemKey } = await subject();
+  const review = fixture();
+  assert.deepEqual(getReviewNavigationItems(review).map((item) => item.key), ["a:0", "a:1", "b", "c"]);
+  assert.equal(nextReviewItemKey(review, "a:0", { pendingOnly: true }), "a:1");
+  assert.equal(nextReviewItemKey(review, "a:1", { pendingOnly: true }), "b");
+  assert.equal(nextReviewItemKey(review, "b", { pendingOnly: true }), "a:1");
+  assert.equal(nextReviewItemKey(review, "b", { direction: -1 }), "a:1");
+  review.files[0].hunks[1].decision = "accepted";
+  assert.equal(nextReviewItemKey(review, "a:1", { pendingOnly: true }), "b", "advance uses original order after the current item is resolved");
+});
+
+test("counts actionable decisions without treating unsupported files as pending", async () => {
+  const { reviewCounts } = await subject();
+  assert.deepEqual(reviewCounts(fixture()), { total: 3, pending: 2, accepted: 1, rejected: 0 });
+});

--- a/lib/code-review.ts
+++ b/lib/code-review.ts
@@ -1,0 +1,71 @@
+import type { GitReviewFile, GitReviewResponse } from "./git-types";
+
+export interface ReviewNavigationItem {
+  key: string;
+  fileId: string;
+  hunkId?: string;
+  actionable: boolean;
+  pending: boolean;
+}
+
+export function getReviewNavigationItems(review: GitReviewResponse): ReviewNavigationItem[] {
+  return review.files.flatMap((file) => {
+    if (file.granular && file.hunks.length > 0) {
+      return file.hunks.map((hunk) => ({
+        key: `${file.id}:${hunk.id}`,
+        fileId: file.id,
+        hunkId: hunk.id,
+        actionable: file.actionable,
+        pending: hunk.decision === "pending",
+      }));
+    }
+    return [{
+      key: file.id,
+      fileId: file.id,
+      actionable: file.actionable,
+      pending: file.actionable && file.decision === "pending",
+    }];
+  });
+}
+
+export function nextReviewItemKey(
+  review: GitReviewResponse,
+  currentKey: string | null,
+  options: { pendingOnly?: boolean; direction?: 1 | -1 } = {},
+): string | null {
+  const items = getReviewNavigationItems(review);
+  if (items.length === 0) return null;
+  const direction = options.direction ?? 1;
+  const currentIndex = items.findIndex((item) => item.key === currentKey);
+  if (currentIndex === -1) {
+    const candidates = items.filter((item) => !options.pendingOnly || item.pending);
+    return direction === 1 ? candidates[0]?.key ?? null : candidates[candidates.length - 1]?.key ?? null;
+  }
+  for (let offset = 1; offset <= items.length; offset++) {
+    const candidate = items[(currentIndex + direction * offset + items.length * 2) % items.length];
+    if (!options.pendingOnly || candidate.pending) return candidate.key;
+  }
+  return null;
+}
+
+export function findReviewFile(review: GitReviewResponse, key: string | null): GitReviewFile | null {
+  if (!key) return review.files[0] ?? null;
+  const item = getReviewNavigationItems(review).find((candidate) => candidate.key === key);
+  return review.files.find((file) => file.id === item?.fileId) ?? review.files[0] ?? null;
+}
+
+export function reviewCounts(review: GitReviewResponse): { total: number; pending: number; accepted: number; rejected: number } {
+  const actionable = getReviewNavigationItems(review).filter((item) => item.actionable);
+  let accepted = 0;
+  let rejected = 0;
+  for (const file of review.files) {
+    if (file.granular) {
+      accepted += file.hunks.filter((hunk) => hunk.decision === "accepted").length;
+      rejected += file.hunks.filter((hunk) => hunk.decision === "rejected").length;
+    } else if (file.actionable) {
+      if (file.decision === "accepted") accepted++;
+      if (file.decision === "rejected") rejected++;
+    }
+  }
+  return { total: actionable.length, pending: actionable.filter((item) => item.pending).length, accepted, rejected };
+}

--- a/lib/git-review.test.mjs
+++ b/lib/git-review.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+async function subject() {
+  return import("./git-review.ts");
+}
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+}
+
+function repo() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-git-review-test-"));
+  git(cwd, "init", "-q");
+  git(cwd, "config", "user.email", "test@example.com");
+  git(cwd, "config", "user.name", "Test");
+  fs.writeFileSync(path.join(cwd, "app.txt"), "one\ntwo\nthree\n");
+  git(cwd, "add", "app.txt");
+  git(cwd, "commit", "-qm", "initial");
+  return cwd;
+}
+
+test("splits a file patch into server-owned hunk patches", async () => {
+  const { splitGitReviewPatch } = await subject();
+  const patch = [
+    "diff --git a/a.txt b/a.txt",
+    "--- a/a.txt",
+    "+++ b/a.txt",
+    "@@ -1 +1 @@",
+    "-one",
+    "+ONE",
+    "@@ -9 +9 @@",
+    "-nine",
+    "+NINE",
+    "",
+  ].join("\n");
+  const parsed = splitGitReviewPatch(patch);
+  assert.equal(parsed.hunks.length, 2);
+  assert.match(parsed.hunks[0].patch, /@@ -1 \+1 @@/);
+  assert.doesNotMatch(parsed.hunks[0].patch, /@@ -9 \+9 @@/);
+  assert.match(parsed.hunks[1].patch, /diff --git a\/a.txt b\/a.txt/);
+});
+
+test("captures only prompt changes, preserves the real index, and supports reversible decisions", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  fs.writeFileSync(path.join(cwd, "app.txt"), "preexisting\ntwo\nthree\n");
+  git(cwd, "add", "app.txt");
+  const stagedBefore = git(cwd, "diff", "--cached");
+
+  const started = await api.startGitReview(cwd);
+  assert.equal(started.supported, true);
+  fs.writeFileSync(path.join(cwd, "app.txt"), "preexisting\ntwo\nthree\nai change\n");
+
+  const review = await api.finishGitReview(started.reviewId);
+  assert.equal(review.files.length, 1);
+  assert.equal(review.files[0].hunks.length, 1);
+  assert.equal(git(cwd, "diff", "--cached"), stagedBefore, "temporary index must not mutate the real index");
+
+  const file = review.files[0];
+  const hunk = file.hunks[0];
+  const rejected = await api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, fileId: file.id, hunkId: hunk.id });
+  assert.equal(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), "preexisting\ntwo\nthree\n");
+  assert.equal(rejected.files[0].hunks[0].decision, "rejected");
+
+  const accepted = await api.decideGitReview(review.id, { decision: "accepted", revision: rejected.revision, fileId: file.id, hunkId: hunk.id });
+  assert.equal(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), "preexisting\ntwo\nthree\nai change\n");
+  assert.equal(accepted.files[0].hunks[0].decision, "accepted");
+});
+
+test("rejects added and deleted files at file level and can restore them", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const started = await api.startGitReview(cwd);
+  fs.unlinkSync(path.join(cwd, "app.txt"));
+  fs.writeFileSync(path.join(cwd, "new.txt"), "new\n");
+  const review = await api.finishGitReview(started.reviewId);
+  assert.deepEqual(review.files.map((file) => file.status).sort(), ["added", "deleted"]);
+
+  const rejected = await api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, all: true });
+  assert.equal(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), "one\ntwo\nthree\n");
+  assert.equal(fs.existsSync(path.join(cwd, "new.txt")), false);
+  assert.ok(rejected.files.every((file) => file.decision === "rejected"));
+
+  await api.decideGitReview(review.id, { decision: "accepted", revision: rejected.revision, all: true });
+  assert.equal(fs.existsSync(path.join(cwd, "app.txt")), false);
+  assert.equal(fs.readFileSync(path.join(cwd, "new.txt"), "utf8"), "new\n");
+});
+
+test("mode-bearing text patches are file-level and reversible as one operation", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const started = await api.startGitReview(cwd, 7);
+  fs.writeFileSync(path.join(cwd, "app.txt"), "ONE\ntwo\nthree\n");
+  fs.chmodSync(path.join(cwd, "app.txt"), 0o755);
+  const review = await api.finishGitReview(started.reviewId);
+  assert.equal(review.runId, 7);
+  assert.equal(review.files[0].granular, false);
+  assert.match(review.files[0].reason, /mode changes/);
+
+  const rejected = await api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, fileId: review.files[0].id });
+  assert.equal(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), "one\ntwo\nthree\n");
+  assert.equal(fs.statSync(path.join(cwd, "app.txt")).mode & 0o777, 0o644);
+  await api.decideGitReview(review.id, { decision: "accepted", revision: rejected.revision, fileId: review.files[0].id });
+  assert.equal(fs.statSync(path.join(cwd, "app.txt")).mode & 0o777, 0o755);
+});
+
+test("multi-file stale decisions fail before any file is mutated", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const started = await api.startGitReview(cwd, 8);
+  fs.appendFileSync(path.join(cwd, "app.txt"), "ai\n");
+  fs.writeFileSync(path.join(cwd, "second.txt"), "ai second\n");
+  const review = await api.finishGitReview(started.reviewId);
+  fs.appendFileSync(path.join(cwd, "app.txt"), "external\n");
+
+  await assert.rejects(
+    api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, all: true }),
+    (error) => error.status === 409,
+  );
+  assert.equal(fs.readFileSync(path.join(cwd, "second.txt"), "utf8"), "ai second\n");
+  assert.match(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), /ai\nexternal/);
+});
+
+test("a losing deferred reservation cannot seal the review of the accepted prompt", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const first = await api.startGitReview(cwd, 39, true);
+  const competing = await api.startGitReview(cwd, 40, true);
+  await api.activateGitReview(first.reviewId);
+  await api.cancelGitReview(competing.reviewId);
+  assert.equal((await api.finishGitReview(first.reviewId)).runId, 39);
+});
+
+test("server workspace generations seal older run ids without client cooperation", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const first = await api.startGitReview(cwd, 41);
+  const second = await api.startGitReview(cwd, 42);
+  await assert.rejects(api.finishGitReview(first.reviewId), (error) => error.status === 409);
+  const current = await api.finishGitReview(second.reviewId);
+  assert.equal(current.runId, 42);
+});
+
+test("a newer subdirectory review seals an overlapping repository-root review", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+  const subdir = path.join(cwd, "src");
+  fs.mkdirSync(subdir);
+  fs.writeFileSync(path.join(subdir, "nested.txt"), "base\n");
+  git(cwd, "add", "src/nested.txt");
+  git(cwd, "commit", "-qm", "nested file");
+
+  const rootReview = await api.startGitReview(cwd, 50);
+  const nestedReview = await api.startGitReview(subdir, 51);
+  await assert.rejects(api.finishGitReview(rootReview.reviewId), (error) => error.status === 409);
+  assert.equal((await api.finishGitReview(nestedReview.reviewId)).runId, 51);
+});
+
+test("symlink target changes are file-level and reversible", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+  const linkPath = path.join(cwd, "current.txt");
+  fs.symlinkSync("app.txt", linkPath);
+  git(cwd, "add", "current.txt");
+  git(cwd, "commit", "-qm", "symlink");
+
+  const started = await api.startGitReview(cwd, 52);
+  fs.unlinkSync(linkPath);
+  fs.symlinkSync("other.txt", linkPath);
+  const review = await api.finishGitReview(started.reviewId);
+  const file = review.files.find((candidate) => candidate.path === "current.txt");
+  assert.ok(file);
+  assert.equal(file.granular, false);
+  const rejected = await api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, fileId: file.id });
+  assert.equal(fs.readlinkSync(linkPath), "app.txt");
+  await api.decideGitReview(review.id, { decision: "accepted", revision: rejected.revision, fileId: file.id });
+  assert.equal(fs.readlinkSync(linkPath), "other.txt");
+});
+
+test("mixed hunk decisions carry revisions and reject stale mutations", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+  fs.writeFileSync(path.join(cwd, "app.txt"), Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join("\n") + "\n");
+  git(cwd, "add", "app.txt");
+  git(cwd, "commit", "-qm", "long file");
+
+  const started = await api.startGitReview(cwd, 9);
+  const lines = fs.readFileSync(path.join(cwd, "app.txt"), "utf8").split("\n");
+  lines[1] = "AI TWO";
+  lines[25] = "AI TWENTY SIX";
+  fs.writeFileSync(path.join(cwd, "app.txt"), lines.join("\n"));
+  const review = await api.finishGitReview(started.reviewId);
+  assert.equal(review.files[0].hunks.length, 2);
+  const next = await api.decideGitReview(review.id, {
+    decision: "rejected", revision: review.revision, fileId: review.files[0].id, hunkId: review.files[0].hunks[0].id,
+  });
+  assert.equal(next.files[0].decision, "mixed");
+  await assert.rejects(
+    api.decideGitReview(review.id, { decision: "accepted", revision: review.revision, fileId: review.files[0].id }),
+    (error) => error.status === 409,
+  );
+});
+
+test("returns a conflict instead of overwriting concurrent edits and seals old reviews", async (t) => {
+  const api = await subject();
+  api.resetGitReviewsForTests();
+  const cwd = repo();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+
+  const started = await api.startGitReview(cwd);
+  fs.writeFileSync(path.join(cwd, "app.txt"), "one\ntwo\nthree\nai\n");
+  const review = await api.finishGitReview(started.reviewId);
+  fs.appendFileSync(path.join(cwd, "app.txt"), "user edit\n");
+
+  await assert.rejects(
+    api.decideGitReview(review.id, { decision: "rejected", revision: review.revision, fileId: review.files[0].id }),
+    (error) => error.status === 409,
+  );
+  assert.match(fs.readFileSync(path.join(cwd, "app.txt"), "utf8"), /user edit/);
+
+  await api.startGitReview(cwd, 2);
+  await assert.rejects(
+    api.decideGitReview(review.id, { decision: "accepted", revision: review.revision, fileId: review.files[0].id }),
+    (error) => error.status === 409,
+  );
+});

--- a/lib/git-review.ts
+++ b/lib/git-review.ts
@@ -1,0 +1,487 @@
+import { execFile } from "child_process";
+import { createHash, randomUUID } from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { promisify } from "util";
+import type { GitReviewDecision, GitReviewFile, GitReviewHunk, GitReviewResponse } from "./git-types";
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 20_000;
+const GIT_MAX_BUFFER = 32 * 1024 * 1024;
+const REVIEW_TTL_MS = 60 * 60 * 1000;
+const MAX_REVIEWS = 64;
+const MAX_REVIEW_FILES = 200;
+const MAX_FILE_PATCH_BYTES = 2 * 1024 * 1024;
+const MAX_REVIEW_PATCH_BYTES = 8 * 1024 * 1024;
+const MAX_RENDER_HUNKS = 500;
+const MAX_RENDER_LINES = 20_000;
+const HASH_CHUNK_BYTES = 1024 * 1024;
+
+type FinalDecision = Exclude<GitReviewDecision, "pending" | "mixed">;
+type StoredHunk = GitReviewHunk & { patch: string };
+type StoredFile = Omit<GitReviewFile, "hunks"> & {
+  hunks: StoredHunk[];
+  patch: string;
+  paths: string[];
+  fingerprints: Map<string, string>;
+};
+type StoredReview = {
+  id: string;
+  runId: number;
+  cwd: string;
+  repositoryRoot: string;
+  scope: string;
+  workspaceGeneration: number;
+  baseTree: string;
+  postTree?: string;
+  files?: StoredFile[];
+  createdAt: number;
+  activated: boolean;
+  sealed: boolean;
+  finished: boolean;
+  revision: number;
+  lock: Promise<void>;
+};
+
+declare global {
+  var __piGitReviews: Map<string, StoredReview> | undefined;
+  var __piGitReviewWorkspaceGenerations: Map<string, number> | undefined;
+}
+
+const reviews = globalThis.__piGitReviews ?? new Map<string, StoredReview>();
+const workspaceGenerations = globalThis.__piGitReviewWorkspaceGenerations ?? new Map<string, number>();
+globalThis.__piGitReviews = reviews;
+globalThis.__piGitReviewWorkspaceGenerations = workspaceGenerations;
+let registryLock: Promise<void> = Promise.resolve();
+
+async function serialized<T>(getLock: () => Promise<void>, setLock: (lock: Promise<void>) => void, operation: () => Promise<T>): Promise<T> {
+  const previous = getLock();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => { release = resolve; });
+  setLock(next);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+function withRegistryLock<T>(operation: () => Promise<T>): Promise<T> {
+  return serialized(() => registryLock, (lock) => { registryLock = lock; }, operation);
+}
+
+function withReviewLock<T>(review: StoredReview, operation: () => Promise<T>): Promise<T> {
+  return serialized(() => review.lock, (lock) => { review.lock = lock; }, operation);
+}
+
+function pruneReviews(): void {
+  const cutoff = Date.now() - REVIEW_TTL_MS;
+  for (const [id, review] of reviews) if (review.createdAt < cutoff) reviews.delete(id);
+  while (reviews.size >= MAX_REVIEWS) {
+    const ordered = [...reviews.values()].sort((a, b) => a.createdAt - b.createdAt);
+    const victim = ordered.find((review) => review.sealed) ?? ordered[0];
+    if (!victim) break;
+    victim.sealed = true;
+    reviews.delete(victim.id);
+  }
+}
+
+async function git(cwd: string, args: string[], options: { indexFile?: string; maxBuffer?: number } = {}): Promise<string> {
+  const env: NodeJS.ProcessEnv = { ...process.env, LC_ALL: "C" };
+  if (options.indexFile) env.GIT_INDEX_FILE = options.indexFile;
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: options.maxBuffer ?? GIT_MAX_BUFFER,
+    env,
+  });
+  return stdout;
+}
+
+async function repositoryRoot(cwd: string): Promise<string | null> {
+  try { return (await git(cwd, ["rev-parse", "--show-toplevel"])).trim() || null; }
+  catch { return null; }
+}
+
+function toGitPath(value: string): string { return value.split(path.sep).join("/"); }
+
+async function snapshotTree(root: string, scope: string): Promise<string> {
+  const indexFile = path.join(os.tmpdir(), `pi-web-review-${randomUUID()}.index`);
+  try {
+    await git(root, ["read-tree", "HEAD"], { indexFile });
+    await git(root, ["add", "-A", "--", scope], { indexFile });
+    return (await git(root, ["write-tree"], { indexFile })).trim();
+  } finally {
+    fs.rmSync(indexFile, { force: true });
+  }
+}
+
+function fingerprint(root: string, relativePath: string): string {
+  const absolutePath = path.resolve(root, relativePath);
+  try {
+    const stat = fs.lstatSync(absolutePath);
+    const hash = createHash("sha256");
+    hash.update(`${stat.isSymbolicLink() ? "symlink" : stat.isFile() ? "file" : "other"}\0${stat.mode}\0`);
+    if (stat.isSymbolicLink()) {
+      hash.update(fs.readlinkSync(absolutePath));
+    } else if (stat.isFile()) {
+      const descriptor = fs.openSync(absolutePath, "r");
+      const buffer = Buffer.allocUnsafe(HASH_CHUNK_BYTES);
+      try {
+        let bytesRead = 0;
+        do {
+          bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+          if (bytesRead > 0) hash.update(buffer.subarray(0, bytesRead));
+        } while (bytesRead > 0);
+      } finally {
+        fs.closeSync(descriptor);
+      }
+    } else {
+      hash.update(`${stat.size}:${stat.mtimeMs}`);
+    }
+    return hash.digest("hex");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+}
+
+export function splitGitReviewPatch(patch: string): { header: string; hunks: Array<{ header: string; patch: string; lines: string[] }> } {
+  const lines = patch.replace(/\n$/, "").split("\n");
+  const firstHunk = lines.findIndex((line) => line.startsWith("@@ "));
+  if (firstHunk === -1) return { header: `${lines.join("\n")}\n`, hunks: [] };
+  const fileHeader = lines.slice(0, firstHunk);
+  const starts: number[] = [];
+  for (let i = firstHunk; i < lines.length; i++) if (lines[i].startsWith("@@ ")) starts.push(i);
+  return {
+    header: `${fileHeader.join("\n")}\n`,
+    hunks: starts.map((start, index) => {
+      const hunkLines = lines.slice(start, starts[index + 1] ?? lines.length);
+      return { header: hunkLines[0], patch: `${[...fileHeader, ...hunkLines].join("\n")}\n`, lines: hunkLines.slice(1) };
+    }),
+  };
+}
+
+function parseNameStatus(output: string): Array<{ status: string; oldPath?: string; path: string }> {
+  const fields = output.split("\0").filter(Boolean);
+  const result: Array<{ status: string; oldPath?: string; path: string }> = [];
+  for (let i = 0; i < fields.length;) {
+    const status = fields[i++];
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const oldPath = fields[i++];
+      const nextPath = fields[i++];
+      if (oldPath && nextPath) result.push({ status, oldPath, path: nextPath });
+    } else {
+      const nextPath = fields[i++];
+      if (nextPath) result.push({ status, path: nextPath });
+    }
+  }
+  return result;
+}
+
+function statusKind(status: string): GitReviewFile["status"] {
+  if (status.startsWith("A")) return "added";
+  if (status.startsWith("D")) return "deleted";
+  if (status.startsWith("R")) return "renamed";
+  if (status.startsWith("C")) return "copied";
+  if (status.startsWith("T")) return "type-changed";
+  return "modified";
+}
+
+function aggregateDecision(hunks: StoredHunk[]): GitReviewDecision {
+  const decisions = new Set(hunks.map((hunk) => hunk.decision));
+  if (decisions.size === 1) return hunks[0]?.decision ?? "pending";
+  return "mixed";
+}
+
+function publicReview(review: StoredReview): GitReviewResponse {
+  return {
+    id: review.id,
+    runId: review.runId,
+    revision: review.revision,
+    repositoryRoot: review.repositoryRoot,
+    files: (review.files ?? []).map((file): GitReviewFile => ({
+      id: file.id, path: file.path, oldPath: file.oldPath, status: file.status,
+      decision: file.decision, actionable: file.actionable, granular: file.granular, reason: file.reason,
+      hunks: file.hunks.map((hunk): GitReviewHunk => ({
+        id: hunk.id, header: hunk.header, lines: hunk.lines, decision: hunk.decision,
+      })),
+    })),
+    sealed: review.sealed,
+    finished: review.finished,
+  };
+}
+
+function assertCurrent(review: StoredReview): void {
+  if (!review.activated) {
+    throw Object.assign(new Error("Review has not been attached to an accepted prompt"), { status: 409 });
+  }
+  if (review.sealed || workspaceGenerations.get(review.repositoryRoot) !== review.workspaceGeneration) {
+    review.sealed = true;
+    throw Object.assign(new Error("This review was sealed by a newer prompt"), { status: 409 });
+  }
+}
+
+function assertMutableReview(id: string, revision: number): StoredReview {
+  const review = reviews.get(id);
+  if (!review) throw Object.assign(new Error("Review expired or not found"), { status: 404 });
+  assertCurrent(review);
+  if (!review.finished || !review.files) throw Object.assign(new Error("Review is not ready"), { status: 409 });
+  if (review.revision !== revision) {
+    throw Object.assign(new Error("Review changed in another request; reload before deciding"), { status: 409 });
+  }
+  return review;
+}
+
+function verifyFingerprints(review: StoredReview, files: StoredFile[]): void {
+  for (const file of files) for (const relativePath of file.paths) {
+    if (file.fingerprints.get(relativePath) !== fingerprint(review.repositoryRoot, relativePath)) {
+      throw Object.assign(new Error(`File changed outside this review: ${relativePath}`), { status: 409 });
+    }
+  }
+}
+
+async function runGitApply(review: StoredReview, patchText: string, reverse: boolean, check: boolean): Promise<void> {
+  if (!patchText) return;
+  const patchFile = path.join(os.tmpdir(), `pi-web-review-${randomUUID()}.patch`);
+  const args = ["apply", "--whitespace=nowarn", "--recount"];
+  if (check) args.push("--check");
+  if (reverse) args.push("--reverse");
+  args.push(patchFile);
+  try {
+    fs.writeFileSync(patchFile, patchText);
+    await git(review.repositoryRoot, args);
+  } finally {
+    fs.rmSync(patchFile, { force: true });
+  }
+}
+
+function combinedPatch(entries: Array<{ file: StoredFile; patch: string }>): string {
+  const byFile = new Map<string, { file: StoredFile; patches: string[] }>();
+  for (const entry of entries) {
+    const group = byFile.get(entry.file.id) ?? { file: entry.file, patches: [] };
+    group.patches.push(entry.patch);
+    byFile.set(entry.file.id, group);
+  }
+  return [...byFile.values()].map(({ file, patches }) => {
+    if (!file.granular || patches.includes(file.patch)) return file.patch;
+    const header = splitGitReviewPatch(file.patch).header;
+    const bodies = patches.map((patchText) => patchText.slice(patchText.indexOf("@@ ")).trimEnd());
+    return `${header}${bodies.join("\n")}\n`;
+  }).join("");
+}
+
+async function applyTransaction(review: StoredReview, reversePatch: string, forwardPatch: string): Promise<void> {
+  const applied: Array<{ patch: string; reverse: boolean }> = [];
+  try {
+    for (const step of [{ patch: reversePatch, reverse: true }, { patch: forwardPatch, reverse: false }]) {
+      if (!step.patch) continue;
+      await runGitApply(review, step.patch, step.reverse, true);
+      await runGitApply(review, step.patch, step.reverse, false);
+      applied.push(step);
+    }
+  } catch {
+    let rollbackFailed = false;
+    for (const step of applied.reverse()) {
+      try {
+        await runGitApply(review, step.patch, !step.reverse, true);
+        await runGitApply(review, step.patch, !step.reverse, false);
+      } catch { rollbackFailed = true; }
+    }
+    if (rollbackFailed) {
+      review.sealed = true;
+      throw Object.assign(new Error("Review operation failed and could not be fully rolled back; inspect the working tree"), { status: 500 });
+    }
+    throw Object.assign(new Error("The requested decisions no longer apply cleanly; no review changes were kept"), { status: 409 });
+  }
+}
+
+function refreshFingerprints(review: StoredReview, files: StoredFile[]): void {
+  for (const file of files) for (const relativePath of file.paths) {
+    file.fingerprints.set(relativePath, fingerprint(review.repositoryRoot, relativePath));
+  }
+}
+
+export async function startGitReview(cwd: string, runId = 0, deferredActivation = false): Promise<{ supported: boolean; reviewId?: string; reason?: string }> {
+  const resolvedCwd = fs.realpathSync(cwd);
+  const root = await repositoryRoot(resolvedCwd);
+  if (!root) return { supported: false, reason: "Code review requires a Git repository" };
+  const relativeScope = toGitPath(path.relative(root, resolvedCwd)) || ".";
+  try {
+    return await withRegistryLock(async () => {
+      pruneReviews();
+      // Snapshot before the prompt can run, but defer claiming the workspace
+      // generation until RPC accepts that prompt. This prevents a losing
+      // request from another tab from sealing the review of the prompt that
+      // actually acquired the session.
+      const baseTree = await snapshotTree(root, relativeScope);
+      const id = randomUUID();
+      let workspaceGeneration = 0;
+      if (!deferredActivation) {
+        workspaceGeneration = (workspaceGenerations.get(root) ?? 0) + 1;
+        workspaceGenerations.set(root, workspaceGeneration);
+        for (const review of reviews.values()) if (review.repositoryRoot === root) review.sealed = true;
+      }
+      reviews.set(id, {
+        id, runId, cwd: resolvedCwd, repositoryRoot: root, scope: relativeScope, workspaceGeneration, baseTree,
+        createdAt: Date.now(), activated: !deferredActivation, sealed: false, finished: false, revision: 0, lock: Promise.resolve(),
+      });
+      return { supported: true, reviewId: id };
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : "";
+    return { supported: false, reason: `Unable to snapshot this repository (an initial commit is required)${detail}` };
+  }
+}
+
+export async function activateGitReview(id: string): Promise<void> {
+  const review = reviews.get(id);
+  if (!review) throw Object.assign(new Error("Review expired or not found"), { status: 404 });
+  await withRegistryLock(() => withReviewLock(review, async () => {
+    if (review.sealed) throw Object.assign(new Error("Review was cancelled before prompt acceptance"), { status: 409 });
+    if (review.activated) return;
+    const generation = (workspaceGenerations.get(review.repositoryRoot) ?? 0) + 1;
+    workspaceGenerations.set(review.repositoryRoot, generation);
+    for (const candidate of reviews.values()) {
+      if (candidate.id !== review.id && candidate.repositoryRoot === review.repositoryRoot) candidate.sealed = true;
+    }
+    review.workspaceGeneration = generation;
+    review.activated = true;
+  }));
+}
+
+export async function finishGitReview(id: string): Promise<GitReviewResponse> {
+  const review = reviews.get(id);
+  if (!review) throw Object.assign(new Error("Review expired or not found"), { status: 404 });
+  return withRegistryLock(() => withReviewLock(review, async () => {
+    assertCurrent(review);
+    if (review.finished) return publicReview(review);
+    const postTree = await snapshotTree(review.repositoryRoot, review.scope);
+    assertCurrent(review);
+    review.postTree = postTree;
+    const names = parseNameStatus(await git(review.repositoryRoot, [
+      "diff", "--name-status", "-z", "--find-renames", review.baseTree, postTree, "--", review.scope,
+    ]));
+    if (names.length > MAX_REVIEW_FILES) {
+      review.sealed = true;
+      throw Object.assign(new Error(`Review exceeds the ${MAX_REVIEW_FILES}-file limit`), { status: 413 });
+    }
+    const files: StoredFile[] = [];
+    let totalPatchBytes = 0;
+    for (const name of names) {
+      const paths = name.oldPath ? [name.oldPath, name.path] : [name.path];
+      let patch = "";
+      let oversized = false;
+      try {
+        patch = await git(review.repositoryRoot, [
+          "diff", "--binary", "--full-index", "--no-color", "--no-ext-diff", "--unified=3", "--find-renames",
+          review.baseTree, postTree, "--", ...paths,
+        ], { maxBuffer: MAX_FILE_PATCH_BYTES + 1 });
+      } catch { oversized = true; }
+      const patchBytes = Buffer.byteLength(patch);
+      if (patchBytes > MAX_FILE_PATCH_BYTES || totalPatchBytes + patchBytes > MAX_REVIEW_PATCH_BYTES) oversized = true;
+      if (!oversized) totalPatchBytes += patchBytes;
+      const parsed = splitGitReviewPatch(patch);
+      const kind = statusKind(name.status);
+      const binary = patch.includes("GIT binary patch") || patch.includes("Binary files ");
+      const specialMode = /\b(?:120000|160000)\b/.test(parsed.header);
+      const gitlink = /\b160000\b/.test(parsed.header);
+      const hasFileMetadata = kind !== "modified" || specialMode || /^(?:new file mode|deleted file mode|old mode|new mode|rename |copy )/m.test(parsed.header);
+      const renderLines = parsed.hunks.reduce((sum, hunk) => sum + hunk.lines.length, 0);
+      const renderOversized = parsed.hunks.length > MAX_RENDER_HUNKS || renderLines > MAX_RENDER_LINES;
+      const actionable = !oversized && !gitlink && patch.trim().length > 0;
+      const granular = actionable && !binary && !hasFileMetadata && !renderOversized && parsed.hunks.length > 0;
+      const reason = oversized ? "Change exceeds the safe review size limit"
+        : gitlink ? "Submodule changes must be reviewed outside this panel"
+        : !actionable ? "Git did not produce a safely applicable patch"
+        : renderOversized ? "Change is too large for block review and is available at file level"
+        : hasFileMetadata ? "File creation, deletion, rename, symlink, type, and mode changes are reviewed at file level"
+        : binary ? "Binary changes are reviewed at file level"
+        : parsed.hunks.length === 0 ? "This change is reviewed at file level" : undefined;
+      files.push({
+        id: randomUUID(), path: name.path, oldPath: name.oldPath, status: kind, decision: "pending",
+        actionable, granular, reason,
+        hunks: granular ? parsed.hunks.map((hunk, index): StoredHunk => ({
+          id: `${index}`, header: hunk.header, lines: hunk.lines, decision: "pending", patch: hunk.patch,
+        })) : [],
+        patch: actionable ? patch : "", paths,
+        fingerprints: new Map(paths.map((relativePath) => [relativePath, fingerprint(review.repositoryRoot, relativePath)])),
+      });
+    }
+    assertCurrent(review);
+    review.files = files;
+    review.finished = true;
+    return publicReview(review);
+  }));
+}
+
+export async function decideGitReview(
+  id: string,
+  input: { decision: GitReviewDecision; revision: number; fileId?: string; hunkId?: string; all?: boolean },
+): Promise<GitReviewResponse> {
+  const review = assertMutableReview(id, input.revision);
+  return withRegistryLock(() => withReviewLock(review, async () => {
+    assertMutableReview(id, input.revision);
+    if (input.decision !== "accepted" && input.decision !== "rejected") {
+      throw Object.assign(new Error("Invalid decision"), { status: 400 });
+    }
+    const decision = input.decision as FinalDecision;
+    const targets = input.all ? review.files!.filter((file) => file.actionable) : review.files!.filter((file) => file.id === input.fileId);
+    if (targets.length === 0) throw Object.assign(new Error("Review item not found"), { status: 404 });
+    verifyFingerprints(review, targets);
+
+    const items: Array<{ file: StoredFile; hunk?: StoredHunk; current: GitReviewDecision }> = [];
+    if (input.hunkId) {
+      const file = targets[0];
+      if (targets.length !== 1 || !file.granular) throw Object.assign(new Error("Hunk review is unavailable for this file"), { status: 400 });
+      const hunk = file.hunks.find((candidate) => candidate.id === input.hunkId);
+      if (!hunk) throw Object.assign(new Error("Hunk not found"), { status: 404 });
+      items.push({ file, hunk, current: hunk.decision });
+    } else {
+      for (const file of targets) {
+        if (file.granular) for (const hunk of file.hunks) items.push({ file, hunk, current: hunk.decision });
+        else items.push({ file, current: file.decision });
+      }
+    }
+
+    const reverseEntries = items.filter((item) => decision === "rejected" && item.current !== "rejected")
+      .map((item) => ({ file: item.file, patch: item.hunk?.patch ?? item.file.patch }));
+    const forwardEntries = items.filter((item) => decision === "accepted" && item.current === "rejected")
+      .map((item) => ({ file: item.file, patch: item.hunk?.patch ?? item.file.patch }));
+    await applyTransaction(review, combinedPatch(reverseEntries), combinedPatch(forwardEntries));
+
+    for (const item of items) {
+      if (item.hunk) item.hunk.decision = decision;
+      else item.file.decision = decision;
+    }
+    for (const file of targets) if (file.granular) file.decision = aggregateDecision(file.hunks);
+    refreshFingerprints(review, targets);
+    review.revision += 1;
+    return publicReview(review);
+  }));
+}
+
+export function getGitReview(id: string): GitReviewResponse {
+  const review = reviews.get(id);
+  if (!review) throw Object.assign(new Error("Review expired or not found"), { status: 404 });
+  return publicReview(review);
+}
+
+export function getGitReviewCwd(id: string): string {
+  const review = reviews.get(id);
+  if (!review) throw Object.assign(new Error("Review expired or not found"), { status: 404 });
+  return review.cwd;
+}
+
+export async function cancelGitReview(id: string): Promise<void> {
+  const review = reviews.get(id);
+  if (!review) return;
+  await withRegistryLock(() => withReviewLock(review, async () => { review.sealed = true; }));
+}
+
+export function resetGitReviewsForTests(): void {
+  reviews.clear();
+  workspaceGenerations.clear();
+  registryLock = Promise.resolve();
+}

--- a/lib/git-types.ts
+++ b/lib/git-types.ts
@@ -25,3 +25,35 @@ export interface GitFileDiffResponse {
   status?: GitFileStatusKind;
   patch?: string;
 }
+
+export type GitReviewDecision = "pending" | "accepted" | "rejected" | "mixed";
+export type GitReviewFileStatus = "modified" | "added" | "deleted" | "renamed" | "copied" | "type-changed";
+
+export interface GitReviewHunk {
+  id: string;
+  header: string;
+  lines: string[];
+  decision: GitReviewDecision;
+}
+
+export interface GitReviewFile {
+  id: string;
+  path: string;
+  oldPath?: string;
+  status: GitReviewFileStatus;
+  decision: GitReviewDecision;
+  actionable: boolean;
+  granular: boolean;
+  reason?: string;
+  hunks: GitReviewHunk[];
+}
+
+export interface GitReviewResponse {
+  id: string;
+  runId: number;
+  revision: number;
+  repositoryRoot: string;
+  files: GitReviewFile[];
+  sealed: boolean;
+  finished: boolean;
+}

--- a/lib/path-security.test.mjs
+++ b/lib/path-security.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+async function subject() { return import("./path-security.ts"); }
+
+test("canonical allow-list checks reject symlink escapes", async (t) => {
+  const { resolveAllowedDirectory } = await subject();
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-path-security-"));
+  t.after(() => fs.rmSync(base, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+  const allowed = path.join(base, "allowed");
+  const outside = path.join(base, "outside");
+  fs.mkdirSync(allowed);
+  fs.mkdirSync(outside);
+  fs.symlinkSync(outside, path.join(allowed, "escape"), "dir");
+
+  assert.equal(resolveAllowedDirectory(allowed, new Set([allowed])), fs.realpathSync(allowed));
+  assert.equal(resolveAllowedDirectory(path.join(allowed, "escape"), new Set([allowed])), null);
+});
+
+test("an explicitly allowed symlink root is canonicalized consistently", async (t) => {
+  const { resolveAllowedDirectory } = await subject();
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-path-security-root-"));
+  t.after(() => fs.rmSync(base, { recursive: true, force: true, maxRetries: 3, retryDelay: 20 }));
+  const target = path.join(base, "target");
+  const alias = path.join(base, "alias");
+  fs.mkdirSync(target);
+  fs.symlinkSync(target, alias, "dir");
+  assert.equal(resolveAllowedDirectory(alias, new Set([alias])), fs.realpathSync(target));
+});

--- a/lib/path-security.ts
+++ b/lib/path-security.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+function isWithin(target: string, root: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+export function resolveAllowedDirectory(target: string, allowedRoots: Set<string>): string | null {
+  let resolvedTarget: string;
+  try {
+    resolvedTarget = fs.realpathSync(target);
+    if (!fs.statSync(resolvedTarget).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const canonicalRoots = new Set<string>();
+  for (const root of allowedRoots) {
+    try {
+      canonicalRoots.add(fs.realpathSync(path.resolve(root)));
+    } catch {
+      // Stale session roots are ignored rather than weakening canonical checks.
+    }
+  }
+  return [...canonicalRoots].some((root) => isWithin(resolvedTarget, root)) ? resolvedTarget : null;
+}

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -11,6 +11,16 @@ test("RPC session startup preloads extension-registered providers before restori
   assert.doesNotMatch(startupSource, /await createAgentSession\(/);
 });
 
+test("prompt events are tagged with the browser run id and concurrent prompts are rejected", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  assert.match(source, /activePromptRunId/);
+  assert.match(source, /taggedEvent.*runId/s);
+  assert.match(source, /prompt_done", runId/);
+  assert.match(source, /activeRunId: this\.activePromptRunId/);
+  assert.match(source, /!streamingBehavior && \(this\.promptRunning \|\| this\.inner\.isStreaming/);
+  assert.match(source, /Cannot send a prompt while the session is busy/);
+});
+
 test("custom extension UI receives the fixed headless terminal facade", async () => {
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const customUiSource = source.slice(

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -113,6 +113,7 @@ export class AgentSessionWrapper {
   private extensionStatuses = new Map<string, string>();
   private extensionWidgets = new Map<string, ExtensionWidgetItem>();
   private promptRunning = false;
+  private activePromptRunId: number | null = null;
   private extensionsBound = false;
   private extensionBindingPromise: Promise<void> | null = null;
   private extensionBindingError: unknown = null;
@@ -146,7 +147,8 @@ export class AgentSessionWrapper {
       if (event.type === "agent_end") {
         invalidateSessionListCache();
       }
-      this.emit(event);
+      const taggedEvent = this.activePromptRunId === null ? event : { ...event, runId: this.activePromptRunId };
+      this.emit(taggedEvent);
       // Streaming / compaction / tool events flow through here; re-broadcast
       // the running-status snapshot so the sidebar can update live.
       notifyRunningChange();
@@ -308,12 +310,17 @@ export class AgentSessionWrapper {
 
     switch (type) {
       case "prompt": {
-        if (this.inner.isBashRunning) {
-          throw new Error("Cannot send a prompt while a shell command is running");
+        const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
+        if (!streamingBehavior && (this.promptRunning || this.inner.isStreaming || this.inner.isCompacting || this.inner.isBashRunning)) {
+          throw new Error("Cannot send a prompt while the session is busy");
         }
         // Fire and forget — events come via subscribe
         const promptImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
-        const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
+        const requestedRunId = command.runId;
+        if (!streamingBehavior && typeof requestedRunId === "number" && Number.isSafeInteger(requestedRunId)) {
+          this.activePromptRunId = requestedRunId;
+        }
+        const runId = this.activePromptRunId;
         this.promptRunning = true;
         notifyRunningChange();
         this.inner.prompt(command.message as string, {
@@ -322,16 +329,19 @@ export class AgentSessionWrapper {
           source: "rpc",
         }).then(() => {
           this.promptRunning = false;
-          if (!streamingBehavior) this.emit({ type: "prompt_done" });
+          if (!streamingBehavior) this.emit({ type: "prompt_done", runId });
+          if (!streamingBehavior && this.activePromptRunId === runId) this.activePromptRunId = null;
           notifyRunningChange();
         }).catch((error) => {
           this.promptRunning = false;
           invalidateSessionListCache();
           this.emit({
             type: "prompt_error",
+            runId,
             errorMessage: error instanceof Error ? error.message : String(error),
           });
-          if (!streamingBehavior) this.emit({ type: "prompt_done" });
+          if (!streamingBehavior) this.emit({ type: "prompt_done", runId });
+          if (!streamingBehavior && this.activePromptRunId === runId) this.activePromptRunId = null;
           notifyRunningChange();
         });
         return null;
@@ -347,6 +357,7 @@ export class AgentSessionWrapper {
         return {
           sessionId: this.inner.sessionId,
           sessionFile: this.inner.sessionFile ?? "",
+          activeRunId: this.activePromptRunId,
           isStreaming: this.inner.isStreaming,
           isPromptRunning: this.promptRunning,
           isBashRunning: this.inner.isBashRunning,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11859,6 +11859,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"


### PR DESCRIPTION
## Summary

- Capture Git working-tree changes made by each accepted agent prompt by snapshotting the selected repository scope before and after the run.
- Open a prompt-scoped Review panel when changes are detected, with file and hunk navigation plus Accept, Reject, Accept all, and Reject all actions.
- Apply review decisions transactionally with revision checks, file fingerprints, rollback, size limits, and safe file-level fallbacks for changes that cannot be reviewed by hunk.
- Bind review state to prompt run IDs so concurrent prompts and stale SSE events cannot attach changes to the wrong run.
- Re-authorize canonical allowed roots on every API operation and reject symlink escapes.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `node --test lib/*.test.mjs components/*.test.mjs` — 117 tests passed
- `git diff --check origin/main...HEAD`

## Notes

- Code review requires a Git repository with an initial commit.
- New, deleted, renamed, binary, mode-changing, and oversized files fall back to whole-file review when safe.
- `next build` was intentionally not run, following the repository development guidance.