### PR TITLE
fix(agent/new): use randomUUID for new-session lock key to prevent session collision

### DIFF
--- a/app/api/agent/new/route.ts
+++ b/app/api/agent/new/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
+import { randomUUID } from "crypto";
 import { allowFileRoot } from "@/lib/file-access";
 import { invalidateSessionListCache } from "@/lib/session-reader";
 import { startRpcSession } from "@/lib/rpc-manager";
@@ -19,10 +20,14 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: `Directory does not exist: ${cwd}` }, { status: 400 });
     }
 
-    // Use a one-time key so startRpcSession's lock doesn't conflict with real session ids
     const { provider, modelId, toolNames, thinkingLevel, ...promptCommand } = command as { provider?: string; modelId?: string; toolNames?: string[]; thinkingLevel?: string; [key: string]: unknown };
 
-    const tempKey = `__new__${Date.now()}`;
+    // Use a unique one-time key so startRpcSession's in-flight lock never
+    // coalesces two independent new-session requests. Date.now() has only
+    // millisecond resolution, so concurrent calls in the same millisecond
+    // would otherwise share one lock key and be merged into a single pi
+    // session (see issue #227). randomUUID() guarantees per-request isolation.
+    const tempKey = `__new__${randomUUID()}`;
     const { session, realSessionId } = await startRpcSession(tempKey, "", cwd, toolNames);
 
     // Keep the files-route allowed-roots cache (see app/api/files/[...path]/route.ts)


### PR DESCRIPTION
## Summary

`POST /api/agent/new` derived its de-duplication lock key from `Date.now()` alone, which has only millisecond resolution. `startRpcSession()` (`lib/rpc-manager.ts`) coalesces concurrent callers by that key via an in-flight lock, so two new-session requests arriving in the **same millisecond** received the same `AgentSessionWrapper` and the same `sessionId` — silently merging two independent chats into one pi session.

Fixes #227

## Root cause

`app/api/agent/new/route.ts`:
```ts
const tempKey = `__new__`;
```
Session creation takes tens to hundreds of ms, so the in-flight lock stays live well beyond 1 ms. Any second `POST /api/agent/new` computing the same `tempKey` gets the first request's in-flight promise, and therefore the same real session — a cross-conversation isolation failure the client cannot detect or recover from.

## Fix

Use `randomUUID()` for the key (already imported and used the same way throughout `lib/rpc-manager.ts`):
```ts
const tempKey = `__new__`;
```
A distinct key per request means the in-flight lock only ever coalesces retries of the *same* logical request, never two different ones. `__new__`/`tempKey` has exactly one call site in the repo, and nothing depends on the key being time-ordered or parseable, so there is no downstream impact.

## Testing

The repo has no test harness, so this was verified by inspection and the deterministic reproduction from the issue (two near-simultaneous `POST /api/agent/new` now return distinct `sessionId`s). The change is a drop-in of an existing, already-used pattern.
