### PR TITLE
feat: 为聊天消息和工具调用块添加角色头像

### DIFF
--- a/app/api/avatars/route.test.mjs
+++ b/app/api/avatars/route.test.mjs
@@ -114,6 +114,30 @@ test("GET rejects an absolute cwd outside allowed roots", async (t) => {
 
 // PUT tests ---
 
+test("PUT clears one role while preserving the other custom roles", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  await PUT(makePutRequest(cwd, {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  }));
+
+  const response = await PUT(makePutRequest(cwd, { user: null }));
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: null,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+  assert.deepEqual(readAvatarConfig(cwd), {
+    user: null,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+});
+
 test("PUT writes a complete three-role record to the project avatars.json", async (t) => {
   resetAllowedRoots();
   const cwd = createProject(t);

--- a/app/api/avatars/route.test.mjs
+++ b/app/api/avatars/route.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -8,9 +8,9 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url, {
   tsconfigPaths: true,
 });
-const { GET } = await jiti.import("./route.ts");
+const { GET, PUT } = await jiti.import("./route.ts");
 const { allowFileRoot } = await jiti.import("../../../lib/file-access.ts");
-const { getAvatarConfigPath } = await jiti.import(
+const { getAvatarConfigPath, readAvatarConfig } = await jiti.import(
   "../../../lib/avatar-config.server.ts",
 );
 
@@ -31,6 +31,20 @@ function resetAllowedRoots() {
     expiresAt: Date.now() + 60_000,
   };
 }
+
+function makePutRequest(cwd, body) {
+  return new Request("http://localhost/api/avatars", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cwd, ...body }),
+  });
+}
+
+const SAMPLE_USER = "data:image/png;base64,dXNlcg==";
+const SAMPLE_ASSISTANT = "data:image/jpeg;base64,YXNz";
+const SAMPLE_TOOL = "data:image/webp;base64,dG9vbA==";
+
+// GET tests ---
 
 test("GET returns a null-backed avatar config for an allowed project with no file", async (t) => {
   resetAllowedRoots();
@@ -56,7 +70,7 @@ test("GET reads valid keys from an allowed project avatar file", async (t) => {
   mkdirSync(join(cwd, ".pi"), { recursive: true });
   writeFileSync(
     getAvatarConfigPath(cwd),
-    JSON.stringify({ user: "data:image/png;base64,dXNlcg==" }),
+    JSON.stringify({ user: SAMPLE_USER }),
     "utf8",
   );
 
@@ -66,7 +80,7 @@ test("GET reads valid keys from an allowed project avatar file", async (t) => {
 
   assert.equal(response.status, 200);
   assert.deepEqual(await getJson(response), {
-    user: "data:image/png;base64,dXNlcg==",
+    user: SAMPLE_USER,
     assistant: null,
     tool: null,
   });
@@ -96,4 +110,174 @@ test("GET rejects an absolute cwd outside allowed roots", async (t) => {
 
   assert.equal(response.status, 403);
   assert.deepEqual(await getJson(response), { error: "Access denied" });
+});
+
+// PUT tests ---
+
+test("PUT writes a complete three-role record to the project avatars.json", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+
+  const response = await PUT(
+    makePutRequest(cwd, {
+      user: SAMPLE_USER,
+      assistant: SAMPLE_ASSISTANT,
+      tool: SAMPLE_TOOL,
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+  assert.deepEqual(readAvatarConfig(cwd), {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+  // Confirm the on-disk JSON is human-readable.
+  const onDisk = JSON.parse(readFileSync(getAvatarConfigPath(cwd), "utf8"));
+  assert.deepEqual(onDisk, {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+});
+
+test("PUT preserves existing role values for roles not in the body", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  writeFileSync(
+    getAvatarConfigPath(cwd),
+    JSON.stringify({
+      user: SAMPLE_USER,
+      assistant: SAMPLE_ASSISTANT,
+      tool: SAMPLE_TOOL,
+    }),
+    "utf8",
+  );
+
+  // Update only the assistant slot.
+  const response = await PUT(
+    makePutRequest(cwd, { assistant: SAMPLE_USER }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_USER,
+    tool: SAMPLE_TOOL,
+  });
+});
+
+test("PUT allows null to clear a role while preserving the others", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  writeFileSync(
+    getAvatarConfigPath(cwd),
+    JSON.stringify({
+      user: SAMPLE_USER,
+      assistant: SAMPLE_ASSISTANT,
+      tool: SAMPLE_TOOL,
+    }),
+    "utf8",
+  );
+
+  const response = await PUT(
+    makePutRequest(cwd, { assistant: null }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: SAMPLE_USER,
+    assistant: null,
+    tool: SAMPLE_TOOL,
+  });
+});
+
+test("PUT rejects an unsupported MIME with a 400 mentioning the role", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+
+  const response = await PUT(
+    makePutRequest(cwd, { user: "data:image/svg+xml;base64,PHN2Zy8+" }),
+  );
+
+  assert.equal(response.status, 400);
+  const body = await getJson(response);
+  assert.match(body.error, /user/);
+});
+
+test("PUT rejects a missing cwd", async () => {
+  const response = await PUT(
+    new Request("http://localhost/api/avatars", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user: SAMPLE_USER, assistant: null, tool: null }),
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await getJson(response), { error: "cwd is required" });
+});
+
+test("PUT rejects a cwd outside the allowed roots", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+
+  const response = await PUT(
+    makePutRequest(cwd, { user: SAMPLE_USER, assistant: null, tool: null }),
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await getJson(response), { error: "Access denied" });
+});
+
+test("PUT rejects non-JSON and non-object bodies with a 400", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+
+  const badJsonResponse = await PUT(
+    new Request("http://localhost/api/avatars", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    }),
+  );
+  assert.equal(badJsonResponse.status, 400);
+
+  const arrayResponse = await PUT(
+    new Request("http://localhost/api/avatars", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([SAMPLE_USER]),
+    }),
+  );
+  assert.equal(arrayResponse.status, 400);
+});
+
+test("PUT does not write the file when validation fails", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+
+  const response = await PUT(
+    makePutRequest(cwd, { user: "not-a-data-url", assistant: null, tool: null }),
+  );
+
+  assert.equal(response.status, 400);
+  // No avatar file should have been created.
+  assert.equal(
+    (await import("node:fs")).existsSync(getAvatarConfigPath(cwd)),
+    false,
+  );
 });

--- a/app/api/avatars/route.test.mjs
+++ b/app/api/avatars/route.test.mjs
@@ -305,3 +305,137 @@ test("PUT does not write the file when validation fails", async (t) => {
     false,
   );
 });
+
+// --- ticket #5: oversized payload, project isolation, saved-state untouched ---
+
+test("PUT rejects a role whose data URL exceeds the 2 MB encoded limit", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  const huge = "data:image/png;base64," + "A".repeat(3 * 1024 * 1024);
+
+  const response = await PUT(
+    makePutRequest(cwd, { user: huge, assistant: null, tool: null }),
+  );
+
+  assert.equal(response.status, 400);
+  const body = await getJson(response);
+  assert.match(body.error, /exceeds|2097152/);
+  // The on-disk file must not have been written.
+  assert.equal(
+    (await import("node:fs")).existsSync(getAvatarConfigPath(cwd)),
+    false,
+  );
+});
+
+test("PUT merges with existing valid roles and still rejects an oversized one", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  // Seed a valid user avatar via the same API.
+  await PUT(makePutRequest(cwd, {
+    user: SAMPLE_USER,
+    assistant: null,
+    tool: null,
+  }));
+
+  const huge = "data:image/png;base64," + "A".repeat(3 * 1024 * 1024);
+  const response = await PUT(
+    makePutRequest(cwd, { assistant: huge }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.match((await getJson(response)).error, /exceeds/);
+  // The previously saved user avatar must remain intact on disk.
+  assert.deepEqual(readAvatarConfig(cwd), {
+    user: SAMPLE_USER,
+    assistant: null,
+    tool: null,
+  });
+});
+
+test("Project A and Project B do not share avatar config", async (t) => {
+  resetAllowedRoots();
+  const projectA = createProject(t);
+  const projectB = createProject(t);
+  allowFileRoot(projectA);
+  allowFileRoot(projectB);
+
+  // Write a complete three-role config into project A.
+  const writeA = await PUT(
+    makePutRequest(projectA, {
+      user: SAMPLE_USER,
+      assistant: SAMPLE_ASSISTANT,
+      tool: SAMPLE_TOOL,
+    }),
+  );
+  assert.equal(writeA.status, 200);
+
+  // Project B must still read the default all-null record even though both
+  // roots are allowed.
+  const readB = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(projectB)}`),
+  );
+  assert.equal(readB.status, 200);
+  assert.deepEqual(await getJson(readB), {
+    user: null,
+    assistant: null,
+    tool: null,
+  });
+
+  // And project A must still see its own saved record.
+  const readA = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(projectA)}`),
+  );
+  assert.equal(readA.status, 200);
+  assert.deepEqual(await getJson(readA), {
+    user: SAMPLE_USER,
+    assistant: SAMPLE_ASSISTANT,
+    tool: SAMPLE_TOOL,
+  });
+
+  // The on-disk files must live under each project's own .pi directory.
+  const { existsSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  assert.equal(existsSync(getAvatarConfigPath(projectA)), true);
+  assert.equal(existsSync(getAvatarConfigPath(projectB)), false);
+  assert.equal(existsSync(join(projectB, ".pi")), false);
+});
+
+test("GET returns an explicit project cwd's avatars.json without leaking data from other roots", async (t) => {
+  resetAllowedRoots();
+  const projectA = createProject(t);
+  const projectB = createProject(t);
+  allowFileRoot(projectA);
+  allowFileRoot(projectB);
+  await PUT(makePutRequest(projectA, { user: SAMPLE_USER, assistant: null, tool: null }));
+
+  // Reading without a cwd still fails.
+  const noCwd = await GET(new Request("http://localhost/api/avatars"));
+  assert.equal(noCwd.status, 400);
+
+  // Reading with a cwd outside the allowed set still fails.
+  const outside = createProject(t);
+  const denied = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(outside)}`),
+  );
+  assert.equal(denied.status, 403);
+
+  // Reading with project A's cwd returns A's data; project B's cwd is empty.
+  const readA = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(projectA)}`),
+  );
+  const readB = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(projectB)}`),
+  );
+  assert.deepEqual(await getJson(readA), {
+    user: SAMPLE_USER,
+    assistant: null,
+    tool: null,
+  });
+  assert.deepEqual(await getJson(readB), {
+    user: null,
+    assistant: null,
+    tool: null,
+  });
+});

--- a/app/api/avatars/route.test.mjs
+++ b/app/api/avatars/route.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const { GET } = await jiti.import("./route.ts");
+const { allowFileRoot } = await jiti.import("../../../lib/file-access.ts");
+const { getAvatarConfigPath } = await jiti.import(
+  "../../../lib/avatar-config.server.ts",
+);
+
+function createProject(t) {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-web-avatar-route-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  return cwd;
+}
+
+async function getJson(response) {
+  return await response.json();
+}
+
+function resetAllowedRoots() {
+  globalThis.__piAdditionalAllowedRoots = new Set();
+  globalThis.__piAllowedRootsCache = {
+    roots: new Set(),
+    expiresAt: Date.now() + 60_000,
+  };
+}
+
+test("GET returns a null-backed avatar config for an allowed project with no file", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+
+  const response = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(cwd)}`),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: null,
+    assistant: null,
+    tool: null,
+  });
+});
+
+test("GET reads valid keys from an allowed project avatar file", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+  allowFileRoot(cwd);
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  writeFileSync(
+    getAvatarConfigPath(cwd),
+    JSON.stringify({ user: "data:image/png;base64,dXNlcg==" }),
+    "utf8",
+  );
+
+  const response = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(cwd)}`),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await getJson(response), {
+    user: "data:image/png;base64,dXNlcg==",
+    assistant: null,
+    tool: null,
+  });
+});
+
+test("GET rejects a missing cwd", async () => {
+  const response = await GET(new Request("http://localhost/api/avatars"));
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await getJson(response), { error: "cwd is required" });
+});
+
+test("GET rejects a relative cwd", async () => {
+  const response = await GET(new Request("http://localhost/api/avatars?cwd=relative"));
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await getJson(response), { error: "cwd must be an absolute path" });
+});
+
+test("GET rejects an absolute cwd outside allowed roots", async (t) => {
+  resetAllowedRoots();
+  const cwd = createProject(t);
+
+  const response = await GET(
+    new Request(`http://localhost/api/avatars?cwd=${encodeURIComponent(cwd)}`),
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await getJson(response), { error: "Access denied" });
+});

--- a/app/api/avatars/route.ts
+++ b/app/api/avatars/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { isAbsolute } from "path";
+import { readAvatarConfig } from "@/lib/avatar-config.server";
+import {
+  getAllowedFileRoots,
+  isFilePathAllowed,
+  isWindowsAbsolutePath,
+} from "@/lib/file-access";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/avatars?cwd=<absolute-project-path>
+// Reads only <cwd>/.pi/avatars.json and always returns a complete role record.
+export async function GET(req: Request) {
+  try {
+    const cwd = new URL(req.url).searchParams.get("cwd")?.trim() ?? "";
+    if (!cwd) {
+      return NextResponse.json({ error: "cwd is required" }, { status: 400 });
+    }
+    if (!isAbsolute(cwd) && !isWindowsAbsolutePath(cwd)) {
+      return NextResponse.json(
+        { error: "cwd must be an absolute path" },
+        { status: 400 },
+      );
+    }
+
+    const allowedRoots = await getAllowedFileRoots();
+    if (!isFilePathAllowed(cwd, allowedRoots)) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    return NextResponse.json(readAvatarConfig(cwd));
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/app/api/avatars/route.ts
+++ b/app/api/avatars/route.ts
@@ -1,35 +1,85 @@
 import { NextResponse } from "next/server";
 import { isAbsolute } from "path";
-import { readAvatarConfig } from "@/lib/avatar-config.server";
+import { readAvatarConfig, writeAvatarConfig } from "@/lib/avatar-config.server";
 import {
   getAllowedFileRoots,
   isFilePathAllowed,
   isWindowsAbsolutePath,
 } from "@/lib/file-access";
+import { validateAvatarConfigPayload } from "@/lib/avatar-config";
 
 export const dynamic = "force-dynamic";
+
+async function authorizeCwd(cwd: string): Promise<NextResponse | null> {
+  if (!cwd) {
+    return NextResponse.json({ error: "cwd is required" }, { status: 400 });
+  }
+  if (!isAbsolute(cwd) && !isWindowsAbsolutePath(cwd)) {
+    return NextResponse.json(
+      { error: "cwd must be an absolute path" },
+      { status: 400 },
+    );
+  }
+  const allowedRoots = await getAllowedFileRoots();
+  if (!isFilePathAllowed(cwd, allowedRoots)) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  return null;
+}
 
 // GET /api/avatars?cwd=<absolute-project-path>
 // Reads only <cwd>/.pi/avatars.json and always returns a complete role record.
 export async function GET(req: Request) {
   try {
     const cwd = new URL(req.url).searchParams.get("cwd")?.trim() ?? "";
-    if (!cwd) {
-      return NextResponse.json({ error: "cwd is required" }, { status: 400 });
-    }
-    if (!isAbsolute(cwd) && !isWindowsAbsolutePath(cwd)) {
+    const denied = await authorizeCwd(cwd);
+    if (denied) return denied;
+
+    return NextResponse.json(readAvatarConfig(cwd));
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}
+
+// PUT /api/avatars  body: { cwd, user, assistant, tool }
+// Writes a complete three-role avatar record to <cwd>/.pi/avatars.json. The
+// server validates each role value is a PNG/JPEG/WebP data URL; missing or
+// null roles clear that slot. Existing role values for roles not present in
+// the body are preserved by being merged with the on-disk record so callers
+// can edit one role without resending the others.
+export async function PUT(req: Request) {
+  try {
+    const raw = await req.json().catch(() => null) as unknown;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
       return NextResponse.json(
-        { error: "cwd must be an absolute path" },
+        { error: "request body must be a JSON object" },
         { status: 400 },
       );
     }
+    const body = raw as { cwd?: unknown; user?: unknown; assistant?: unknown; tool?: unknown };
+    const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
+    const denied = await authorizeCwd(cwd);
+    if (denied) return denied;
 
-    const allowedRoots = await getAllowedFileRoots();
-    if (!isFilePathAllowed(cwd, allowedRoots)) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    // Merge with the existing record so a caller editing one role doesn't
+    // have to re-send the other two. Validation runs on the merged result.
+    const existing = readAvatarConfig(cwd);
+    const merged = {
+      user: "user" in body ? body.user : existing.user,
+      assistant: "assistant" in body ? body.assistant : existing.assistant,
+      tool: "tool" in body ? body.tool : existing.tool,
+    };
+
+    let validated;
+    try {
+      validated = validateAvatarConfigPayload(merged);
+    } catch (validationError) {
+      const message = validationError instanceof Error ? validationError.message : String(validationError);
+      return NextResponse.json({ error: message }, { status: 400 });
     }
 
-    return NextResponse.json(readAvatarConfig(cwd));
+    writeAvatarConfig(cwd, validated);
+    return NextResponse.json(validated);
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
   }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { TabBar, type Tab } from "./TabBar";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
+import { AvatarsConfig } from "./AvatarsConfig";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -48,6 +49,7 @@ export function AppShell() {
   const [modelsRefreshKey, setModelsRefreshKey] = useState(0);
   const [skillsConfigOpen, setSkillsConfigOpen] = useState(false);
   const [pluginsConfigOpen, setPluginsConfigOpen] = useState(false);
+  const [avatarsConfigOpen, setAvatarsConfigOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);
   // On mobile the sidebar is an overlay drawer; hide it by default so the chat
@@ -412,6 +414,9 @@ export function AppShell() {
     );
   }, [selectedSession]);
 
+  const effectiveProjectCwd = activeCwd ?? selectedSession?.cwd ?? newSessionCwd;
+  const settingsButtonCount = effectiveProjectCwd ? 4 : 3;
+  const compactSettingsButtons = settingsButtonCount > 3;
   // Show chat area if a session is selected, or if we have a cwd to start a new session in
   const effectiveNewSessionCwd = newSessionCwd ?? (selectedSession === null && activeCwd ? activeCwd : null);
   const showChat = selectedSession !== null || effectiveNewSessionCwd !== null;
@@ -452,7 +457,7 @@ export function AppShell() {
         onAtMention={handleAtMention}
         onAtMentions={handleAtMentions}
       />
-      <div style={{ padding: "8px", flexShrink: 0, display: "flex", justifyContent: "space-between", gap: 4 }}>
+      <div style={{ padding: "8px", flexShrink: 0, display: "flex", justifyContent: "space-between", gap: compactSettingsButtons ? 2 : 4 }}>
         {([
           {
             label: "Models",
@@ -468,6 +473,18 @@ export function AppShell() {
               </svg>
             ),
           },
+          ...(effectiveProjectCwd ? [{
+            label: "Avatars",
+            onClick: () => setAvatarsConfigOpen(true),
+            disabled: false,
+            icon: (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="8" r="3" />
+                <path d="M5 21a7 7 0 0 1 14 0" />
+                <circle cx="12" cy="12" r="10" />
+              </svg>
+            ),
+          }] : []),
           {
             label: "Skills",
             onClick: () => setSkillsConfigOpen(true),
@@ -500,10 +517,10 @@ export function AppShell() {
             disabled={disabled}
             title={label}
             style={{
-              flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6,
+              flex: 1, minWidth: 0, display: "flex", alignItems: "center", justifyContent: "center", gap: compactSettingsButtons ? 3 : 6,
               height: 32, padding: 0, background: "none", border: "none",
               borderRadius: 9, color: "var(--text-muted)", cursor: disabled ? "default" : "pointer",
-              fontSize: 12, opacity: disabled ? 0.35 : 1,
+              fontSize: compactSettingsButtons ? 11 : 12, whiteSpace: "nowrap", opacity: disabled ? 0.35 : 1,
               transition: "background 0.12s, color 0.12s",
             }}
             onMouseEnter={(e) => { if (!disabled) { e.currentTarget.style.background = "var(--bg-hover)"; e.currentTarget.style.color = "var(--text)"; } }}
@@ -1274,12 +1291,15 @@ export function AppShell() {
       </svg>
     </button>
     {modelsConfigOpen && <ModelsConfig onClose={() => { setModelsConfigOpen(false); setModelsRefreshKey((k) => k + 1); }} />}
-    {skillsConfigOpen && (activeCwd ?? selectedSession?.cwd ?? newSessionCwd) && (
-      <SkillsConfig cwd={(activeCwd ?? selectedSession?.cwd ?? newSessionCwd)!} onClose={() => setSkillsConfigOpen(false)} />
+    {avatarsConfigOpen && effectiveProjectCwd && (
+      <AvatarsConfig cwd={effectiveProjectCwd} onClose={() => setAvatarsConfigOpen(false)} />
     )}
-    {pluginsConfigOpen && (activeCwd ?? selectedSession?.cwd ?? newSessionCwd) && (
+    {skillsConfigOpen && effectiveProjectCwd && (
+      <SkillsConfig cwd={effectiveProjectCwd} onClose={() => setSkillsConfigOpen(false)} />
+    )}
+    {pluginsConfigOpen && effectiveProjectCwd && (
       <PluginsConfig
-        cwd={(activeCwd ?? selectedSession?.cwd ?? newSessionCwd)!}
+        cwd={effectiveProjectCwd}
         sessionId={selectedSession?.id ?? null}
         onClose={() => setPluginsConfigOpen(false)}
         onReloaded={() => setSessionKey((k) => k + 1)}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -11,6 +11,7 @@ import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
 import { AvatarsConfig } from "./AvatarsConfig";
+import { AvatarConfigProvider } from "./AvatarConfigProvider";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -535,7 +536,7 @@ export function AppShell() {
   );
 
   return (
-    <>
+    <AvatarConfigProvider cwd={effectiveProjectCwd}>
     <style>{`
       @keyframes session-info-pop {
         0% {
@@ -1305,6 +1306,6 @@ export function AppShell() {
         onReloaded={() => setSessionKey((k) => k + 1)}
       />
     )}
-    </>
+    </AvatarConfigProvider>
   );
 }

--- a/components/Avatar.test.mjs
+++ b/components/Avatar.test.mjs
@@ -24,6 +24,8 @@ test("renders a blue U by default for the user role", () => {
   // default size for non-tool roles is 28
   assert.match(html, /width:28/);
   assert.match(html, /height:28/);
+  // default source marker
+  assert.match(html, /data-avatar-source="default"/);
 });
 
 test("renders a purple A by default for the assistant role", () => {
@@ -66,4 +68,31 @@ test("allows overriding the accessibility label", () => {
   const html = render({ role: "assistant", title: "Claude" });
   assert.match(html, /aria-label="Claude"/);
   assert.match(html, /title="Claude"/);
+});
+
+test("overlays a custom image source when src is provided", () => {
+  const src = "data:image/png;base64,abc";
+  const html = render({ role: "user", src });
+  // Source marker flips to custom.
+  assert.match(html, /data-avatar-source="custom"/);
+  // Underlying letter is still rendered (hidden via aria-hidden on the inner
+  // span) so screen readers fall back gracefully on broken images.
+  assert.match(html, />U</);
+  // The image overlay is rendered with the supplied src.
+  assert.match(html, new RegExp(`<img src="${src.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
+  assert.match(html, /border-radius:50%/);
+  // Image is positioned absolutely to cover the letter circle.
+  assert.match(html, /position:absolute/);
+});
+
+test("treats an empty-string src the same as no src", () => {
+  const html = render({ role: "user", src: "" });
+  assert.match(html, /data-avatar-source="default"/);
+  assert.doesNotMatch(html, /<img /);
+});
+
+test("treats a null src the same as no src", () => {
+  const html = render({ role: "user", src: null });
+  assert.match(html, /data-avatar-source="default"/);
+  assert.doesNotMatch(html, /<img /);
 });

--- a/components/Avatar.test.mjs
+++ b/components/Avatar.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { Avatar } = await jiti.import("./Avatar.tsx");
+
+function render(props) {
+  return renderToStaticMarkup(React.createElement(Avatar, props));
+}
+
+test("renders a blue U by default for the user role", () => {
+  const html = render({ role: "user" });
+  assert.match(html, /data-avatar-role="user"/);
+  assert.match(html, />U</);
+  // blue background and white foreground
+  assert.match(html, /background:#3b82f6/);
+  assert.match(html, /color:#ffffff/);
+  // default size for non-tool roles is 28
+  assert.match(html, /width:28/);
+  assert.match(html, /height:28/);
+});
+
+test("renders a purple A by default for the assistant role", () => {
+  const html = render({ role: "assistant" });
+  assert.match(html, /data-avatar-role="assistant"/);
+  assert.match(html, />A</);
+  assert.match(html, /background:#a855f7/);
+  assert.match(html, /width:28/);
+});
+
+test("renders a smaller gray T by default for the tool role", () => {
+  const html = render({ role: "tool" });
+  assert.match(html, /data-avatar-role="tool"/);
+  assert.match(html, />T</);
+  assert.match(html, /background:#9ca3af/);
+  // tool default is smaller than message avatars
+  assert.match(html, /width:16/);
+  assert.match(html, /height:16/);
+});
+
+test("respects an explicit size override", () => {
+  const html = render({ role: "tool", size: 22 });
+  assert.match(html, /width:22/);
+  assert.match(html, /height:22/);
+});
+
+test("uses a circular shape (border-radius 50%)", () => {
+  const html = render({ role: "assistant" });
+  assert.match(html, /border-radius:50%/);
+});
+
+test("sets an accessible role and label derived from the role key", () => {
+  const html = render({ role: "user" });
+  assert.match(html, /role="img"/);
+  assert.match(html, /aria-label="user avatar"/);
+  assert.match(html, /title="user avatar"/);
+});
+
+test("allows overriding the accessibility label", () => {
+  const html = render({ role: "assistant", title: "Claude" });
+  assert.match(html, /aria-label="Claude"/);
+  assert.match(html, /title="Claude"/);
+});

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -22,25 +22,32 @@ interface AvatarProps {
   size?: number;
   /** Override the accessibility label. Defaults to `"<role> avatar"`. */
   title?: string;
+  /** Custom data URL / image source. When provided, overlays the letter
+   *  avatar with the image and keeps the letter as a hidden fallback. */
+  src?: string | null;
 }
 
 /**
  * Shared avatar renderer used by chat messages and tool call block headers.
- * Renders the role-keyed default avatar; custom image support is added by
- * later tickets.
+ * Renders the role-keyed default avatar by default; a custom `src` overlays
+ * the same circular surface with the supplied image while preserving the
+ * default letter for screen readers and broken-image fallbacks.
  */
-export const Avatar = memo(function Avatar({ role, size, title }: AvatarProps) {
+export const Avatar = memo(function Avatar({ role, size, title, src }: AvatarProps) {
   const config = ROLE_DEFAULTS[role];
   const diameter = size ?? (role === "tool" ? 16 : 28);
   const fontSize = Math.max(9, Math.round(diameter * 0.45));
   const accessibleTitle = title ?? `${role} avatar`;
+  const hasCustomSrc = Boolean(src);
   return (
     <span
       role="img"
       aria-label={accessibleTitle}
       title={accessibleTitle}
       data-avatar-role={role}
+      data-avatar-source={hasCustomSrc ? "custom" : "default"}
       style={{
+        position: "relative",
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
@@ -58,9 +65,41 @@ export const Avatar = memo(function Avatar({ role, size, title }: AvatarProps) {
         userSelect: "none",
         fontFamily: "var(--font-mono)",
         verticalAlign: "middle",
+        overflow: "hidden",
       }}
     >
-      {config.letter}
+      <span
+        aria-hidden={hasCustomSrc ? true : undefined}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        {config.letter}
+      </span>
+      {hasCustomSrc && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src!}
+          alt=""
+          aria-hidden={true}
+          title={accessibleTitle}
+          onError={(event) => {
+            event.currentTarget.style.display = "none";
+          }}
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            borderRadius: "50%",
+            objectFit: "cover",
+          }}
+        />
+      )}
     </span>
   );
 });

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { memo } from "react";
+
+export type AvatarRole = "user" | "assistant" | "tool";
+
+interface RoleDefaults {
+  letter: string;
+  bg: string;
+  fg: string;
+}
+
+const ROLE_DEFAULTS: Record<AvatarRole, RoleDefaults> = {
+  user: { letter: "U", bg: "#3b82f6", fg: "#ffffff" },
+  assistant: { letter: "A", bg: "#a855f7", fg: "#ffffff" },
+  tool: { letter: "T", bg: "#9ca3af", fg: "#ffffff" },
+};
+
+interface AvatarProps {
+  role: AvatarRole;
+  /** Diameter in px. Defaults vary by role: user/assistant 28, tool 16. */
+  size?: number;
+  /** Override the accessibility label. Defaults to `"<role> avatar"`. */
+  title?: string;
+}
+
+/**
+ * Shared avatar renderer used by chat messages and tool call block headers.
+ * Renders the role-keyed default avatar; custom image support is added by
+ * later tickets.
+ */
+export const Avatar = memo(function Avatar({ role, size, title }: AvatarProps) {
+  const config = ROLE_DEFAULTS[role];
+  const diameter = size ?? (role === "tool" ? 16 : 28);
+  const fontSize = Math.max(9, Math.round(diameter * 0.45));
+  const accessibleTitle = title ?? `${role} avatar`;
+  return (
+    <span
+      role="img"
+      aria-label={accessibleTitle}
+      title={accessibleTitle}
+      data-avatar-role={role}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: diameter,
+        height: diameter,
+        minWidth: diameter,
+        minHeight: diameter,
+        borderRadius: "50%",
+        background: config.bg,
+        color: config.fg,
+        fontSize,
+        fontWeight: 600,
+        lineHeight: 1,
+        flexShrink: 0,
+        userSelect: "none",
+        fontFamily: "var(--font-mono)",
+        verticalAlign: "middle",
+      }}
+    >
+      {config.letter}
+    </span>
+  );
+});

--- a/components/AvatarConfigProvider.test.mjs
+++ b/components/AvatarConfigProvider.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { AvatarConfigProvider, useAvatarSrc } = await jiti.import(
+  "./AvatarConfigProvider.tsx",
+);
+
+function makeProbe(label) {
+  return function Probe() {
+    const value = useAvatarSrc("user");
+    return React.createElement(
+      "span",
+      { "data-probe": label, "data-value": value ?? "" },
+      label,
+    );
+  };
+}
+
+test("AvatarConfigProvider exposes a seeded initialConfig to descendants", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(
+      AvatarConfigProvider,
+      {
+        cwd: "/test/project",
+        initialConfig: {
+          user: "data:image/png;base64,Zm9v",
+          assistant: null,
+          tool: null,
+        },
+      },
+      React.createElement(makeProbe("user-avatar")),
+    ),
+  );
+  assert.match(html, /data-probe="user-avatar"/);
+  assert.match(html, /data-value="data:image\/png;base64,Zm9v"/);
+});
+
+test("AvatarConfigProvider normalizes non-string initial values to null", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(
+      AvatarConfigProvider,
+      {
+        cwd: "/test/project",
+        initialConfig: {
+          user: 42,
+          assistant: null,
+          tool: null,
+        },
+      },
+      React.createElement(makeProbe("user-avatar")),
+    ),
+  );
+  assert.match(html, /data-value=""/);
+});
+
+test("useAvatarSrc returns null when no provider is mounted", () => {
+  const html = renderToStaticMarkup(React.createElement(makeProbe("orphan")));
+  assert.match(html, /data-probe="orphan"/);
+  assert.match(html, /data-value=""/);
+});

--- a/components/AvatarConfigProvider.tsx
+++ b/components/AvatarConfigProvider.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  AVATAR_CONFIG_ROLES,
+  createEmptyAvatarConfig,
+  normalizeAvatarConfig,
+  type AvatarConfig,
+  type AvatarConfigRole,
+} from "@/lib/avatar-config";
+import { responseError } from "@/lib/response-error";
+
+/** Context shape exposed to descendants of `AvatarConfigProvider`. */
+interface AvatarConfigContextValue {
+  /** Current avatar record. Always a complete three-role record; missing or
+   *  failed loads resolve to all-null defaults. */
+  config: AvatarConfig;
+  /** True while the initial fetch for the active cwd is in flight. */
+  loading: boolean;
+  /** Last load error message, if any. Cleared on the next successful load. */
+  error: string | null;
+  /** Cwd the current `config` was loaded for. */
+  cwd: string | null;
+  /** Replace the in-memory config (used after a successful save). */
+  setConfig: (next: AvatarConfig) => void;
+}
+
+const AvatarConfigContext = createContext<AvatarConfigContextValue | null>(null);
+
+/**
+ * Loads `<cwd>/.pi/avatars.json` whenever the project cwd changes and
+ * exposes the current config to descendants. With no cwd, the record stays
+ * at all-null defaults and no fetch is issued.
+ */
+export function AvatarConfigProvider({
+  cwd,
+  initialConfig,
+  children,
+}: {
+  cwd: string | null;
+  /** Optional pre-seeded config. Useful for unit tests that want to render
+   *  MessageView with a custom avatar without making a network call. In the
+   *  app this is left undefined and the provider fetches from the API. */
+  initialConfig?: AvatarConfig;
+  children: ReactNode;
+}) {
+  const [config, setConfig] = useState<AvatarConfig>(() => {
+    if (initialConfig) {
+      const normalized = createEmptyAvatarConfig();
+      for (const role of AVATAR_CONFIG_ROLES) {
+        const value = initialConfig[role];
+        normalized[role] = typeof value === "string" ? value : null;
+      }
+      return normalized;
+    }
+    return createEmptyAvatarConfig();
+  });
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeCwd, setActiveCwd] = useState<string | null>(cwd);
+
+  useEffect(() => {
+    setActiveCwd(cwd);
+    if (!cwd) {
+      setConfig(createEmptyAvatarConfig());
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    setConfig(createEmptyAvatarConfig());
+    setLoading(true);
+    setError(null);
+    void fetch(`/api/avatars?cwd=${encodeURIComponent(cwd)}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const data = await response.json().catch(() => null) as unknown;
+        if (!response.ok) {
+          throw new Error(responseError(data) ?? `HTTP ${response.status}`);
+        }
+        setConfig(normalizeAvatarConfig(data));
+      })
+      .catch((loadError: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [cwd]);
+
+  const handleSetConfig = useCallback((next: AvatarConfig) => {
+    const normalized = createEmptyAvatarConfig();
+    for (const role of AVATAR_CONFIG_ROLES) {
+      normalized[role] = typeof next[role] === "string" ? next[role] : null;
+    }
+    setConfig(normalized);
+    setError(null);
+  }, []);
+
+  const value = useMemo<AvatarConfigContextValue>(
+    () => ({
+      config,
+      loading,
+      error,
+      cwd: activeCwd,
+      setConfig: handleSetConfig,
+    }),
+    [config, loading, error, activeCwd, handleSetConfig],
+  );
+
+  return (
+    <AvatarConfigContext.Provider value={value}>
+      {children}
+    </AvatarConfigContext.Provider>
+  );
+}
+
+export function useAvatarConfig(): AvatarConfigContextValue {
+  const value = useContext(AvatarConfigContext);
+  if (value) return value;
+  // Defensive default so consumers like MessageView keep rendering default
+  // avatars even if mounted outside a provider (isolated tests, pre-mount
+  // frames). When there is no provider, avatars stay all-null and we
+  // pretend the fetch completed successfully.
+  return DEFAULT_AVATAR_CONTEXT_VALUE;
+}
+
+const DEFAULT_AVATAR_CONTEXT_VALUE: AvatarConfigContextValue = {
+  config: {
+    user: null,
+    assistant: null,
+    tool: null,
+  },
+  loading: false,
+  error: null,
+  cwd: null,
+  setConfig: () => {},
+};
+
+export function useAvatarSrc(role: AvatarConfigRole): string | null {
+  const { config } = useAvatarConfig();
+  return config[role];
+}

--- a/components/AvatarsConfig.test.mjs
+++ b/components/AvatarsConfig.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { AvatarsConfig } = await jiti.import("./AvatarsConfig.tsx");
+
+function renderModal() {
+  return renderToStaticMarkup(
+    React.createElement(AvatarsConfig, {
+      cwd: "/work/example-project",
+      onClose() {},
+    }),
+  );
+}
+
+test("renders the Avatars modal with the explicit project config path", () => {
+  const html = renderModal();
+
+  assert.match(html, /data-avatars-settings-modal="true"/);
+  assert.match(html, />Avatars</);
+  assert.match(html, /\/work\/example-project\/\.pi\/avatars\.json/);
+  assert.match(html, /aria-label="Close avatars settings"/);
+});
+
+test("renders null-backed defaults for all three avatar roles", () => {
+  const html = renderModal();
+
+  for (const [role, letter] of [
+    ["user", "U"],
+    ["assistant", "A"],
+    ["tool", "T"],
+  ]) {
+    assert.match(html, new RegExp(`data-avatar-setting-role="${role}"`));
+    assert.match(html, new RegExp(`data-avatar-role="${role}"`));
+    assert.match(html, new RegExp(`>${letter}</span>`));
+  }
+  assert.equal((html.match(/data-avatar-source="default"/g) ?? []).length, 3);
+  assert.equal((html.match(/>Default<\/div>/g) ?? []).length, 3);
+});
+
+test("ticket 2 modal stays read-only", () => {
+  const html = renderModal();
+
+  assert.doesNotMatch(html, /type="file"/);
+  assert.doesNotMatch(html, />Save</);
+  assert.doesNotMatch(html, />Reset</);
+});

--- a/components/AvatarsConfig.test.mjs
+++ b/components/AvatarsConfig.test.mjs
@@ -9,13 +9,21 @@ const jiti = createJiti(import.meta.url, {
   tsconfigPaths: true,
 });
 const { AvatarsConfig } = await jiti.import("./AvatarsConfig.tsx");
+const { AvatarConfigProvider } = await jiti.import("./AvatarConfigProvider.tsx");
 
-function renderModal() {
+function renderModal(initialConfig = null) {
+  const modal = React.createElement(AvatarsConfig, {
+    cwd: "/work/example-project",
+    onClose() {},
+  });
+  if (!initialConfig) return renderToStaticMarkup(modal);
+  // `initialConfig` seeds context for SSR tests without running the provider's fetch effect.
   return renderToStaticMarkup(
-    React.createElement(AvatarsConfig, {
-      cwd: "/work/example-project",
-      onClose() {},
-    }),
+    React.createElement(
+      AvatarConfigProvider,
+      { cwd: "/work/example-project", initialConfig },
+      modal,
+    ),
   );
 }
 
@@ -71,9 +79,20 @@ test("exposes a disabled Save button until the user edits a role", () => {
   assert.match(saveButtonMatch[0], /disabled=""/);
 });
 
-test("does not yet expose ticket 4 reset controls", () => {
+test("reset controls are conditional on a saved custom avatar", () => {
   const html = renderModal();
-
   assert.doesNotMatch(html, /data-avatar-reset-button/);
-  assert.doesNotMatch(html, />Reset</);
+});
+
+test("renders reset controls for saved custom avatars", () => {
+  const html = renderModal({
+    user: "data:image/png;base64,dXNlcg==",
+    assistant: null,
+    tool: null,
+  });
+
+  assert.match(html, /data-avatar-reset-button="user"/);
+  assert.doesNotMatch(html, /data-avatar-reset-button="assistant"/);
+  assert.doesNotMatch(html, /data-avatar-reset-button="tool"/);
+  assert.match(html, /data-avatar-source="custom"/);
 });

--- a/components/AvatarsConfig.test.mjs
+++ b/components/AvatarsConfig.test.mjs
@@ -40,14 +40,40 @@ test("renders null-backed defaults for all three avatar roles", () => {
     assert.match(html, new RegExp(`data-avatar-role="${role}"`));
     assert.match(html, new RegExp(`>${letter}</span>`));
   }
-  assert.equal((html.match(/data-avatar-source="default"/g) ?? []).length, 3);
+  // Each role renders an AvatarPreview + a RoleAvatar; both expose the
+  // default source marker, so 3 roles produce 6 markers.
+  assert.equal((html.match(/data-avatar-source="default"/g) ?? []).length, 6);
   assert.equal((html.match(/>Default<\/div>/g) ?? []).length, 3);
 });
 
-test("ticket 2 modal stays read-only", () => {
+test("exposes a hidden file input and an Upload button for every role", () => {
   const html = renderModal();
 
-  assert.doesNotMatch(html, /type="file"/);
-  assert.doesNotMatch(html, />Save</);
+  for (const role of ["user", "assistant", "tool"]) {
+    assert.match(
+      html,
+      new RegExp(
+        `<input type="file" accept="image/png,image/jpeg,image/webp" data-avatar-upload-input="${role}"`,
+      ),
+    );
+    assert.match(
+      html,
+      new RegExp(`data-avatar-upload-button="${role}"`),
+    );
+  }
+});
+
+test("exposes a disabled Save button until the user edits a role", () => {
+  const html = renderModal();
+
+  const saveButtonMatch = html.match(/<button[^>]*data-avatars-settings-save="true"[^>]*>/);
+  assert.ok(saveButtonMatch, "Save button is rendered");
+  assert.match(saveButtonMatch[0], /disabled=""/);
+});
+
+test("does not yet expose ticket 4 reset controls", () => {
+  const html = renderModal();
+
+  assert.doesNotMatch(html, /data-avatar-reset-button/);
   assert.doesNotMatch(html, />Reset</);
 });

--- a/components/AvatarsConfig.tsx
+++ b/components/AvatarsConfig.tsx
@@ -12,6 +12,7 @@ import {
   AVATAR_IMAGE_MAX_SIZE,
   resizeAvatarDataUrl,
 } from "@/lib/avatar-image";
+import { processAvatarUpload } from "@/lib/avatar-upload";
 import { responseError } from "@/lib/response-error";
 import { useAvatarConfig } from "./AvatarConfigProvider";
 import { Avatar } from "./Avatar";
@@ -21,12 +22,6 @@ const ROLE_LABELS: Record<AvatarConfigRole, string> = {
   assistant: "Assistant",
   tool: "Tool",
 };
-
-const ACCEPTED_MIME_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/webp",
-] as const;
 
 function displayConfigPath(cwd: string): string {
   const shortened = cwd
@@ -51,9 +46,8 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-async function readFileAndResize(file: File): Promise<string> {
-  const dataUrl = await readFileAsDataUrl(file);
-  return await resizeAvatarDataUrl(dataUrl, AVATAR_IMAGE_MAX_SIZE);
+function resizeAvatar(dataUrl: string): Promise<string> {
+  return resizeAvatarDataUrl(dataUrl, AVATAR_IMAGE_MAX_SIZE);
 }
 
 function AvatarPreview({
@@ -164,7 +158,7 @@ function RoleCard({
       <input
         ref={fileInputRef}
         type="file"
-        accept={ACCEPTED_MIME_TYPES.join(",")}
+        accept="image/png,image/jpeg,image/webp"
         onChange={handleFileChange}
         data-avatar-upload-input={role}
         style={{ display: "none" }}
@@ -312,16 +306,29 @@ export function AvatarsConfig({
     return AVATAR_CONFIG_ROLES.some((role) => draftConfig[role] !== savedConfig[role]);
   }, [draftConfig, savedConfig]);
 
+  /**
+   * Validate and apply an uploaded avatar for a single role. The pure
+   * `processAvatarUpload` helper guarantees:
+   * - SVG / unsupported MIME files are rejected before the draft changes.
+   * - Undecodable images are rejected before the draft changes.
+   * - Encoded data URLs over the 2 MB limit are rejected before the draft
+   *   changes.
+   * On any rejection the draft (and therefore the saved config on disk)
+   * remain unchanged - only the per-role error string is updated.
+   */
   const handleUpload = async (role: AvatarConfigRole, file: File) => {
     setUploadingRole(role);
     setUploadErrors((prev) => ({ ...prev, [role]: null }));
     try {
-      const accepted = ACCEPTED_MIME_TYPES as readonly string[];
-      if (!accepted.includes(file.type)) {
-        throw new Error(`Unsupported file type: ${file.type || "unknown"}`);
+      const result = await processAvatarUpload(file, {
+        readDataUrl: readFileAsDataUrl,
+        resizeDataUrl: resizeAvatar,
+      });
+      if (!result.ok) {
+        setUploadErrors((prev) => ({ ...prev, [role]: result.reason }));
+        return;
       }
-      const dataUrl = await readFileAndResize(file);
-      setDraftConfig((prev) => ({ ...prev, [role]: dataUrl }));
+      setDraftConfig((prev) => ({ ...prev, [role]: result.dataUrl }));
     } catch (uploadError) {
       const message = uploadError instanceof Error ? uploadError.message : String(uploadError);
       setUploadErrors((prev) => ({ ...prev, [role]: message }));

--- a/components/AvatarsConfig.tsx
+++ b/components/AvatarsConfig.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   AVATAR_CONFIG_ROLES,
@@ -9,6 +9,12 @@ import {
   type AvatarConfig,
   type AvatarConfigRole,
 } from "@/lib/avatar-config";
+import {
+  AVATAR_IMAGE_MAX_SIZE,
+  resizeAvatarDataUrl,
+} from "@/lib/avatar-image";
+import { responseError } from "@/lib/response-error";
+import { useAvatarConfig } from "./AvatarConfigProvider";
 import { Avatar } from "./Avatar";
 
 const ROLE_LABELS: Record<AvatarConfigRole, string> = {
@@ -17,6 +23,12 @@ const ROLE_LABELS: Record<AvatarConfigRole, string> = {
   tool: "Tool",
 };
 
+const ACCEPTED_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
 function displayConfigPath(cwd: string): string {
   const shortened = cwd
     .replace(/^\/(?:Users|home)\/[^/]+/, "~")
@@ -24,10 +36,25 @@ function displayConfigPath(cwd: string): string {
   return `${shortened.replace(/[\\/]+$/, "")}/.pi/avatars.json`;
 }
 
-function responseError(value: unknown): string | null {
-  if (typeof value !== "object" || value === null) return null;
-  const error = (value as { error?: unknown }).error;
-  return typeof error === "string" ? error : null;
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("Could not read file as data URL"));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function readFileAndResize(file: File): Promise<string> {
+  const dataUrl = await readFileAsDataUrl(file);
+  return await resizeAvatarDataUrl(dataUrl, AVATAR_IMAGE_MAX_SIZE);
 }
 
 function AvatarPreview({
@@ -51,29 +78,159 @@ function AvatarPreview({
         flexShrink: 0,
       }}
     >
-      <span aria-hidden={hasCustomSource ? true : undefined}>
-        <Avatar role={role} size={72} title={`${label} avatar`} />
-      </span>
-      {hasCustomSource && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={source!}
-          alt={`${label} avatar`}
-          title={`${label} avatar`}
-          onError={(event) => {
-            event.currentTarget.style.display = "none";
-          }}
+      <Avatar role={role} size={72} title={`${label} avatar`} src={source} />
+    </div>
+  );
+}
+
+interface RoleCardProps {
+  role: AvatarConfigRole;
+  savedSource: string | null;
+  draftSource: string | null;
+  uploading: boolean;
+  uploadError: string | null;
+  onUpload: (file: File) => void;
+  onClearDraft: () => void;
+}
+
+function RoleCard({
+  role,
+  savedSource,
+  draftSource,
+  uploading,
+  uploadError,
+  onUpload,
+  onClearDraft,
+}: RoleCardProps) {
+  const label = ROLE_LABELS[role];
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const hasDraft = draftSource !== null && draftSource !== savedSource;
+  const hasSaved = Boolean(savedSource);
+  const source = draftSource ?? savedSource;
+  const hasCustomSource = Boolean(source);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset the input so re-picking the same file fires onChange again.
+    event.target.value = "";
+    if (!file) return;
+    onUpload(file);
+  };
+
+  const handlePickClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div
+      key={role}
+      data-avatar-setting-role={role}
+      data-avatar-dirty={hasDraft ? "true" : "false"}
+      style={{
+        minWidth: 0,
+        padding: "22px 16px",
+        border: "1px solid var(--border)",
+        borderRadius: 9,
+        background: "var(--bg-panel)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 10,
+      }}
+    >
+      <AvatarPreview role={role} source={source} />
+      <div
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: "var(--text)",
+        }}
+      >
+        {ROLE_LABELS[role]}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: hasCustomSource ? "var(--accent)" : "var(--text-dim)",
+        }}
+      >
+        {hasDraft
+          ? "Edited (unsaved)"
+          : hasSaved
+            ? "Custom"
+            : "Default"}
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_MIME_TYPES.join(",")}
+        onChange={handleFileChange}
+        data-avatar-upload-input={role}
+        style={{ display: "none" }}
+      />
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          marginTop: 4,
+        }}
+      >
+        <button
+          type="button"
+          onClick={handlePickClick}
+          disabled={uploading}
+          data-avatar-upload-button={role}
           style={{
-            position: "absolute",
-            inset: 0,
-            width: 72,
-            height: 72,
-            borderRadius: "50%",
-            objectFit: "cover",
-            background: "var(--bg-panel)",
+            padding: "5px 10px",
+            background: "var(--bg)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            color: "var(--text)",
+            cursor: uploading ? "wait" : "pointer",
+            fontSize: 12,
+            opacity: uploading ? 0.6 : 1,
           }}
-        />
+        >
+          {uploading ? "Processing..." : "Upload image"}
+        </button>
+        {hasDraft && (
+          <button
+            type="button"
+            onClick={onClearDraft}
+            disabled={uploading}
+            data-avatar-revert-button={role}
+            style={{
+              padding: "5px 10px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              color: "var(--text-muted)",
+              cursor: uploading ? "not-allowed" : "pointer",
+              fontSize: 12,
+            }}
+          >
+            Revert
+          </button>
+        )}
+      </div>
+      {uploadError && (
+        <div
+          role="alert"
+          data-avatar-upload-error={role}
+          style={{
+            fontSize: 11,
+            color: "#f87171",
+            textAlign: "center",
+            wordBreak: "break-word",
+          }}
+        >
+          {uploadError}
+        </div>
       )}
+      {/* Hidden label region used by tests to identify the role card. */}
+      <span data-avatar-role-label={role} style={{ display: "none" }}>
+        {label}
+      </span>
     </div>
   );
 }
@@ -86,15 +243,24 @@ export function AvatarsConfig({
   onClose: () => void;
 }) {
   const isMobile = useIsMobile();
-  const [config, setConfig] = useState<AvatarConfig>(() =>
-    createEmptyAvatarConfig(),
-  );
+  const { config: savedConfig, setConfig: setSavedConfig } = useAvatarConfig();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [draftConfig, setDraftConfig] = useState<AvatarConfig>(() =>
+    createEmptyAvatarConfig(),
+  );
+  const [uploadingRole, setUploadingRole] = useState<AvatarConfigRole | null>(null);
+  const [uploadErrors, setUploadErrors] = useState<Record<AvatarConfigRole, string | null>>({
+    user: null,
+    assistant: null,
+    tool: null,
+  });
+  const [saveState, setSaveState] = useState<
+    { kind: "idle" } | { kind: "saving" } | { kind: "saved" } | { kind: "error"; message: string }
+  >({ kind: "idle" });
 
   useEffect(() => {
     const controller = new AbortController();
-    setConfig(createEmptyAvatarConfig());
     setLoading(true);
     setError(null);
 
@@ -107,7 +273,9 @@ export function AvatarsConfig({
         if (!response.ok) {
           throw new Error(responseError(data) ?? `HTTP ${response.status}`);
         }
-        setConfig(normalizeAvatarConfig(data));
+        const normalized = normalizeAvatarConfig(data);
+        setSavedConfig(normalized);
+        setDraftConfig({ ...normalized });
       })
       .catch((loadError: unknown) => {
         if (controller.signal.aborted) return;
@@ -118,7 +286,65 @@ export function AvatarsConfig({
       });
 
     return () => controller.abort();
-  }, [cwd]);
+  }, [cwd, setSavedConfig]);
+
+  const hasDirtyChanges = useMemo(() => {
+    return AVATAR_CONFIG_ROLES.some((role) => draftConfig[role] !== savedConfig[role]);
+  }, [draftConfig, savedConfig]);
+
+  const handleUpload = async (role: AvatarConfigRole, file: File) => {
+    setUploadingRole(role);
+    setUploadErrors((prev) => ({ ...prev, [role]: null }));
+    try {
+      const accepted = ACCEPTED_MIME_TYPES as readonly string[];
+      if (!accepted.includes(file.type)) {
+        throw new Error(`Unsupported file type: ${file.type || "unknown"}`);
+      }
+      const dataUrl = await readFileAndResize(file);
+      setDraftConfig((prev) => ({ ...prev, [role]: dataUrl }));
+    } catch (uploadError) {
+      const message = uploadError instanceof Error ? uploadError.message : String(uploadError);
+      setUploadErrors((prev) => ({ ...prev, [role]: message }));
+    } finally {
+      setUploadingRole(null);
+    }
+  };
+
+  const handleClearDraft = (role: AvatarConfigRole) => {
+    setDraftConfig((prev) => ({ ...prev, [role]: savedConfig[role] }));
+    setUploadErrors((prev) => ({ ...prev, [role]: null }));
+  };
+
+  const handleSave = async () => {
+    setSaveState({ kind: "saving" });
+    try {
+      const response = await fetch("/api/avatars", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cwd, ...draftConfig }),
+      });
+      const data = await response.json().catch(() => null) as unknown;
+      if (!response.ok) {
+        throw new Error(responseError(data) ?? `HTTP ${response.status}`);
+      }
+      const normalized = normalizeAvatarConfig(data);
+      setSavedConfig(normalized);
+      setDraftConfig({ ...normalized });
+      setSaveState({ kind: "saved" });
+      setTimeout(() => {
+        setSaveState((current) => (current.kind === "saved" ? { kind: "idle" } : current));
+      }, 2000);
+    } catch (saveError) {
+      const message = saveError instanceof Error ? saveError.message : String(saveError);
+      setSaveState({ kind: "error", message });
+    }
+  };
+
+  const handleCancel = () => {
+    setDraftConfig({ ...savedConfig });
+    setUploadErrors({ user: null, assistant: null, tool: null });
+    setSaveState({ kind: "idle" });
+  };
 
   return (
     <div
@@ -143,7 +369,7 @@ export function AvatarsConfig({
         style={{
           width: isMobile ? "calc(100vw - 16px)" : 720,
           maxWidth: "calc(100vw - 16px)",
-          height: isMobile ? "calc(100dvh - 16px)" : 450,
+          height: isMobile ? "calc(100dvh - 16px)" : 540,
           maxHeight: "calc(100dvh - 16px)",
           background: "var(--bg)",
           border: "1px solid var(--border)",
@@ -225,6 +451,7 @@ export function AvatarsConfig({
         >
           <div
             aria-live="polite"
+            data-avatars-settings-status
             style={{
               minHeight: 20,
               marginBottom: 12,
@@ -232,7 +459,15 @@ export function AvatarsConfig({
               color: error ? "#f87171" : "var(--text-muted)",
             }}
           >
-            {loading ? "Loading..." : error ? `Could not load avatars: ${error}` : ""}
+            {loading
+              ? "Loading..."
+              : error
+                ? `Could not load avatars: ${error}`
+                : saveState.kind === "saved"
+                  ? "Saved."
+                  : saveState.kind === "error"
+                    ? `Could not save: ${saveState.message}`
+                    : ""}
           </div>
 
           <div
@@ -244,40 +479,18 @@ export function AvatarsConfig({
               gap: 14,
             }}
           >
-            {AVATAR_CONFIG_ROLES.map((role) => {
-              const source = config[role];
-              return (
-                <div
-                  key={role}
-                  data-avatar-setting-role={role}
-                  style={{
-                    minWidth: 0,
-                    padding: "22px 16px",
-                    border: "1px solid var(--border)",
-                    borderRadius: 9,
-                    background: "var(--bg-panel)",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: 10,
-                  }}
-                >
-                  <AvatarPreview role={role} source={source} />
-                  <div
-                    style={{
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: "var(--text)",
-                    }}
-                  >
-                    {ROLE_LABELS[role]}
-                  </div>
-                  <div style={{ fontSize: 11, color: "var(--text-dim)" }}>
-                    {source ? "Custom" : "Default"}
-                  </div>
-                </div>
-              );
-            })}
+            {AVATAR_CONFIG_ROLES.map((role) => (
+              <RoleCard
+                key={role}
+                role={role}
+                savedSource={savedConfig[role]}
+                draftSource={draftConfig[role]}
+                uploading={uploadingRole === role}
+                uploadError={uploadErrors[role]}
+                onUpload={(file) => void handleUpload(role, file)}
+                onClearDraft={() => handleClearDraft(role)}
+              />
+            ))}
           </div>
         </div>
 
@@ -285,27 +498,54 @@ export function AvatarsConfig({
           style={{
             display: "flex",
             alignItems: "center",
-            justifyContent: "flex-end",
+            justifyContent: "space-between",
+            gap: 8,
             padding: "10px 18px",
             borderTop: "1px solid var(--border)",
             flexShrink: 0,
           }}
         >
-          <button
-            type="button"
-            onClick={onClose}
-            style={{
-              padding: "6px 14px",
-              background: "none",
-              border: "1px solid var(--border)",
-              borderRadius: 6,
-              color: "var(--text-muted)",
-              cursor: "pointer",
-              fontSize: 13,
-            }}
-          >
-            Close
-          </button>
+          <div style={{ fontSize: 11, color: "var(--text-dim)" }}>
+            PNG, JPEG, or WebP. Images are resized before saving.
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={!hasDirtyChanges || saveState.kind === "saving"}
+              data-avatars-settings-cancel
+              style={{
+                padding: "6px 14px",
+                background: "none",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                color: "var(--text-muted)",
+                cursor: hasDirtyChanges ? "pointer" : "default",
+                fontSize: 13,
+                opacity: hasDirtyChanges ? 1 : 0.45,
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!hasDirtyChanges || saveState.kind === "saving"}
+              data-avatars-settings-save
+              style={{
+                padding: "6px 14px",
+                background: "var(--accent)",
+                border: "1px solid var(--accent)",
+                borderRadius: 6,
+                color: "#ffffff",
+                cursor: hasDirtyChanges ? "pointer" : "default",
+                fontSize: 13,
+                opacity: hasDirtyChanges ? 1 : 0.45,
+              }}
+            >
+              {saveState.kind === "saving" ? "Saving..." : "Save"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/components/AvatarsConfig.tsx
+++ b/components/AvatarsConfig.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   AVATAR_CONFIG_ROLES,
-  createEmptyAvatarConfig,
   normalizeAvatarConfig,
   type AvatarConfig,
   type AvatarConfigRole,
@@ -91,6 +90,7 @@ interface RoleCardProps {
   uploadError: string | null;
   onUpload: (file: File) => void;
   onClearDraft: () => void;
+  onReset: () => void;
 }
 
 function RoleCard({
@@ -101,12 +101,13 @@ function RoleCard({
   uploadError,
   onUpload,
   onClearDraft,
+  onReset,
 }: RoleCardProps) {
   const label = ROLE_LABELS[role];
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const hasDraft = draftSource !== null && draftSource !== savedSource;
+  const hasDraft = draftSource !== savedSource;
   const hasSaved = Boolean(savedSource);
-  const source = draftSource ?? savedSource;
+  const source = draftSource;
   const hasCustomSource = Boolean(source);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -212,6 +213,25 @@ function RoleCard({
             Revert
           </button>
         )}
+        {hasSaved && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={uploading}
+            data-avatar-reset-button={role}
+            style={{
+              padding: "5px 10px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              color: "var(--text-muted)",
+              cursor: uploading ? "not-allowed" : "pointer",
+              fontSize: 12,
+            }}
+          >
+            Reset
+          </button>
+        )}
       </div>
       {uploadError && (
         <div
@@ -246,9 +266,9 @@ export function AvatarsConfig({
   const { config: savedConfig, setConfig: setSavedConfig } = useAvatarConfig();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [draftConfig, setDraftConfig] = useState<AvatarConfig>(() =>
-    createEmptyAvatarConfig(),
-  );
+  const [draftConfig, setDraftConfig] = useState<AvatarConfig>(() => ({
+    ...savedConfig,
+  }));
   const [uploadingRole, setUploadingRole] = useState<AvatarConfigRole | null>(null);
   const [uploadErrors, setUploadErrors] = useState<Record<AvatarConfigRole, string | null>>({
     user: null,
@@ -312,6 +332,11 @@ export function AvatarsConfig({
 
   const handleClearDraft = (role: AvatarConfigRole) => {
     setDraftConfig((prev) => ({ ...prev, [role]: savedConfig[role] }));
+    setUploadErrors((prev) => ({ ...prev, [role]: null }));
+  };
+
+  const handleReset = (role: AvatarConfigRole) => {
+    setDraftConfig((prev) => ({ ...prev, [role]: null }));
     setUploadErrors((prev) => ({ ...prev, [role]: null }));
   };
 
@@ -489,6 +514,7 @@ export function AvatarsConfig({
                 uploadError={uploadErrors[role]}
                 onUpload={(file) => void handleUpload(role, file)}
                 onClearDraft={() => handleClearDraft(role)}
+                onReset={() => handleReset(role)}
               />
             ))}
           </div>

--- a/components/AvatarsConfig.tsx
+++ b/components/AvatarsConfig.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import {
+  AVATAR_CONFIG_ROLES,
+  createEmptyAvatarConfig,
+  normalizeAvatarConfig,
+  type AvatarConfig,
+  type AvatarConfigRole,
+} from "@/lib/avatar-config";
+import { Avatar } from "./Avatar";
+
+const ROLE_LABELS: Record<AvatarConfigRole, string> = {
+  user: "User",
+  assistant: "Assistant",
+  tool: "Tool",
+};
+
+function displayConfigPath(cwd: string): string {
+  const shortened = cwd
+    .replace(/^\/(?:Users|home)\/[^/]+/, "~")
+    .replace(/^[A-Za-z]:[\\/]Users[\\/][^\\/]+/, "~");
+  return `${shortened.replace(/[\\/]+$/, "")}/.pi/avatars.json`;
+}
+
+function responseError(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const error = (value as { error?: unknown }).error;
+  return typeof error === "string" ? error : null;
+}
+
+function AvatarPreview({
+  role,
+  source,
+}: {
+  role: AvatarConfigRole;
+  source: string | null;
+}) {
+  const label = ROLE_LABELS[role];
+  const hasCustomSource = Boolean(source);
+
+  return (
+    <div
+      data-avatar-preview-role={role}
+      data-avatar-source={hasCustomSource ? "custom" : "default"}
+      style={{
+        position: "relative",
+        width: 72,
+        height: 72,
+        flexShrink: 0,
+      }}
+    >
+      <span aria-hidden={hasCustomSource ? true : undefined}>
+        <Avatar role={role} size={72} title={`${label} avatar`} />
+      </span>
+      {hasCustomSource && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={source!}
+          alt={`${label} avatar`}
+          title={`${label} avatar`}
+          onError={(event) => {
+            event.currentTarget.style.display = "none";
+          }}
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: 72,
+            height: 72,
+            borderRadius: "50%",
+            objectFit: "cover",
+            background: "var(--bg-panel)",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function AvatarsConfig({
+  cwd,
+  onClose,
+}: {
+  cwd: string;
+  onClose: () => void;
+}) {
+  const isMobile = useIsMobile();
+  const [config, setConfig] = useState<AvatarConfig>(() =>
+    createEmptyAvatarConfig(),
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setConfig(createEmptyAvatarConfig());
+    setLoading(true);
+    setError(null);
+
+    void fetch(`/api/avatars?cwd=${encodeURIComponent(cwd)}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const data = await response.json().catch(() => null) as unknown;
+        if (!response.ok) {
+          throw new Error(responseError(data) ?? `HTTP ${response.status}`);
+        }
+        setConfig(normalizeAvatarConfig(data));
+      })
+      .catch((loadError: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [cwd]);
+
+  return (
+    <div
+      data-avatars-settings-modal
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="avatars-settings-title"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: isMobile ? "calc(100vw - 16px)" : 720,
+          maxWidth: "calc(100vw - 16px)",
+          height: isMobile ? "calc(100dvh - 16px)" : 450,
+          maxHeight: "calc(100dvh - 16px)",
+          background: "var(--bg)",
+          border: "1px solid var(--border)",
+          borderRadius: 10,
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            padding: "12px 18px",
+            borderBottom: "1px solid var(--border)",
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 10,
+              minWidth: 0,
+            }}
+          >
+            <span
+              id="avatars-settings-title"
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--text)",
+                flexShrink: 0,
+              }}
+            >
+              Avatars
+            </span>
+            <code
+              title={displayConfigPath(cwd)}
+              style={{
+                fontSize: 11,
+                color: "var(--text-muted)",
+                fontFamily: "var(--font-mono)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {displayConfigPath(cwd)}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close avatars settings"
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              fontSize: 20,
+              lineHeight: 1,
+              padding: "2px 6px",
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            overflowY: "auto",
+            padding: isMobile ? 16 : 24,
+          }}
+        >
+          <div
+            aria-live="polite"
+            style={{
+              minHeight: 20,
+              marginBottom: 12,
+              fontSize: 12,
+              color: error ? "#f87171" : "var(--text-muted)",
+            }}
+          >
+            {loading ? "Loading..." : error ? `Could not load avatars: ${error}` : ""}
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: isMobile
+                ? "1fr"
+                : "repeat(3, minmax(0, 1fr))",
+              gap: 14,
+            }}
+          >
+            {AVATAR_CONFIG_ROLES.map((role) => {
+              const source = config[role];
+              return (
+                <div
+                  key={role}
+                  data-avatar-setting-role={role}
+                  style={{
+                    minWidth: 0,
+                    padding: "22px 16px",
+                    border: "1px solid var(--border)",
+                    borderRadius: 9,
+                    background: "var(--bg-panel)",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 10,
+                  }}
+                >
+                  <AvatarPreview role={role} source={source} />
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: "var(--text)",
+                    }}
+                  >
+                    {ROLE_LABELS[role]}
+                  </div>
+                  <div style={{ fontSize: 11, color: "var(--text-dim)" }}>
+                    {source ? "Custom" : "Default"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            padding: "10px 18px",
+            borderTop: "1px solid var(--border)",
+            flexShrink: 0,
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: "6px 14px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MessageView.avatars.test.mjs
+++ b/components/MessageView.avatars.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { MessageView } = await jiti.import("./MessageView.tsx");
+
+function renderMessage(props) {
+  return renderToStaticMarkup(React.createElement(MessageView, props));
+}
+
+test("user messages render a blue U avatar beside the bubble", () => {
+  const html = renderMessage({
+    message: {
+      role: "user",
+      content: "",
+      timestamp: Date.UTC(2025, 0, 1, 12, 0, 0),
+    },
+  });
+  assert.match(html, /data-avatar-role="user"/);
+  assert.match(html, />U</);
+  assert.match(html, /background:#3b82f6/);
+});
+
+test("assistant messages render a purple A avatar beside the content", () => {
+  const html = renderMessage({
+    message: {
+      role: "assistant",
+      provider: "test",
+      model: "test-model",
+      content: [{ type: "text", text: "Hello there." }],
+      timestamp: Date.UTC(2025, 0, 1, 12, 0, 1),
+    },
+  });
+  assert.match(html, /data-avatar-role="assistant"/);
+  assert.match(html, />A</);
+  assert.match(html, /background:#a855f7/);
+});
+
+test("assistant tool call blocks render a small gray T avatar in the header", () => {
+  const html = renderMessage({
+    message: {
+      role: "assistant",
+      provider: "test",
+      model: "test-model",
+      content: [
+        {
+          type: "toolCall",
+          toolCallId: "call-1",
+          toolName: "bash",
+          input: { command: "ls -la" },
+        },
+      ],
+      timestamp: Date.UTC(2025, 0, 1, 12, 0, 2),
+    },
+  });
+  assert.match(html, /data-avatar-role="tool"/);
+  assert.match(html, />T</);
+  assert.match(html, /background:#9ca3af/);
+  // The tool avatar must use the smaller default size, not the message size.
+  assert.match(html, /data-avatar-role="tool"[^>]*style="[^"]*width:16/);
+});
+
+test("toolResult messages do not render standalone avatar rows", () => {
+  const html = renderMessage({
+    message: {
+      role: "toolResult",
+      toolCallId: "call-1",
+      content: [{ type: "text", text: "ok" }],
+    },
+  });
+  // Paired toolResults return null; no avatar markup should leak through.
+  assert.doesNotMatch(html, /data-avatar-role/);
+});
+
+test("bashExecution messages reuse ToolCallBlock and pick up the tool avatar", () => {
+  const html = renderMessage({
+    message: {
+      role: "bashExecution",
+      command: "echo hi",
+      output: "hi\n",
+      exitCode: 0,
+      timestamp: Date.UTC(2025, 0, 1, 12, 0, 3),
+    },
+    sessionId: "session-1",
+  });
+  assert.match(html, /data-avatar-role="tool"/);
+  assert.match(html, />T</);
+});

--- a/components/MessageView.avatars.test.mjs
+++ b/components/MessageView.avatars.test.mjs
@@ -9,9 +9,24 @@ const jiti = createJiti(import.meta.url, {
   tsconfigPaths: true,
 });
 const { MessageView } = await jiti.import("./MessageView.tsx");
+const { AvatarConfigProvider } = await jiti.import("./AvatarConfigProvider.tsx");
 
-function renderMessage(props) {
-  return renderToStaticMarkup(React.createElement(MessageView, props));
+const USER_AVATAR = "data:image/png;base64,dXNlcg==";
+const ASSISTANT_AVATAR = "data:image/jpeg;base64,YXNz";
+const TOOL_AVATAR = "data:image/webp;base64,dG9vbA==";
+
+function renderMessage(props, customConfig) {
+  const content = React.createElement(MessageView, props);
+  if (customConfig) {
+    return renderToStaticMarkup(
+      React.createElement(
+        AvatarConfigProvider,
+        { cwd: "/test/project", initialConfig: customConfig },
+        content,
+      ),
+    );
+  }
+  return renderToStaticMarkup(content);
 }
 
 test("user messages render a blue U avatar beside the bubble", () => {
@@ -91,4 +106,101 @@ test("bashExecution messages reuse ToolCallBlock and pick up the tool avatar", (
   });
   assert.match(html, /data-avatar-role="tool"/);
   assert.match(html, />T</);
+});
+
+test("custom user avatar appears beside a user message when the provider has a value", () => {
+  const html = renderMessage(
+    {
+      message: {
+        role: "user",
+        content: "",
+        timestamp: Date.UTC(2025, 0, 1, 12, 0, 0),
+      },
+    },
+    { user: USER_AVATAR, assistant: null, tool: null },
+  );
+  // The custom marker is present.
+  assert.match(html, /data-avatar-source="custom"/);
+  // The custom image src is rendered.
+  assert.match(
+    html,
+    new RegExp(`<img[^>]+src="${USER_AVATAR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`),
+  );
+  // The letter is still rendered as a hidden fallback.
+  assert.match(html, />U</);
+});
+
+test("custom assistant avatar appears beside an assistant message when the provider has a value", () => {
+  const html = renderMessage(
+    {
+      message: {
+        role: "assistant",
+        provider: "test",
+        model: "test-model",
+        content: [{ type: "text", text: "Hello there." }],
+        timestamp: Date.UTC(2025, 0, 1, 12, 0, 1),
+      },
+    },
+    { user: null, assistant: ASSISTANT_AVATAR, tool: null },
+  );
+  assert.match(html, /data-avatar-source="custom"/);
+  assert.match(
+    html,
+    new RegExp(`<img[^>]+src="${ASSISTANT_AVATAR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`),
+  );
+});
+
+test("custom tool avatar appears in assistant tool call block headers", () => {
+  const html = renderMessage(
+    {
+      message: {
+        role: "assistant",
+        provider: "test",
+        model: "test-model",
+        content: [
+          {
+            type: "toolCall",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { command: "ls -la" },
+          },
+        ],
+        timestamp: Date.UTC(2025, 0, 1, 12, 0, 2),
+      },
+    },
+    { user: null, assistant: null, tool: TOOL_AVATAR },
+  );
+  assert.match(html, /data-avatar-source="custom"/);
+  assert.match(
+    html,
+    new RegExp(`<img[^>]+src="${TOOL_AVATAR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`),
+  );
+});
+
+test("custom avatars for one role do not affect other roles", () => {
+  const html = renderMessage(
+    {
+      message: {
+        role: "assistant",
+        provider: "test",
+        model: "test-model",
+        content: [
+          {
+            type: "toolCall",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { command: "ls -la" },
+          },
+        ],
+        timestamp: Date.UTC(2025, 0, 1, 12, 0, 2),
+      },
+    },
+    { user: USER_AVATAR, assistant: ASSISTANT_AVATAR, tool: null },
+  );
+  // Both user (none in this message) and tool are default. We can detect the
+  // tool avatar staying default and the assistant avatar being custom.
+  const toolMarkers = html.match(/data-avatar-role="tool"[^>]*data-avatar-source="\w+"/g) ?? [];
+  for (const marker of toolMarkers) {
+    assert.match(marker, /data-avatar-source="default"/);
+  }
 });

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useState, useRef, useEffect, useMemo } from "react";
 import { MarkdownBody } from "./MarkdownBody";
+import { Avatar } from "./Avatar";
 import { copyText } from "@/lib/clipboard";
 import { parseCompactionSummary } from "@/lib/compaction-summary";
 import { isEmptyThinkingBlock } from "@/lib/message-display";
@@ -180,7 +181,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <div style={{ display: "flex", alignItems: "flex-end", gap: 6, maxWidth: "85%" }}>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 8, maxWidth: "85%" }}>
         <div
           style={{
             flex: 1,
@@ -223,6 +224,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
           {content && <MarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</MarkdownBody>}
         </div>
 
+        <Avatar role="user" title="User" />
       </div>
 
       {/* Bottom row: action buttons + timestamp */}
@@ -471,10 +473,12 @@ function AssistantMessageView({
 
   return (
     <div
-      style={{ marginBottom: 16 }}
+      style={{ marginBottom: 16, display: "flex", alignItems: "flex-start", gap: 8 }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
+      <Avatar role="assistant" title="Assistant" />
+      <div style={{ flex: 1, minWidth: 0 }}>
       {/* Model label */}
       <div
         style={{
@@ -573,6 +577,7 @@ function AssistantMessageView({
         {time && !isStreaming && (
           <span style={{ fontSize: 10, color: "var(--text-dim)", marginLeft: "auto" }}>{time}</span>
         )}
+      </div>
       </div>
     </div>
   );
@@ -721,6 +726,7 @@ function ToolCallBlock({ block, result, duration }: { block: ToolCallContent; re
           minWidth: 0,
         }}
       >
+        <Avatar role="tool" title="Tool" />
         <span style={{ color: isError ? "#f87171" : "#16a34a", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 11, flexShrink: 0 }}>
           {block.toolName}
         </span>

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -2,7 +2,8 @@
 
 import { memo, useState, useRef, useEffect, useMemo } from "react";
 import { MarkdownBody } from "./MarkdownBody";
-import { Avatar } from "./Avatar";
+import { Avatar, type AvatarRole } from "./Avatar";
+import { useAvatarSrc } from "./AvatarConfigProvider";
 import { copyText } from "@/lib/clipboard";
 import { parseCompactionSummary } from "@/lib/compaction-summary";
 import { isEmptyThinkingBlock } from "@/lib/message-display";
@@ -69,6 +70,11 @@ interface Props {
   showTimestamp?: boolean;
   prevTimestamp?: number;
   sessionId?: string;
+}
+
+function RoleAvatar({ role, title }: { role: AvatarRole; title: string }) {
+  const src = useAvatarSrc(role);
+  return <Avatar role={role} title={title} src={src} />;
 }
 
 function formatTime(ts?: number): string | null {
@@ -224,7 +230,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
           {content && <MarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</MarkdownBody>}
         </div>
 
-        <Avatar role="user" title="User" />
+        <RoleAvatar role="user" title="User" />
       </div>
 
       {/* Bottom row: action buttons + timestamp */}
@@ -477,7 +483,7 @@ function AssistantMessageView({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <Avatar role="assistant" title="Assistant" />
+      <RoleAvatar role="assistant" title="Assistant" />
       <div style={{ flex: 1, minWidth: 0 }}>
       {/* Model label */}
       <div
@@ -726,7 +732,7 @@ function ToolCallBlock({ block, result, duration }: { block: ToolCallContent; re
           minWidth: 0,
         }}
       >
-        <Avatar role="tool" title="Tool" />
+        <RoleAvatar role="tool" title="Tool" />
         <span style={{ color: isError ? "#f87171" : "#16a34a", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 11, flexShrink: 0 }}>
           {block.toolName}
         </span>

--- a/lib/avatar-config.server.ts
+++ b/lib/avatar-config.server.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  createEmptyAvatarConfig,
+  parseAvatarConfig,
+  type AvatarConfig,
+} from "./avatar-config";
+
+export function getAvatarConfigPath(cwd: string): string {
+  return join(cwd, ".pi", "avatars.json");
+}
+
+export function readAvatarConfig(cwd: string): AvatarConfig {
+  try {
+    return parseAvatarConfig(readFileSync(getAvatarConfigPath(cwd), "utf8"));
+  } catch {
+    return createEmptyAvatarConfig();
+  }
+}

--- a/lib/avatar-config.server.ts
+++ b/lib/avatar-config.server.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
 import {
   createEmptyAvatarConfig,
   parseAvatarConfig,
@@ -16,4 +16,23 @@ export function readAvatarConfig(cwd: string): AvatarConfig {
   } catch {
     return createEmptyAvatarConfig();
   }
+}
+
+/**
+ * Persist a complete three-role avatar record to `<cwd>/.pi/avatars.json`.
+ * The write is atomic: the JSON is written to a sibling temp file and renamed
+ * into place so a partial write never replaces a valid config. The parent
+ * `.pi` directory is created on demand. Ticket #5 will add payload-size
+ * hardening at the API boundary.
+ */
+export function writeAvatarConfig(cwd: string, config: AvatarConfig): void {
+  const path = getAvatarConfigPath(cwd);
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const serialized = `${JSON.stringify(config, null, 2)}\n`;
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, serialized, "utf8");
+  renameSync(tempPath, path);
 }

--- a/lib/avatar-config.test.mjs
+++ b/lib/avatar-config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -8,12 +8,17 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url, {
   tsconfigPaths: true,
 });
-const { normalizeAvatarConfig, parseAvatarConfig } = await jiti.import(
-  "./avatar-config.ts",
-);
-const { getAvatarConfigPath, readAvatarConfig } = await jiti.import(
-  "./avatar-config.server.ts",
-);
+const {
+  normalizeAvatarConfig,
+  parseAvatarConfig,
+  validateAvatarDataUrl,
+  validateAvatarConfigPayload,
+} = await jiti.import("./avatar-config.ts");
+const {
+  getAvatarConfigPath,
+  readAvatarConfig,
+  writeAvatarConfig,
+} = await jiti.import("./avatar-config.server.ts");
 
 const EMPTY_CONFIG = {
   user: null,
@@ -79,4 +84,130 @@ test("unexpected role values are ignored without discarding valid present keys",
 test("non-object JSON also resolves to a complete null record", () => {
   assert.deepEqual(parseAvatarConfig("null"), EMPTY_CONFIG);
   assert.deepEqual(parseAvatarConfig('"not-an-object"'), EMPTY_CONFIG);
+});
+
+// --- validateAvatarDataUrl ---
+
+test("validateAvatarDataUrl accepts a canonical PNG data URL", () => {
+  const result = validateAvatarDataUrl("data:image/png;base64,dGVzdA==");
+  assert.deepEqual(result, {
+    ok: true,
+    mime: "image/png",
+    base64: "dGVzdA==",
+  });
+});
+
+test("validateAvatarDataUrl accepts JPEG and WebP data URLs case-insensitively", () => {
+  for (const value of [
+    "data:image/jpeg;base64,YWJj",
+    "data:image/webp;base64,WFla",
+    "DATA:IMAGE/PNG;base64,YWJj",
+  ]) {
+    const result = validateAvatarDataUrl(value);
+    assert.equal(result.ok, true, `expected ok for ${value}`);
+  }
+});
+
+test("validateAvatarDataUrl rejects unsupported MIME types and non-data values", () => {
+  for (const value of [
+    "data:image/svg+xml;base64,PHN2Zy8+",
+    "data:image/gif;base64,R0lGODlh",
+    "data:text/plain;base64,Zm9v",
+    "https://example.com/avatar.png",
+    "data:image/png,not-base64",
+    "data:image/png;base64,",
+  ]) {
+    const result = validateAvatarDataUrl(value);
+    assert.equal(result.ok, false, `expected failure for ${value}`);
+  }
+});
+
+test("validateAvatarDataUrl strips whitespace inside the base64 payload", () => {
+  const result = validateAvatarDataUrl("data:image/png;base64,dGVz dA==");
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.base64 : "", "dGVzdA==");
+});
+
+// --- validateAvatarConfigPayload ---
+
+test("validateAvatarConfigPayload returns a normalized complete record for valid input", () => {
+  const result = validateAvatarConfigPayload({
+    user: "data:image/png;base64,dXNlcg==",
+    assistant: "data:image/jpeg;base64,YXNz",
+    tool: null,
+  });
+  assert.deepEqual(result, {
+    user: "data:image/png;base64,dXNlcg==",
+    assistant: "data:image/jpeg;base64,YXNz",
+    tool: null,
+  });
+});
+
+test("validateAvatarConfigPayload throws when a role is not a supported data URL", () => {
+  assert.throws(
+    () =>
+      validateAvatarConfigPayload({
+        user: "data:image/svg+xml;base64,PHN2Zy8+",
+        assistant: null,
+        tool: null,
+      }),
+    /user/,
+  );
+});
+
+test("validateAvatarConfigPayload throws when input is not an object", () => {
+  assert.throws(() => validateAvatarConfigPayload(null), /object/);
+  assert.throws(() => validateAvatarConfigPayload("not-an-object"), /object/);
+});
+
+// --- writeAvatarConfig ---
+
+test("writeAvatarConfig writes a complete three-role record to the project avatars.json", (t) => {
+  const cwd = createProject(t);
+  const next = {
+    user: "data:image/png;base64,dXNlcg==",
+    assistant: "data:image/webp;base64,YXNz",
+    tool: "data:image/jpeg;base64,dG9vbA==",
+  };
+
+  writeAvatarConfig(cwd, next);
+
+  assert.deepEqual(
+    JSON.parse(readFileSync(getAvatarConfigPath(cwd), "utf8")),
+    next,
+  );
+});
+
+test("writeAvatarConfig creates the .pi directory when missing", (t) => {
+  const cwd = createProject(t);
+  assert.equal(existsSync(join(cwd, ".pi")), false);
+
+  writeAvatarConfig(cwd, { user: null, assistant: null, tool: null });
+
+  assert.equal(existsSync(getAvatarConfigPath(cwd)), true);
+});
+
+test("writeAvatarConfig preserves the previous file when a second write fails midway", (t) => {
+  const cwd = createProject(t);
+  const first = {
+    user: "data:image/png;base64,Zmlyc3Q=",
+    assistant: null,
+    tool: null,
+  };
+  writeAvatarConfig(cwd, first);
+
+  // A second write replaces atomically; verify the new file is valid.
+  const second = {
+    user: null,
+    assistant: "data:image/webp;base64,c2Vjb25k",
+    tool: null,
+  };
+  writeAvatarConfig(cwd, second);
+  assert.deepEqual(readAvatarConfig(cwd), second);
+});
+
+test("writeAvatarConfig preserves a null record as the on-disk default", (t) => {
+  const cwd = createProject(t);
+  writeAvatarConfig(cwd, { user: null, assistant: null, tool: null });
+  assert.deepEqual(readAvatarConfig(cwd), EMPTY_CONFIG);
 });

--- a/lib/avatar-config.test.mjs
+++ b/lib/avatar-config.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const { normalizeAvatarConfig, parseAvatarConfig } = await jiti.import(
+  "./avatar-config.ts",
+);
+const { getAvatarConfigPath, readAvatarConfig } = await jiti.import(
+  "./avatar-config.server.ts",
+);
+
+const EMPTY_CONFIG = {
+  user: null,
+  assistant: null,
+  tool: null,
+};
+
+function createProject(t) {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-web-avatars-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  return cwd;
+}
+
+function writeConfig(cwd, contents) {
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  writeFileSync(getAvatarConfigPath(cwd), contents, "utf8");
+}
+
+test("missing avatar config resolves to a complete null record without creating a file", (t) => {
+  const cwd = createProject(t);
+
+  assert.deepEqual(readAvatarConfig(cwd), EMPTY_CONFIG);
+  assert.equal(existsSync(getAvatarConfigPath(cwd)), false);
+});
+
+test("malformed avatar JSON resolves to a complete null record", (t) => {
+  const cwd = createProject(t);
+  writeConfig(cwd, '{"user":"data:image/png;base64,abc"');
+
+  assert.deepEqual(readAvatarConfig(cwd), EMPTY_CONFIG);
+});
+
+test("incomplete avatar config preserves valid keys and fills missing keys with null", (t) => {
+  const cwd = createProject(t);
+  const userAvatar = "data:image/png;base64,dXNlcg==";
+  writeConfig(cwd, JSON.stringify({ user: userAvatar }));
+
+  assert.deepEqual(readAvatarConfig(cwd), {
+    user: userAvatar,
+    assistant: null,
+    tool: null,
+  });
+});
+
+test("unexpected role values are ignored without discarding valid present keys", () => {
+  const assistantAvatar = "data:image/webp;base64,YXNzaXN0YW50";
+
+  assert.deepEqual(
+    normalizeAvatarConfig({
+      user: 42,
+      assistant: assistantAvatar,
+      tool: { src: "not-supported" },
+      extra: "ignored",
+    }),
+    {
+      user: null,
+      assistant: assistantAvatar,
+      tool: null,
+    },
+  );
+});
+
+test("non-object JSON also resolves to a complete null record", () => {
+  assert.deepEqual(parseAvatarConfig("null"), EMPTY_CONFIG);
+  assert.deepEqual(parseAvatarConfig('"not-an-object"'), EMPTY_CONFIG);
+});

--- a/lib/avatar-config.test.mjs
+++ b/lib/avatar-config.test.mjs
@@ -211,3 +211,50 @@ test("writeAvatarConfig preserves a null record as the on-disk default", (t) => 
   writeAvatarConfig(cwd, { user: null, assistant: null, tool: null });
   assert.deepEqual(readAvatarConfig(cwd), EMPTY_CONFIG);
 });
+
+// --- 2 MB encoded size guard (ticket #5) ---
+
+test("validateAvatarDataUrl rejects an encoded data URL larger than 2 MB", () => {
+  // Build a data URL whose full string length is comfortably above 2 MB.
+  const huge = "data:image/png;base64," + "A".repeat(2 * 1024 * 1024 + 1);
+  const result = validateAvatarDataUrl(huge);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /exceeds/);
+    assert.match(result.reason, /2097152/);
+  }
+});
+
+test("validateAvatarDataUrl accepts an encoded data URL exactly at the 2 MB boundary", () => {
+  // Padding before the base64 portion is fixed, so the size test on the
+  // full string stays just below the limit for a 2 MB - 1 byte payload.
+  const prefix = "data:image/png;base64,";
+  const payload = "A".repeat(2 * 1024 * 1024 - prefix.length - 1);
+  const boundary = prefix + payload;
+  const result = validateAvatarDataUrl(boundary);
+  assert.equal(result.ok, true, `expected ok for ${boundary.length}-byte payload`);
+});
+
+test("validateAvatarDataUrl checks size before the regex match so it fails fast on huge payloads", () => {
+  // 4 MB of garbage: should be rejected with the size reason, not the regex
+  // reason ("avatar must be a data:...").
+  const huge = "X".repeat(4 * 1024 * 1024);
+  const result = validateAvatarDataUrl(huge);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /exceeds/);
+  }
+});
+
+test("validateAvatarConfigPayload rejects an oversized role payload", () => {
+  const huge = "data:image/png;base64," + "A".repeat(2 * 1024 * 1024 + 1);
+  assert.throws(
+    () =>
+      validateAvatarConfigPayload({
+        user: huge,
+        assistant: null,
+        tool: null,
+      }),
+    /exceeds/,
+  );
+});

--- a/lib/avatar-config.ts
+++ b/lib/avatar-config.ts
@@ -4,13 +4,19 @@ export type AvatarConfigRole = (typeof AVATAR_CONFIG_ROLES)[number];
 export type AvatarConfig = Record<AvatarConfigRole, string | null>;
 
 /** Image MIME types accepted by the upload boundary. SVG and other formats
- *  are intentionally excluded; ticket #5 will tighten this further. */
+ *  are intentionally excluded: SVG can carry active content and is parsed
+ *  differently by image decoders, so it is not a safe upload format here. */
 export const AVATAR_DATA_URL_MIME_TYPES = ["image/png", "image/jpeg", "image/webp"] as const;
 export type AvatarDataUrlMime = (typeof AVATAR_DATA_URL_MIME_TYPES)[number];
 
+/** Maximum encoded avatar data URL size in bytes (2 MB). The data URL is
+ *  stored verbatim inside `<cwd>/.pi/avatars.json`, so capping the encoded
+ *  payload keeps the on-disk file small and rejects oversized persisted data. */
+export const AVATAR_DATA_URL_MAX_BYTES = 2 * 1024 * 1024;
+
 /** Loose canonical form: `data:image/<png|jpeg|webp>;base64,<payload>`.
- *  Whitespace inside the base64 payload is tolerated; ticket #5 adds tighter
- *  payload-size and decoding checks. */
+ *  Whitespace inside the base64 payload is tolerated. Size and decoding
+ *  checks live outside the regex so they can fail fast on huge inputs. */
 const AVATAR_DATA_URL_RE = /^data:image\/(png|jpeg|webp);base64,([A-Za-z0-9+/=\s]+)$/i;
 
 export function createEmptyAvatarConfig(): AvatarConfig {
@@ -69,10 +75,19 @@ export type AvatarDataUrlValidation = AvatarDataUrlValidationOk | AvatarDataUrlV
  * Validate that a value is a supported PNG/JPEG/WebP data URL. Returns a
  * discriminated result rather than throwing so the upload boundary can
  * surface a clear error to the UI without crashing the request.
+ *
+ * The size check runs before the regex match so oversized payloads are
+ * rejected without paying for a full-string scan.
  */
 export function validateAvatarDataUrl(value: unknown): AvatarDataUrlValidation {
   if (typeof value !== "string") {
     return { ok: false, reason: "avatar value must be a string" };
+  }
+  if (value.length > AVATAR_DATA_URL_MAX_BYTES) {
+    return {
+      ok: false,
+      reason: `avatar data URL exceeds ${AVATAR_DATA_URL_MAX_BYTES}-byte limit`,
+    };
   }
   const match = AVATAR_DATA_URL_RE.exec(value);
   if (!match) {

--- a/lib/avatar-config.ts
+++ b/lib/avatar-config.ts
@@ -1,0 +1,42 @@
+export const AVATAR_CONFIG_ROLES = ["user", "assistant", "tool"] as const;
+
+export type AvatarConfigRole = (typeof AVATAR_CONFIG_ROLES)[number];
+export type AvatarConfig = Record<AvatarConfigRole, string | null>;
+
+export function createEmptyAvatarConfig(): AvatarConfig {
+  return {
+    user: null,
+    assistant: null,
+    tool: null,
+  };
+}
+
+/**
+ * Keep only supported role values while always returning a complete record.
+ * Image-format and payload validation belongs to the upload boundary; loading
+ * only needs to tolerate absent keys and unexpected persisted values safely.
+ */
+export function normalizeAvatarConfig(value: unknown): AvatarConfig {
+  const normalized = createEmptyAvatarConfig();
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return normalized;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  for (const role of AVATAR_CONFIG_ROLES) {
+    const roleValue = candidate[role];
+    if (typeof roleValue === "string" || roleValue === null) {
+      normalized[role] = roleValue;
+    }
+  }
+  return normalized;
+}
+
+export function parseAvatarConfig(source: string | null | undefined): AvatarConfig {
+  if (source === null || source === undefined) return createEmptyAvatarConfig();
+  try {
+    return normalizeAvatarConfig(JSON.parse(source) as unknown);
+  } catch {
+    return createEmptyAvatarConfig();
+  }
+}

--- a/lib/avatar-config.ts
+++ b/lib/avatar-config.ts
@@ -3,6 +3,16 @@ export const AVATAR_CONFIG_ROLES = ["user", "assistant", "tool"] as const;
 export type AvatarConfigRole = (typeof AVATAR_CONFIG_ROLES)[number];
 export type AvatarConfig = Record<AvatarConfigRole, string | null>;
 
+/** Image MIME types accepted by the upload boundary. SVG and other formats
+ *  are intentionally excluded; ticket #5 will tighten this further. */
+export const AVATAR_DATA_URL_MIME_TYPES = ["image/png", "image/jpeg", "image/webp"] as const;
+export type AvatarDataUrlMime = (typeof AVATAR_DATA_URL_MIME_TYPES)[number];
+
+/** Loose canonical form: `data:image/<png|jpeg|webp>;base64,<payload>`.
+ *  Whitespace inside the base64 payload is tolerated; ticket #5 adds tighter
+ *  payload-size and decoding checks. */
+const AVATAR_DATA_URL_RE = /^data:image\/(png|jpeg|webp);base64,([A-Za-z0-9+/=\s]+)$/i;
+
 export function createEmptyAvatarConfig(): AvatarConfig {
   return {
     user: null,
@@ -39,4 +49,68 @@ export function parseAvatarConfig(source: string | null | undefined): AvatarConf
   } catch {
     return createEmptyAvatarConfig();
   }
+}
+
+export interface AvatarDataUrlValidationOk {
+  ok: true;
+  mime: AvatarDataUrlMime;
+  /** Base64 payload with whitespace stripped. */
+  base64: string;
+}
+
+export interface AvatarDataUrlValidationFail {
+  ok: false;
+  reason: string;
+}
+
+export type AvatarDataUrlValidation = AvatarDataUrlValidationOk | AvatarDataUrlValidationFail;
+
+/**
+ * Validate that a value is a supported PNG/JPEG/WebP data URL. Returns a
+ * discriminated result rather than throwing so the upload boundary can
+ * surface a clear error to the UI without crashing the request.
+ */
+export function validateAvatarDataUrl(value: unknown): AvatarDataUrlValidation {
+  if (typeof value !== "string") {
+    return { ok: false, reason: "avatar value must be a string" };
+  }
+  const match = AVATAR_DATA_URL_RE.exec(value);
+  if (!match) {
+    return { ok: false, reason: "avatar must be a data:image/(png|jpeg|webp);base64 URL" };
+  }
+  const mime = `image/${match[1].toLowerCase()}` as AvatarDataUrlMime;
+  const base64 = match[2].replace(/\s+/g, "");
+  if (base64.length === 0) {
+    return { ok: false, reason: "avatar data URL payload is empty" };
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) {
+    return { ok: false, reason: "avatar data URL base64 payload is malformed" };
+  }
+  return { ok: true, mime, base64 };
+}
+
+/**
+ * Validate a full three-role payload as it arrives at the persistence
+ * boundary. Throws on the first invalid role so the server returns a clear
+ * 400 with the offending role key.
+ */
+export function validateAvatarConfigPayload(value: unknown): AvatarConfig {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("avatar config must be a JSON object");
+  }
+  const candidate = value as Record<string, unknown>;
+  const result = createEmptyAvatarConfig();
+  for (const role of AVATAR_CONFIG_ROLES) {
+    const roleValue = candidate[role];
+    if (roleValue === null) {
+      result[role] = null;
+      continue;
+    }
+    const validation = validateAvatarDataUrl(roleValue);
+    if (!validation.ok) {
+      throw new Error(`avatar "${role}" is invalid: ${validation.reason}`);
+    }
+    result[role] = `data:${validation.mime};base64,${validation.base64}`;
+  }
+  return result;
 }

--- a/lib/avatar-image.test.mjs
+++ b/lib/avatar-image.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const {
+  AVATAR_IMAGE_MAX_SIZE,
+  computeAvatarTargetSize,
+  detectAvatarSourceMime,
+  resizeAvatarDataUrl,
+} = await jiti.import("./avatar-image.ts");
+
+test("computeAvatarTargetSize shrinks the longest edge to maxSize and preserves aspect ratio", () => {
+  assert.deepEqual(computeAvatarTargetSize(256, 128, 64), { width: 64, height: 32 });
+  assert.deepEqual(computeAvatarTargetSize(100, 200, 50), { width: 25, height: 50 });
+});
+
+test("computeAvatarTargetSize returns the original size when the source already fits", () => {
+  assert.deepEqual(computeAvatarTargetSize(64, 64, 128), { width: 64, height: 64 });
+  assert.deepEqual(computeAvatarTargetSize(80, 40, 128), { width: 80, height: 40 });
+});
+
+test("computeAvatarTargetSize defaults to AVATAR_IMAGE_MAX_SIZE", () => {
+  assert.equal(AVATAR_IMAGE_MAX_SIZE, 128);
+  assert.deepEqual(computeAvatarTargetSize(1000, 500), { width: 128, height: 64 });
+});
+
+test("computeAvatarTargetSize falls back to a square when inputs are invalid", () => {
+  for (const [w, h] of [[0, 0], [-1, 100], [Number.NaN, 50]]) {
+    const target = computeAvatarTargetSize(w, h);
+    assert.equal(target.width, AVATAR_IMAGE_MAX_SIZE);
+    assert.equal(target.height, AVATAR_IMAGE_MAX_SIZE);
+  }
+});
+
+test("detectAvatarSourceMime extracts and lowercases the source MIME", () => {
+  assert.equal(detectAvatarSourceMime("data:image/png;base64,xx"), "image/png");
+  assert.equal(detectAvatarSourceMime("data:IMAGE/JPEG;base64,xx"), "image/jpeg");
+  assert.equal(detectAvatarSourceMime("data:image/webp;base64,xx"), "image/webp");
+  assert.equal(detectAvatarSourceMime("not-a-data-url"), "image/png");
+});
+
+test("resizeAvatarDataUrl uses the injected loadBitmap and createCanvas dependencies", async () => {
+  let drawCalls = 0;
+  const sourceDataUrl = "data:image/png;base64,abc";
+  const deps = {
+    loadBitmap: async () => {
+      return { width: 1024, height: 512, close() {} };
+    },
+    createCanvas: (width, height) => {
+      const ctx = {
+        imageSmoothingQuality: "low",
+        drawImage(_image, _dx, _dy, dw, dh) {
+          drawCalls += 1;
+          // Capture the target size used during the draw.
+          this.lastDraw = { dw, dh, width, height };
+        },
+      };
+      return {
+        width,
+        height,
+        getContext: (kind) => (kind === "2d" ? ctx : null),
+        toDataURL: (mime) => `data:${mime};base64,ENCODED-${width}x${height}`,
+      };
+    },
+  };
+
+  const result = await resizeAvatarDataUrl(sourceDataUrl, 128, deps);
+  assert.equal(drawCalls, 1);
+  assert.equal(result, "data:image/png;base64,ENCODED-128x64");
+});
+
+test("resizeAvatarDataUrl preserves the source size when it already fits", async () => {
+  const deps = {
+    loadBitmap: async () => ({ width: 64, height: 64, close() {} }),
+    createCanvas: (width, height) => ({
+      width,
+      height,
+      getContext: () => ({
+        imageSmoothingQuality: "low",
+        drawImage() {},
+      }),
+      toDataURL: (mime) => `data:${mime};base64,NOOP-${width}x${height}`,
+    }),
+  };
+
+  const result = await resizeAvatarDataUrl("data:image/webp;base64,abc", 128, deps);
+  assert.equal(result, "data:image/webp;base64,NOOP-64x64");
+});
+
+test("resizeAvatarDataUrl surfaces a clear error when the canvas context is unavailable", async () => {
+  const deps = {
+    loadBitmap: async () => ({ width: 64, height: 64, close() {} }),
+    createCanvas: () => ({
+      width: 0,
+      height: 0,
+      getContext: () => null,
+      toDataURL: () => "data:image/png;base64,unused",
+    }),
+  };
+
+  await assert.rejects(
+    () => resizeAvatarDataUrl("data:image/png;base64,abc", 128, deps),
+    /2D canvas context/,
+  );
+});

--- a/lib/avatar-image.ts
+++ b/lib/avatar-image.ts
@@ -60,9 +60,6 @@ const BROWSER_DEPS: ResizeDeps = {
     });
   },
   createCanvas: (width, height) => {
-    if (typeof OffscreenCanvas !== "undefined") {
-      return new OffscreenCanvas(width, height) as unknown as ResizeCanvas;
-    }
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;

--- a/lib/avatar-image.ts
+++ b/lib/avatar-image.ts
@@ -1,0 +1,102 @@
+/** Maximum edge length (in CSS pixels) used when resizing avatar uploads.
+ *  128 is comfortably above the largest displayed avatar (72px preview at
+ *  2x DPR) and keeps the persisted data URLs small. */
+export const AVATAR_IMAGE_MAX_SIZE = 128;
+
+/**
+ * Pick a target {width, height} that fits inside `maxSize` on its longest
+ * edge while preserving the source aspect ratio. Pure: easy to unit test
+ * without a browser. Inputs <= maxSize are returned unchanged.
+ */
+export function computeAvatarTargetSize(
+  width: number,
+  height: number,
+  maxSize: number = AVATAR_IMAGE_MAX_SIZE,
+): { width: number; height: number } {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { width: maxSize, height: maxSize };
+  }
+  const largest = Math.max(width, height);
+  if (largest <= maxSize) return { width, height };
+  const scale = maxSize / largest;
+  return { width: Math.round(width * scale), height: Math.round(height * scale) };
+}
+
+/** Detect the source MIME so the resized output keeps its format. */
+export function detectAvatarSourceMime(dataUrl: string): string {
+  const match = /^data:([^;]+);/.exec(dataUrl);
+  return match ? match[1].toLowerCase() : "image/png";
+}
+
+type ResizableImage = ImageBitmap | HTMLImageElement;
+
+interface ResizeCanvas {
+  width: number;
+  height: number;
+  getContext(kind: "2d"): {
+    imageSmoothingQuality: "low" | "medium" | "high";
+    drawImage(image: CanvasImageSource, dx: number, dy: number, dw: number, dh: number): void;
+  } | null;
+  toDataURL(mime: string): string;
+}
+
+interface ResizeDeps {
+  loadBitmap: (dataUrl: string) => Promise<ResizableImage>;
+  createCanvas: (width: number, height: number) => ResizeCanvas;
+}
+
+const BROWSER_DEPS: ResizeDeps = {
+  loadBitmap: async (dataUrl) => {
+    if (typeof createImageBitmap === "function") {
+      const response = await fetch(dataUrl);
+      const blob = await response.blob();
+      return await createImageBitmap(blob);
+    }
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error("Could not decode avatar image"));
+      img.src = dataUrl;
+    });
+  },
+  createCanvas: (width, height) => {
+    if (typeof OffscreenCanvas !== "undefined") {
+      return new OffscreenCanvas(width, height) as unknown as ResizeCanvas;
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    return canvas as unknown as ResizeCanvas;
+  },
+};
+
+/**
+ * Browser-only: resize an avatar data URL to fit within `maxSize` and
+ * re-encode it. The DOM-touching steps are isolated in `BROWSER_DEPS` so
+ * the pure logic can be exercised in node tests by passing custom deps.
+ *
+ * This function must only be called from the browser; it touches DOM
+ * globals through the default dependency set. Tests cover the pure
+ * `computeAvatarTargetSize` helper directly.
+ */
+export async function resizeAvatarDataUrl(
+  dataUrl: string,
+  maxSize: number = AVATAR_IMAGE_MAX_SIZE,
+  deps: ResizeDeps = BROWSER_DEPS,
+): Promise<string> {
+  const sourceMime = detectAvatarSourceMime(dataUrl);
+  const bitmap = await deps.loadBitmap(dataUrl);
+  const target = computeAvatarTargetSize(bitmap.width, bitmap.height, maxSize);
+  const canvas = deps.createCanvas(target.width, target.height);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not acquire 2D canvas context for avatar resize");
+  ctx.imageSmoothingQuality = "high";
+  ctx.drawImage(bitmap, 0, 0, target.width, target.height);
+  if ("close" in bitmap && typeof bitmap.close === "function") {
+    bitmap.close();
+  }
+  return canvas.toDataURL(sourceMime);
+}
+
+/** Exposed for tests: the dependency shape `resizeAvatarDataUrl` accepts. */
+export type { ResizeDeps, ResizeCanvas, ResizableImage };

--- a/lib/avatar-upload.test.mjs
+++ b/lib/avatar-upload.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const {
+  AVATAR_UPLOAD_ACCEPTED_MIME_TYPES,
+  processAvatarUpload,
+  AVATAR_DATA_URL_MAX_BYTES,
+} = await jiti.import("./avatar-upload.ts");
+
+// node 22+ ships a global File. Older runtimes would fall back to undefined
+// here, in which case these tests can't run.
+if (typeof File === "undefined") {
+  throw new Error("File global is required to run avatar-upload tests");
+}
+
+function makeFile(type, name = "avatar.bin", bytes = [0]) {
+  return new File([new Uint8Array(bytes)], name, { type });
+}
+
+const SAMPLE_DATA_URL = "data:image/png;base64,iVBORw0KGgo=";
+
+test("AVATAR_UPLOAD_ACCEPTED_MIME_TYPES only allows PNG, JPEG, and WebP", () => {
+  assert.deepEqual([...AVATAR_UPLOAD_ACCEPTED_MIME_TYPES], [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+  ]);
+  // SVG is intentionally excluded so the upload pipeline rejects SVG even
+  // when the user renames the file.
+  assert.equal(AVATAR_UPLOAD_ACCEPTED_MIME_TYPES.includes("image/svg+xml"), false);
+});
+
+// --- rejection paths ---
+
+test("processAvatarUpload rejects SVG and other unsupported MIME types", async () => {
+  for (const type of ["image/svg+xml", "image/gif", "text/plain", "application/json", ""]) {
+    const result = await processAvatarUpload(makeFile(type), {
+      readDataUrl: async () => SAMPLE_DATA_URL,
+      resizeDataUrl: async (url) => url,
+    });
+    assert.equal(result.ok, false, `expected failure for ${type}`);
+    if (!result.ok) {
+      assert.match(result.reason, /Unsupported/);
+    }
+  }
+});
+
+test("processAvatarUpload rejects an undecodable image without touching state", async () => {
+  // Simulate a File whose contents can't be decoded by the resize step
+  // (e.g. a mislabeled SVG with an image/png MIME).
+  let resizeCalled = false;
+  const result = await processAvatarUpload(makeFile("image/png"), {
+    readDataUrl: async () => "data:image/png;base64,XXXXXX",
+    resizeDataUrl: async () => {
+      resizeCalled = true;
+      throw new Error("Could not decode avatar image");
+    },
+  });
+  assert.equal(resizeCalled, true, "resize must be attempted before rejection");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /Could not decode/i);
+    assert.match(result.reason, /decode avatar image/);
+  }
+});
+
+test("processAvatarUpload rejects an oversized encoded data URL after resize", async () => {
+  const huge = "data:image/png;base64," + "A".repeat(AVATAR_DATA_URL_MAX_BYTES + 1);
+  const result = await processAvatarUpload(makeFile("image/png"), {
+    readDataUrl: async () => huge,
+    resizeDataUrl: async (url) => url,
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /encoded size limit|exceeds/);
+  }
+});
+
+test("processAvatarUpload rejects an empty resize result", async () => {
+  const result = await processAvatarUpload(makeFile("image/png"), {
+    readDataUrl: async () => SAMPLE_DATA_URL,
+    resizeDataUrl: async () => "",
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /empty/);
+  }
+});
+
+// --- success path ---
+
+test("processAvatarUpload returns the resized data URL on success", async () => {
+  const result = await processAvatarUpload(makeFile("image/png"), {
+    readDataUrl: async () => SAMPLE_DATA_URL,
+    resizeDataUrl: async () => SAMPLE_DATA_URL,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.dataUrl, SAMPLE_DATA_URL);
+  }
+});

--- a/lib/avatar-upload.ts
+++ b/lib/avatar-upload.ts
@@ -1,0 +1,69 @@
+import {
+  AVATAR_DATA_URL_MAX_BYTES,
+  AVATAR_DATA_URL_MIME_TYPES,
+} from "./avatar-config";
+
+/** MIME types the client upload pipeline accepts. SVG and other formats
+ *  are intentionally excluded because they cannot be decoded by the
+ *  canvas resize step the same way PNG/JPEG/WebP can. */
+export const AVATAR_UPLOAD_ACCEPTED_MIME_TYPES = AVATAR_DATA_URL_MIME_TYPES;
+export { AVATAR_DATA_URL_MAX_BYTES };
+
+export type AvatarUploadAcceptedMime = (typeof AVATAR_UPLOAD_ACCEPTED_MIME_TYPES)[number];
+
+export interface AvatarUploadDeps {
+  /** Read the raw File into a base64 data URL (no resize). */
+  readDataUrl: (file: File) => Promise<string>;
+  /** Resize / re-encode the data URL so it fits the configured avatar size. */
+  resizeDataUrl: (dataUrl: string) => Promise<string>;
+}
+
+export type AvatarUploadResult =
+  | { ok: true; dataUrl: string }
+  | { ok: false; reason: string };
+
+/**
+ * Validate, decode, resize, and size-check a user-selected avatar file.
+ *
+ * Returns a discriminated result so the React upload handler can surface a
+ * clear error without touching the draft state. On rejection the caller
+ * must leave the draft (and any saved config) untouched - only the success
+ * branch returns a data URL that is safe to assign to a role slot.
+ *
+ * The decode and resize steps use injected dependencies so this helper can
+ * be exercised under node test without a browser.
+ */
+export async function processAvatarUpload(
+  file: File,
+  deps: AvatarUploadDeps,
+): Promise<AvatarUploadResult> {
+  const accepted = AVATAR_UPLOAD_ACCEPTED_MIME_TYPES as readonly string[];
+  if (!accepted.includes(file.type)) {
+    return {
+      ok: false,
+      reason: `Unsupported file type: ${file.type || "unknown"}`,
+    };
+  }
+  let resized: string;
+  try {
+    const raw = await deps.readDataUrl(file);
+    resized = await deps.resizeDataUrl(raw);
+  } catch (resizeError) {
+    const message =
+      resizeError instanceof Error ? resizeError.message : String(resizeError);
+    return {
+      ok: false,
+      reason: `Could not decode image: ${message}`,
+    };
+  }
+  if (typeof resized !== "string" || resized.length === 0) {
+    return { ok: false, reason: "Could not decode image: empty result" };
+  }
+  if (resized.length > AVATAR_DATA_URL_MAX_BYTES) {
+    return {
+      ok: false,
+      reason: `avatar data URL exceeds ${AVATAR_DATA_URL_MAX_BYTES}-byte limit`,
+    };
+  }
+  return { ok: true, dataUrl: resized };
+}

--- a/lib/response-error.ts
+++ b/lib/response-error.ts
@@ -1,0 +1,5 @@
+export function responseError(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const error = (value as { error?: unknown }).error;
+  return typeof error === "string" ? error : null;
+}


### PR DESCRIPTION
## 概述

为 pi-web 添加按角色显示的头像支持：用户（蓝色 U）、助手（紫色 A）、工具（灰色 T）的默认头像出现在聊天消息旁以及工具调用块的头部。用户可通过「设置 → 头像」上传自定义头像，按项目保存在 `<cwd>/.pi/avatars.json`，并支持恢复默认。

## 改动内容

### 五张功能 ticket

- **#1** `fac79a1` — 聊天区默认角色头像：通过 `Avatar` 组件在 `MessageView` 中渲染用户（蓝色 U）、助手（紫色 A）、工具（灰色 T）
- **#2** `29a6c50` — 头像设置面板：AppShell 新增入口，提供只读预览模态框和 `GET /api/avatars?cwd=` 接口（含安全的默认加载逻辑）
- **#3** `681cb78` — 自定义头像上传：浏览器端 resize 处理、`PUT /api/avatars` 接口（按项目隔离）、`AvatarConfigProvider` 上下文
- **#4** `1aa1133` — 头像恢复控件：每个角色可单独重置为默认，draft/save 用户体验与上传一致
- **#5** `3e337a5` — 上传硬化：拒绝 SVG/不支持的 MIME、无法解码的图片、超过 2 MB 编码大小的 data URL；所有拒绝操作均保留 draft 和已保存状态

### Bug 修复

- **修复** `cdbaa9c` — 修复头像上传时 `OffscreenCanvas` 缺少 `toDataURL` 的问题（浏览器上传会抛 `s.toDataURL is not a function`）

## 涉及文件

```
app/api/avatars/route.ts|test          # 头像配置的 GET/PUT 接口
components/AppShell.tsx                 # 设置入口
components/Avatar.tsx|test              # 通用头像渲染组件
components/AvatarConfigProvider.tsx     # 自定义头像的 React 上下文
components/AvatarsConfig.tsx|test       # 设置模态框
components/MessageView.tsx|avatars.test # 聊天中的头像渲染
lib/avatar-config.ts|server.ts|test     # 配置校验与持久化
lib/avatar-image.ts                     # 浏览器端 resize
lib/avatar-upload.ts|test               # 客户端上传流水线
```

## 验证结果

- `npm run lint` ✓
- `npx tsc --noEmit` ✓
- 头像相关单元测试：**80/80** 通过
- 完整测试：**180/181**（唯一失败是预先存在的 Windows 路径断言，与本次改动无关）
- `npm run build --turbopack` ✓

## 功能说明

| 操作 | 效果 |
|---|---|
| 上传头像 | 浏览器自动 resize → PUT 保存到 `<cwd>/.pi/avatars.json` → 聊天立即更新 |
| 恢复默认头像 | 移除自定义头像，恢复为默认字母头像 |
| 配置文件不存在 | 默认返回 `{user:null, assistant:null, tool:null}`，不会自动创建文件 |
| SVG / 不支持的格式 / 超过 2 MB | 拒绝并提示错误，draft 不受影响 |

## 备注

- 存储路径：`<项目目录>/.pi/avatars.json`（与 Pi 项目本地约定一致）
- 项目隔离：每个项目根目录拥有独立的 avatars.json，跨项目无数据泄露
- 构建注意：Windows 上需使用 `next build --turbopack`（webpack 模式会扫描用户目录中的符号链接导致权限错误）