### PR TITLE
fix: reload ModelRuntime config before set_model to pick up newly added providers

### DIFF
--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -121,7 +121,11 @@ export interface AgentSessionLike {
   readonly autoCompactionEnabled: boolean;
   readonly autoRetryEnabled: boolean;
   readonly model: ModelLike | undefined;
-  readonly modelRuntime: { getModel: (provider: string, modelId: string) => ModelLike | undefined };
+  readonly modelRuntime: {
+    getModel: (provider: string, modelId: string) => ModelLike | undefined;
+    reloadConfig: () => Promise<void>;
+    refresh: (options?: { allowNetwork?: boolean }) => Promise<unknown>;
+  };
   readonly sessionManager: SessionManager;
   readonly settingsManager: SettingsManager;
   readonly agent: { state?: { systemPrompt?: string; thinkingLevel?: string } };

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -124,7 +124,6 @@ export interface AgentSessionLike {
   readonly modelRuntime: {
     getModel: (provider: string, modelId: string) => ModelLike | undefined;
     reloadConfig: () => Promise<void>;
-    refresh: (options?: { allowNetwork?: boolean }) => Promise<unknown>;
   };
   readonly sessionManager: SessionManager;
   readonly settingsManager: SettingsManager;

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -372,7 +372,13 @@ export class AgentSessionWrapper {
 
       case "set_model": {
         const { provider, modelId } = command as { provider: string; modelId: string };
-        const model = this.inner.modelRuntime.getModel(provider, modelId);
+        await this.inner.modelRuntime.reloadConfig();
+        let model = this.inner.modelRuntime.getModel(provider, modelId);
+        if (!model) {
+          // If still not found, try refreshing available models (dynamic providers)
+          await this.inner.modelRuntime.refresh({ allowNetwork: false });
+          model = this.inner.modelRuntime.getModel(provider, modelId);
+        }
         if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
         await this.inner.setModel(model);
         invalidateModelsCache();

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -372,11 +372,9 @@ export class AgentSessionWrapper {
 
       case "set_model": {
         const { provider, modelId } = command as { provider: string; modelId: string };
-        await this.inner.modelRuntime.reloadConfig();
         let model = this.inner.modelRuntime.getModel(provider, modelId);
         if (!model) {
-          // If still not found, try refreshing available models (dynamic providers)
-          await this.inner.modelRuntime.refresh({ allowNetwork: false });
+          await this.inner.modelRuntime.reloadConfig();
           model = this.inner.modelRuntime.getModel(provider, modelId);
         }
         if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);


### PR DESCRIPTION
Bug: When switching models in the same session, the cached AgentSessionWrapper's ModelRuntime never re-reads ~/.pi/agent/models.json. If a custom provider was added after session creation, getModel() returns undefined → "Model not found" error.
Fix: Call modelRuntime.reloadConfig() before getModel() in the set_model handler so the config is reloaded from disk on every model switch. Added reloadConfig/refresh to the AgentSessionLike type to pass typecheck.