### PR TITLE
feat(markdown): support LaTeX bracket delimiters

### DIFF
--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -35,3 +35,26 @@ test("keeps local file markdown links in the app", () => {
   assert.match(html, /<a href="components\/MarkdownBody\.tsx">file<\/a>/);
   assert.doesNotMatch(html, /target=|rel=|\snode=/);
 });
+
+test("renders parenthesized LaTeX delimiters as inline KaTeX", () => {
+  const html = renderMarkdown(String.raw`射线为 \(r_c = K^{-1}p\)。`);
+
+  assert.match(html, /class="katex"/);
+  assert.match(html, /r_c/);
+});
+
+test("renders bracketed LaTeX delimiters as display KaTeX", () => {
+  const html = renderMarkdown(String.raw`\[
+P(\lambda)=o_b+\lambda r_b
+\]`);
+
+  assert.match(html, /class="katex-display"/);
+  assert.match(html, /lambda/);
+});
+
+test("does not normalize LaTeX delimiters inside code", () => {
+  const html = renderMarkdown("Inline code: `\\(x+y\\)`\n\n```text\n\\[x+y\\]\n```");
+
+  assert.doesNotMatch(html, /class="katex"/);
+  assert.match(html, /\\\(x\+y\\\)/);
+});

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -19,7 +19,7 @@ interface MarkdownBodyProps {
 }
 
 export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile }: MarkdownBodyProps) {
-  const normalizedMarkdown = useMemo(() => normalizeDisplayMath(children), [children]);
+  const normalizedMarkdown = useMemo(() => normalizeMathDelimiters(children), [children]);
 
   return (
     <div className={["markdown-body", className].filter(Boolean).join(" ")}>
@@ -92,10 +92,11 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
   );
 }
 
-function normalizeDisplayMath(markdown: string): string {
+export function normalizeMathDelimiters(markdown: string): string {
   const lineBreak = markdown.includes("\r\n") ? "\r\n" : "\n";
   const lines = markdown.split(/\r?\n/);
   let fence: { marker: string; size: number } | null = null;
+  let bracketDisplayIndent: string | null = null;
 
   return lines
     .map((line) => {
@@ -110,15 +111,76 @@ function normalizeDisplayMath(markdown: string): string {
 
       if (fence) return line;
 
+      if (bracketDisplayIndent !== null) {
+        if (/^[ \t]{0,3}\\\][ \t]*$/.test(line)) {
+          const indent = bracketDisplayIndent;
+          bracketDisplayIndent = null;
+          return `${indent}$$`;
+        }
+        return line;
+      }
+
+      const bracketDisplayOneLine = line.match(/^([ \t]{0,3})\\\[\s*(.+?)\s*\\\][ \t]*$/);
+      if (bracketDisplayOneLine) {
+        return `${bracketDisplayOneLine[1]}$$${lineBreak}${bracketDisplayOneLine[2]}${lineBreak}${bracketDisplayOneLine[1]}$$`;
+      }
+
+      const bracketDisplayStart = line.match(/^([ \t]{0,3})\\\[[ \t]*$/);
+      if (bracketDisplayStart) {
+        bracketDisplayIndent = bracketDisplayStart[1];
+        return `${bracketDisplayIndent}$$`;
+      }
+
       const displayMathMatch = line.match(/^([ \t]{0,3})\$\$(.+)\$\$[ \t]*$/);
-      if (!displayMathMatch) return line;
+      if (displayMathMatch) {
+        const math = displayMathMatch[2].trim();
+        if (math) {
+          return `${displayMathMatch[1]}$$${lineBreak}${math}${lineBreak}${displayMathMatch[1]}$$`;
+        }
+      }
 
-      const math = displayMathMatch[2].trim();
-      if (!math) return line;
-
-      return `${displayMathMatch[1]}$$${lineBreak}${math}${lineBreak}${displayMathMatch[1]}$$`;
+      return normalizeInlineMathDelimiters(line);
     })
     .join(lineBreak);
+}
+
+function normalizeInlineMathDelimiters(line: string): string {
+  let result = "";
+  let cursor = 0;
+  let inCode = false;
+  let codeMarkerSize = 0;
+
+  while (cursor < line.length) {
+    if (line[cursor] === "`") {
+      let end = cursor + 1;
+      while (line[end] === "`") end++;
+      const markerSize = end - cursor;
+      if (!inCode) {
+        inCode = true;
+        codeMarkerSize = markerSize;
+      } else if (markerSize === codeMarkerSize) {
+        inCode = false;
+        codeMarkerSize = 0;
+      }
+      result += line.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+
+    if (!inCode && line.startsWith("\\(", cursor)) {
+      const closing = line.indexOf("\\)", cursor + 2);
+      if (closing !== -1) {
+        result += `$${line.slice(cursor + 2, closing)}$`;
+        cursor = closing + 2;
+        continue;
+      }
+    }
+
+    result += line[cursor];
+    cursor++;
+  }
+
+  return result;
 }
 
 function MermaidBlock({ code, isStreaming }: { code: string; isStreaming?: boolean }) {


### PR DESCRIPTION
## Problem

Pi Web already renders KaTeX for `$...$` and `$$...$$`, but model
responses commonly use `\(...\)` and `\[...\]`. These delimiters were
displayed as plain text.

## Changes

- Normalize `\(...\)` to inline math syntax.
- Normalize `\[...\]` to display math syntax.
- Preserve delimiters inside inline and fenced code blocks.
- Add rendering and regression tests.

## Validation

- `node --test components/MarkdownBody.test.mjs`
- `npx tsc --noEmit`
- `npm run build`

## 简言之，我修改了数学公式渲染功能，请审核。如果修改合适，请把它合并到官方版本。