### PR TITLE
feat: add browsable directory picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ app/
   api/
     agent/          # creates/drives AgentSession and exposes SSE events
     auth/           # OAuth and API key management
+    cwd/browse/     # browsable server directory listing
     cwd/validate/   # custom working directory validation
     default-cwd/    # pi default working directory lookup
     files/          # file listing, reading, preview, and watching
@@ -113,6 +114,7 @@ app/
 components/
   AppShell.tsx        # main layout, URL state, top panels, file tabs
   SessionSidebar.tsx  # project selector, session tree, Explorer
+  DirectoryPicker.tsx # browsable and editable working-directory picker
   ChatWindow.tsx      # messages, SSE, image drag/drop, minimap
   ChatInput.tsx       # input bar, model/tools/thinking/compact/slash controls
   MessageView.tsx     # message, thinking, tool call/result rendering
@@ -121,6 +123,7 @@ components/
   FileExplorer.tsx    # file tree
   FileViewer.tsx      # source, diff, image, audio, PDF, DOCX preview
 lib/
+  directory-browser.ts # directory normalization and safe listing helpers
   http-dispatcher.ts  # HTTP(S) proxy setup for server-side fetch
   rpc-manager.ts      # AgentSessionWrapper lifecycle and global registry
   session-reader.ts   # parses .jsonl session files and branch contexts

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,6 +98,7 @@ app/
   api/
     agent/          # 创建/驱动 AgentSession，提供 SSE 事件流
     auth/           # OAuth 和 API key 管理
+    cwd/browse/     # 服务端目录浏览
     cwd/validate/   # 自定义工作目录校验
     default-cwd/    # 获取 pi 默认工作目录
     files/          # 文件列表、读取、预览、watch
@@ -109,6 +110,7 @@ app/
 components/
   AppShell.tsx        # 主布局、URL 状态、顶部面板、文件标签
   SessionSidebar.tsx  # 项目选择、会话树、Explorer
+  DirectoryPicker.tsx # 支持浏览和路径输入的工作目录选择器
   ChatWindow.tsx      # 消息区、SSE、拖拽图片、minimap
   ChatInput.tsx       # 输入栏、模型/工具/thinking/compact/slash controls
   MessageView.tsx     # 消息、thinking、tool call/result 渲染
@@ -117,6 +119,7 @@ components/
   FileExplorer.tsx    # 文件树
   FileViewer.tsx      # 源码、diff、图片、音频、PDF、DOCX 预览
 lib/
+  directory-browser.ts # 目录规范化和安全枚举工具
   http-dispatcher.ts  # 服务端 fetch 的 HTTP(S) 代理配置
   rpc-manager.ts      # AgentSessionWrapper 生命周期和全局 registry
   session-reader.ts   # 解析 .jsonl 会话文件和分支上下文

--- a/app/api/cwd/browse/route.ts
+++ b/app/api/cwd/browse/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { stat } from "fs/promises";
+import path from "path";
+import { listDirectories, resolveDirectory } from "@/lib/directory-browser";
+
+// GET /api/cwd/browse?path=...：列出文件系统中的可读子目录。
+export async function GET(request: NextRequest) {
+  try {
+    const requested = request.nextUrl.searchParams.get("path")?.trim();
+    const filesystemRoot = path.parse(process.cwd()).root;
+    const candidate = requested || filesystemRoot;
+
+    let resolved: string;
+    try {
+      resolved = await resolveDirectory(candidate);
+    } catch {
+      return NextResponse.json({ error: "Directory does not exist" }, { status: 404 });
+    }
+
+
+    const directoryStat = await stat(resolved);
+    if (!directoryStat.isDirectory()) {
+      return NextResponse.json({ error: "Path is not a directory" }, { status: 400 });
+    }
+
+    const directories = await listDirectories(resolved);
+
+    return NextResponse.json({ path: resolved, directories });
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/app/api/cwd/browse/route.ts
+++ b/app/api/cwd/browse/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { stat } from "fs/promises";
-import path from "path";
-import { listDirectories, resolveDirectory } from "@/lib/directory-browser";
+import {
+  getBrowseStartDirectory,
+  getParentDirectory,
+  listDirectories,
+  resolveDirectory,
+} from "@/lib/directory-browser";
 
 // GET /api/cwd/browse?path=...：列出文件系统中的可读子目录。
 export async function GET(request: NextRequest) {
   try {
     const requested = request.nextUrl.searchParams.get("path")?.trim();
-    const filesystemRoot = path.parse(process.cwd()).root;
-    const candidate = requested || filesystemRoot;
+    const candidate = getBrowseStartDirectory(requested);
 
     let resolved: string;
     try {
@@ -25,7 +28,11 @@ export async function GET(request: NextRequest) {
 
     const directories = await listDirectories(resolved);
 
-    return NextResponse.json({ path: resolved, directories });
+    return NextResponse.json({
+      path: resolved,
+      parentPath: getParentDirectory(resolved),
+      directories,
+    });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -781,7 +781,4 @@ span.linenumber {
     flex-wrap: wrap;
     padding-bottom: max(10px, env(safe-area-inset-bottom)) !important;
   }
-  .directory-picker-footer > div {
-    flex-basis: 100%;
-  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -524,6 +524,11 @@ pre, code {
   outline-offset: -2px;
 }
 
+.directory-picker-path:focus-visible {
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
 @media (max-width: 640px) {
   .file-viewer-meta {
     display: none;
@@ -750,5 +755,28 @@ span.linenumber {
     min-width: 0 !important;
     border-left: none !important;
     display: none !important;
+  }
+  .directory-picker-backdrop {
+    align-items: stretch !important;
+    padding: max(8px, env(safe-area-inset-top)) 0 max(8px, env(safe-area-inset-bottom)) !important;
+  }
+  .directory-picker-panel {
+    width: 100% !important;
+    max-height: none !important;
+    border-radius: 0 !important;
+    border-left: 0 !important;
+    border-right: 0 !important;
+  }
+  .directory-picker-back,
+  .directory-picker-entry,
+  .directory-picker-action {
+    min-height: 44px !important;
+  }
+  .directory-picker-footer {
+    flex-wrap: wrap;
+    padding-bottom: max(10px, env(safe-area-inset-bottom)) !important;
+  }
+  .directory-picker-footer > div {
+    flex-basis: 100%;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -762,7 +762,9 @@ span.linenumber {
   }
   .directory-picker-panel {
     width: 100% !important;
+    height: auto !important;
     max-height: none !important;
+    align-self: stretch;
     border-radius: 0 !important;
     border-left: 0 !important;
     border-right: 0 !important;
@@ -771,6 +773,9 @@ span.linenumber {
   .directory-picker-entry,
   .directory-picker-action {
     min-height: 44px !important;
+  }
+  .directory-picker-back {
+    min-width: 44px !important;
   }
   .directory-picker-footer {
     flex-wrap: wrap;

--- a/components/DirectoryPicker.tsx
+++ b/components/DirectoryPicker.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+
+interface DirectoryEntry {
+  name: string;
+  path: string;
+}
+
+interface BrowseResponse {
+  path?: string;
+  directories?: DirectoryEntry[];
+  error?: string;
+}
+
+async function loadDirectories(directory?: string): Promise<BrowseResponse> {
+  const query = directory ? `?path=${encodeURIComponent(directory)}` : "";
+  const response = await fetch(`/api/cwd/browse${query}`);
+  const data = await response.json() as BrowseResponse;
+  if (!response.ok || data.error) throw new Error(data.error ?? `HTTP ${response.status}`);
+  return data;
+}
+
+function parentPath(directory: string): string {
+  if (!directory || directory === "/") return "/";
+  const normalized = directory.replace(/\/+$/, "");
+  const separator = normalized.lastIndexOf("/");
+  return separator <= 0 ? "/" : normalized.slice(0, separator);
+}
+
+function FolderIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden="true">
+      <path d="M1.5 3h4l1.5 2h7.5v7.5h-13z" />
+    </svg>
+  );
+}
+
+interface Props {
+  onCancel: () => void;
+  onSelect: (path: string) => void;
+  busy?: boolean;
+  error?: string | null;
+}
+
+export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Props) {
+  const [currentPath, setCurrentPath] = useState("");
+  const [pathInput, setPathInput] = useState("");
+  const [selectedPath, setSelectedPath] = useState("");
+  const [directories, setDirectories] = useState<DirectoryEntry[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const navigateTo = useCallback(async (directory?: string) => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await loadDirectories(directory);
+      const nextPath = data.path ?? directory ?? "/";
+      setCurrentPath(nextPath);
+      setPathInput(nextPath);
+      setSelectedPath(nextPath);
+      setDirectories(data.directories ?? []);
+    } catch (cause) {
+      setLoadError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void navigateTo();
+  }, [navigateTo]);
+
+  const handlePathSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const candidate = pathInput.trim();
+    if (candidate) void navigateTo(candidate);
+  };
+
+  return (
+    <div className="directory-picker-backdrop" role="dialog" aria-modal="true" aria-label="Select directory" onClick={(event) => event.stopPropagation()} style={{ position: "fixed", inset: 0, zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, background: "rgba(0,0,0,0.38)" }}>
+      <div className="directory-picker-panel" style={{ width: "min(520px, 100%)", maxHeight: "min(620px, 85vh)", display: "flex", flexDirection: "column", background: "var(--bg)", border: "1px solid var(--border)", borderRadius: 8, boxShadow: "0 18px 50px rgba(0,0,0,0.25)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
+          <button className="directory-picker-back" type="button" onClick={() => void navigateTo(parentPath(currentPath))} disabled={loading || currentPath === "/"} title="Back to parent directory" aria-label="Back to parent directory" style={{ width: 28, height: 28, padding: 0, flexShrink: 0, border: "1px solid var(--border)", borderRadius: 5, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: currentPath === "/" ? "default" : "pointer", opacity: currentPath === "/" ? 0.45 : 1, fontSize: 17 }}>
+            ←
+          </button>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{ color: "var(--text)", fontWeight: 600, fontSize: 13 }}>Select directory</div>
+            <div title={currentPath} style={{ marginTop: 3, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{currentPath || "Loading…"}</div>
+          </div>
+        </div>
+
+        <form onSubmit={handlePathSubmit} style={{ display: "flex", gap: 8, padding: "10px 12px", borderBottom: "1px solid var(--border)" }}>
+          <label htmlFor="directory-path" style={{ position: "absolute", width: 1, height: 1, padding: 0, margin: -1, overflow: "hidden", clip: "rect(0, 0, 0, 0)", whiteSpace: "nowrap", border: 0 }}>
+            Directory path
+          </label>
+          <input
+            className="directory-picker-path"
+            id="directory-path"
+            type="text"
+            value={pathInput}
+            placeholder="/path/to/project or ~/project"
+            autoComplete="off"
+            spellCheck={false}
+            onChange={(event) => {
+              setPathInput(event.target.value);
+              setSelectedPath(event.target.value.trim());
+              setLoadError(null);
+            }}
+            style={{ minWidth: 0, flex: 1, height: 36, padding: "0 10px", border: "1px solid var(--border)", borderRadius: 6, outline: "none", background: "var(--bg-panel)", color: "var(--text)", fontFamily: "var(--font-mono)", fontSize: 12 }}
+          />
+          <button
+            className="directory-picker-action"
+            type="submit"
+            disabled={loading || !pathInput.trim()}
+            title="Open directory"
+            style={{ minWidth: 58, height: 36, padding: "0 12px", border: "1px solid var(--border)", borderRadius: 6, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: loading || !pathInput.trim() ? "default" : "pointer", opacity: loading || !pathInput.trim() ? 0.6 : 1 }}
+          >
+            Open
+          </button>
+        </form>
+
+        <div style={{ minHeight: 260, overflow: "auto", padding: "8px 10px" }}>
+          {loading ? (
+            <div style={{ padding: 8, color: "var(--text-dim)", fontSize: 11 }}>Loading directories…</div>
+          ) : directories.length > 0 ? (
+            directories.map((entry) => (
+              <button
+                key={entry.path}
+                className="directory-picker-entry"
+                type="button"
+                onClick={() => setSelectedPath(entry.path)}
+                onDoubleClick={() => void navigateTo(entry.path)}
+                title={`${entry.path} — double-click to open`}
+                style={{ width: "100%", minHeight: 30, display: "flex", alignItems: "center", gap: 7, padding: "5px 8px", border: 0, borderRadius: 5, background: selectedPath === entry.path ? "var(--bg-selected)" : "none", color: selectedPath === entry.path ? "var(--text)" : "var(--text-muted)", cursor: "pointer", textAlign: "left", fontFamily: "var(--font-mono)", fontSize: 11 }}
+              >
+                <FolderIcon />
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.name}</span>
+              </button>
+            ))
+          ) : (
+            <div style={{ padding: 8, color: "var(--text-dim)", fontSize: 11 }}>No subdirectories</div>
+          )}
+          {(loadError || error) && <div style={{ padding: "8px", color: "#dc2626", fontSize: 11 }}>{loadError ?? error}</div>}
+        </div>
+
+        <div className="directory-picker-footer" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, padding: "10px 12px", borderTop: "1px solid var(--border)" }}>
+          <div title={selectedPath} style={{ minWidth: 0, flex: 1, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{selectedPath}</div>
+          <button className="directory-picker-action" type="button" onClick={onCancel} disabled={busy} style={{ padding: "6px 12px", border: "1px solid var(--border)", borderRadius: 6, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: "pointer" }}>Cancel</button>
+          <button className="directory-picker-action" type="button" onClick={() => onSelect(selectedPath)} disabled={busy || !selectedPath} style={{ padding: "6px 12px", border: 0, borderRadius: 6, background: "var(--accent)", color: "#fff", fontWeight: 600, opacity: busy || !selectedPath ? 0.6 : 1, cursor: "pointer" }}>{busy ? "Checking…" : "Select"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DirectoryPicker.tsx
+++ b/components/DirectoryPicker.tsx
@@ -74,6 +74,8 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
     const candidate = pathInput.trim();
     if (candidate) void navigateTo(candidate);
   };
+  const hasUncommittedPath = pathInput.trim() !== currentPath;
+  const canSelect = Boolean(currentPath) && !hasUncommittedPath && !busy;
 
   if (!portalTarget) return null;
 
@@ -98,7 +100,6 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
           </button>
           <div style={{ minWidth: 0, flex: 1 }}>
             <div style={{ color: "var(--text)", fontWeight: 600, fontSize: 13 }}>Select directory</div>
-            <div title={currentPath} style={{ marginTop: 3, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{currentPath || "Loading…"}</div>
           </div>
         </div>
 
@@ -155,10 +156,18 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
           {(loadError || error) && <div style={{ padding: "8px", color: "#dc2626", fontSize: 11 }}>{loadError ?? error}</div>}
         </div>
 
-        <div className="directory-picker-footer" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, flexShrink: 0, padding: "10px 12px", borderTop: "1px solid var(--border)" }}>
-          <div title={currentPath} style={{ minWidth: 0, flex: 1, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{currentPath}</div>
+        <div className="directory-picker-footer" style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 8, flexShrink: 0, padding: "10px 12px", borderTop: "1px solid var(--border)" }}>
           <button className="directory-picker-action" type="button" onClick={onCancel} disabled={busy} style={{ padding: "6px 12px", border: "1px solid var(--border)", borderRadius: 6, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: "pointer" }}>Cancel</button>
-          <button className="directory-picker-action" type="button" onClick={() => onSelect(currentPath)} disabled={busy || !currentPath} style={{ padding: "6px 12px", border: 0, borderRadius: 6, background: "var(--accent)", color: "#fff", fontWeight: 600, opacity: busy || !currentPath ? 0.6 : 1, cursor: "pointer" }}>{busy ? "Checking…" : "Select this folder"}</button>
+          <button
+            className="directory-picker-action"
+            type="button"
+            onClick={() => onSelect(currentPath)}
+            disabled={!canSelect}
+            title={hasUncommittedPath ? "Open this path before selecting it" : "Select current directory"}
+            style={{ padding: "6px 12px", border: 0, borderRadius: 6, background: "var(--accent)", color: "#fff", fontWeight: 600, opacity: canSelect ? 1 : 0.6, cursor: canSelect ? "pointer" : "default" }}
+          >
+            {busy ? "Checking…" : "Select this folder"}
+          </button>
         </div>
       </div>
     </div>,

--- a/components/DirectoryPicker.tsx
+++ b/components/DirectoryPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface DirectoryEntry {
   name: string;
@@ -9,6 +10,7 @@ interface DirectoryEntry {
 
 interface BrowseResponse {
   path?: string;
+  parentPath?: string | null;
   directories?: DirectoryEntry[];
   error?: string;
 }
@@ -19,13 +21,6 @@ async function loadDirectories(directory?: string): Promise<BrowseResponse> {
   const data = await response.json() as BrowseResponse;
   if (!response.ok || data.error) throw new Error(data.error ?? `HTTP ${response.status}`);
   return data;
-}
-
-function parentPath(directory: string): string {
-  if (!directory || directory === "/") return "/";
-  const normalized = directory.replace(/\/+$/, "");
-  const separator = normalized.lastIndexOf("/");
-  return separator <= 0 ? "/" : normalized.slice(0, separator);
 }
 
 function FolderIcon() {
@@ -44,9 +39,10 @@ interface Props {
 }
 
 export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Props) {
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   const [currentPath, setCurrentPath] = useState("");
+  const [parentDirectory, setParentDirectory] = useState<string | null>(null);
   const [pathInput, setPathInput] = useState("");
-  const [selectedPath, setSelectedPath] = useState("");
   const [directories, setDirectories] = useState<DirectoryEntry[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -58,8 +54,8 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
       const data = await loadDirectories(directory);
       const nextPath = data.path ?? directory ?? "/";
       setCurrentPath(nextPath);
+      setParentDirectory(data.parentPath ?? null);
       setPathInput(nextPath);
-      setSelectedPath(nextPath);
       setDirectories(data.directories ?? []);
     } catch (cause) {
       setLoadError(cause instanceof Error ? cause.message : String(cause));
@@ -69,6 +65,7 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
   }, []);
 
   useEffect(() => {
+    setPortalTarget(document.body);
     void navigateTo();
   }, [navigateTo]);
 
@@ -78,12 +75,26 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
     if (candidate) void navigateTo(candidate);
   };
 
-  return (
-    <div className="directory-picker-backdrop" role="dialog" aria-modal="true" aria-label="Select directory" onClick={(event) => event.stopPropagation()} style={{ position: "fixed", inset: 0, zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, background: "rgba(0,0,0,0.38)" }}>
-      <div className="directory-picker-panel" style={{ width: "min(520px, 100%)", maxHeight: "min(620px, 85vh)", display: "flex", flexDirection: "column", background: "var(--bg)", border: "1px solid var(--border)", borderRadius: 8, boxShadow: "0 18px 50px rgba(0,0,0,0.25)" }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
-          <button className="directory-picker-back" type="button" onClick={() => void navigateTo(parentPath(currentPath))} disabled={loading || currentPath === "/"} title="Back to parent directory" aria-label="Back to parent directory" style={{ width: 28, height: 28, padding: 0, flexShrink: 0, border: "1px solid var(--border)", borderRadius: 5, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: currentPath === "/" ? "default" : "pointer", opacity: currentPath === "/" ? 0.45 : 1, fontSize: 17 }}>
-            ←
+  if (!portalTarget) return null;
+
+  return createPortal(
+    <div
+      className="directory-picker-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Select directory"
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && !busy) onCancel();
+      }}
+      style={{ position: "fixed", inset: 0, zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, background: "rgba(0,0,0,0.38)" }}
+    >
+      <div className="directory-picker-panel" style={{ width: "min(520px, 100%)", height: "min(620px, calc(100dvh - 32px))", display: "flex", flexDirection: "column", background: "var(--bg)", border: "1px solid var(--border)", borderRadius: 8, boxShadow: "0 18px 50px rgba(0,0,0,0.25)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
+          <button className="directory-picker-back" type="button" onClick={() => parentDirectory && void navigateTo(parentDirectory)} disabled={loading || !parentDirectory} title="Back to parent directory" aria-label="Back to parent directory" style={{ width: 28, height: 28, padding: 0, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0, border: "1px solid var(--border)", borderRadius: 5, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: parentDirectory ? "pointer" : "default", opacity: parentDirectory ? 1 : 0.45 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="m15 18-6-6 6-6" />
+            </svg>
           </button>
           <div style={{ minWidth: 0, flex: 1 }}>
             <div style={{ color: "var(--text)", fontWeight: 600, fontSize: 13 }}>Select directory</div>
@@ -91,7 +102,7 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
           </div>
         </div>
 
-        <form onSubmit={handlePathSubmit} style={{ display: "flex", gap: 8, padding: "10px 12px", borderBottom: "1px solid var(--border)" }}>
+        <form onSubmit={handlePathSubmit} style={{ display: "flex", gap: 8, flexShrink: 0, padding: "10px 12px", borderBottom: "1px solid var(--border)" }}>
           <label htmlFor="directory-path" style={{ position: "absolute", width: 1, height: 1, padding: 0, margin: -1, overflow: "hidden", clip: "rect(0, 0, 0, 0)", whiteSpace: "nowrap", border: 0 }}>
             Directory path
           </label>
@@ -101,11 +112,11 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
             type="text"
             value={pathInput}
             placeholder="/path/to/project or ~/project"
+            autoFocus
             autoComplete="off"
             spellCheck={false}
             onChange={(event) => {
               setPathInput(event.target.value);
-              setSelectedPath(event.target.value.trim());
               setLoadError(null);
             }}
             style={{ minWidth: 0, flex: 1, height: 36, padding: "0 10px", border: "1px solid var(--border)", borderRadius: 6, outline: "none", background: "var(--bg-panel)", color: "var(--text)", fontFamily: "var(--font-mono)", fontSize: 12 }}
@@ -121,7 +132,7 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
           </button>
         </form>
 
-        <div style={{ minHeight: 260, overflow: "auto", padding: "8px 10px" }}>
+        <div className="directory-picker-list" style={{ flex: 1, minHeight: 0, overflow: "auto", padding: "8px 10px" }}>
           {loading ? (
             <div style={{ padding: 8, color: "var(--text-dim)", fontSize: 11 }}>Loading directories…</div>
           ) : directories.length > 0 ? (
@@ -130,10 +141,9 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
                 key={entry.path}
                 className="directory-picker-entry"
                 type="button"
-                onClick={() => setSelectedPath(entry.path)}
-                onDoubleClick={() => void navigateTo(entry.path)}
-                title={`${entry.path} — double-click to open`}
-                style={{ width: "100%", minHeight: 30, display: "flex", alignItems: "center", gap: 7, padding: "5px 8px", border: 0, borderRadius: 5, background: selectedPath === entry.path ? "var(--bg-selected)" : "none", color: selectedPath === entry.path ? "var(--text)" : "var(--text-muted)", cursor: "pointer", textAlign: "left", fontFamily: "var(--font-mono)", fontSize: 11 }}
+                onClick={() => void navigateTo(entry.path)}
+                title={entry.path}
+                style={{ width: "100%", minHeight: 30, display: "flex", alignItems: "center", gap: 7, padding: "5px 8px", border: 0, borderRadius: 5, background: "none", color: "var(--text-muted)", cursor: "pointer", textAlign: "left", fontFamily: "var(--font-mono)", fontSize: 11 }}
               >
                 <FolderIcon />
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.name}</span>
@@ -145,12 +155,13 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
           {(loadError || error) && <div style={{ padding: "8px", color: "#dc2626", fontSize: 11 }}>{loadError ?? error}</div>}
         </div>
 
-        <div className="directory-picker-footer" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, padding: "10px 12px", borderTop: "1px solid var(--border)" }}>
-          <div title={selectedPath} style={{ minWidth: 0, flex: 1, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{selectedPath}</div>
+        <div className="directory-picker-footer" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, flexShrink: 0, padding: "10px 12px", borderTop: "1px solid var(--border)" }}>
+          <div title={currentPath} style={{ minWidth: 0, flex: 1, color: "var(--text-dim)", fontFamily: "var(--font-mono)", fontSize: 10, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{currentPath}</div>
           <button className="directory-picker-action" type="button" onClick={onCancel} disabled={busy} style={{ padding: "6px 12px", border: "1px solid var(--border)", borderRadius: 6, background: "var(--bg-hover)", color: "var(--text-muted)", cursor: "pointer" }}>Cancel</button>
-          <button className="directory-picker-action" type="button" onClick={() => onSelect(selectedPath)} disabled={busy || !selectedPath} style={{ padding: "6px 12px", border: 0, borderRadius: 6, background: "var(--accent)", color: "#fff", fontWeight: 600, opacity: busy || !selectedPath ? 0.6 : 1, cursor: "pointer" }}>{busy ? "Checking…" : "Select"}</button>
+          <button className="directory-picker-action" type="button" onClick={() => onSelect(currentPath)} disabled={busy || !currentPath} style={{ padding: "6px 12px", border: 0, borderRadius: 6, background: "var(--accent)", color: "#fff", fontWeight: 600, opacity: busy || !currentPath ? 0.6 : 1, cursor: "pointer" }}>{busy ? "Checking…" : "Select this folder"}</button>
         </div>
       </div>
-    </div>
+    </div>,
+    portalTarget,
   );
 }

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useLayoutEffect, useState, useCallback, useRef, type CSSProperties, type ReactNode } from "react";
 import type { SessionInfo } from "@/lib/types";
+import { DirectoryPicker } from "./DirectoryPicker";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
 
 declare global {
@@ -333,7 +334,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [customPathValue, setCustomPathValue] = useState("");
   const [customPathError, setCustomPathError] = useState<string | null>(null);
   const [customPathValidating, setCustomPathValidating] = useState(false);
-  const customPathInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   // Worktree switcher state
   const [worktreeState, setWorktreeState] = useState<WorktreeState | null>(null);
@@ -584,30 +584,11 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     }
   }, [customPathValue, customPathValidating]);
 
-  const handleCustomPathClick = useCallback(async () => {
-    const desktop = window.piDesktop;
-    if (!desktop) {
-      setCustomPathOpen(true);
-      setCustomPathError(null);
-      setTimeout(() => customPathInputRef.current?.focus(), 0);
-      return;
-    }
-
-    try {
-      setCustomPathError(null);
-      const path = await desktop.selectDirectory();
-      if (path === null) return;
-
-      setCustomPathValue(path);
-      setCustomPathOpen(true);
-      await commitCustomPath(path);
-    } catch (e) {
-      setCustomPathOpen(true);
-      setCustomPathError(e instanceof Error ? e.message : String(e));
-      setTimeout(() => customPathInputRef.current?.focus(), 0);
-    }
-  }, [commitCustomPath]);
-
+  const handleCustomPathClick = useCallback(() => {
+    setCustomPathOpen(true);
+    setCustomPathError(null);
+    setDropdownOpen(false);
+  }, []);
   const handleDefaultCwd = useCallback(async () => {
     try {
       const res = await fetch("/api/default-cwd", { method: "POST" });
@@ -696,9 +677,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setDropdownOpen(false);
         setProjectFilter("");
-        setCustomPathOpen(false);
-        setCustomPathValue("");
-        setCustomPathError(null);
       }
       if (wtDropdownRef.current && !wtDropdownRef.current.contains(e.target as Node)) {
         setWtDropdownOpen(false);
@@ -776,6 +754,17 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      {customPathOpen && (
+        <DirectoryPicker
+          busy={customPathValidating}
+          error={customPathError}
+          onCancel={() => {
+            setCustomPathOpen(false);
+            setCustomPathError(null);
+          }}
+          onSelect={(path) => void commitCustomPath(path)}
+        />
+      )}
       {/* Header */}
       <div
         style={{
@@ -1029,115 +1018,32 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 </button>
               )}
 
-              {/* Custom path entry */}
-              {!customPathOpen ? (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleCustomPathClick();
-                  }}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 7,
-                    width: "100%",
-                    padding: "8px 10px",
-                    background: "none",
-                    border: "none",
-                    color: "var(--text-muted)",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    fontSize: 11,
-                  }}
-                >
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" style={{ flexShrink: 0 }}>
-                    <line x1="5" y1="1" x2="5" y2="9" />
-                    <line x1="1" y1="5" x2="9" y2="5" />
-                  </svg>
-                  <span>Custom path…</span>
-                </button>
-              ) : (
-                <div style={{ padding: "6px 8px", borderTop: visibleProjects.length > 0 ? "none" : undefined }}>
-                  <input
-                    ref={customPathInputRef}
-                    value={customPathValue}
-                    onChange={(e) => {
-                      setCustomPathValue(e.target.value);
-                      setCustomPathError(null);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        void commitCustomPath();
-                      }
-                      if (e.key === "Escape") {
-                        setCustomPathOpen(false);
-                        setCustomPathValue("");
-                        setCustomPathError(null);
-                      }
-                    }}
-                    placeholder="/path/to/project"
-                    style={{
-                      width: "100%",
-                      fontSize: 11,
-                      fontFamily: "var(--font-mono)",
-                      padding: "5px 8px",
-                      border: "1px solid var(--accent)",
-                      borderRadius: 5,
-                      outline: "none",
-                      background: "var(--bg)",
-                      color: "var(--text)",
-                      boxSizing: "border-box",
-                    }}
-                  />
-                  {customPathError && (
-                    <div style={{
-                      marginTop: 5,
-                      color: "#dc2626",
-                      fontSize: 11,
-                      lineHeight: 1.35,
-                      overflowWrap: "anywhere",
-                    }}>
-                      {customPathError}
-                    </div>
-                  )}
-                  <div style={{ display: "flex", gap: 5, marginTop: 5 }}>
-                    <button
-                      onClick={() => void commitCustomPath()}
-                      disabled={customPathValidating || !customPathValue.trim()}
-                      style={{
-                        flex: 1,
-                        padding: "4px 0",
-                        background: "var(--accent)",
-                        border: "none",
-                        borderRadius: 5,
-                        color: "#fff",
-                        fontSize: 11,
-                        fontWeight: 600,
-                        cursor: customPathValidating || !customPathValue.trim() ? "not-allowed" : "pointer",
-                        opacity: customPathValidating || !customPathValue.trim() ? 0.65 : 1,
-                      }}
-                    >
-                      {customPathValidating ? "Checking…" : "Open"}
-                    </button>
-                    <button
-                      onClick={() => { setCustomPathOpen(false); setCustomPathValue(""); setCustomPathError(null); }}
-                      style={{
-                        flex: 1,
-                        padding: "4px 0",
-                        background: "var(--bg-hover)",
-                        border: "1px solid var(--border)",
-                        borderRadius: 5,
-                        color: "var(--text-muted)",
-                        fontSize: 11,
-                        cursor: "pointer",
-                      }}
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              )}
+              {/* Custom path directory picker */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCustomPathClick();
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 7,
+                  width: "100%",
+                  padding: "8px 10px",
+                  background: "none",
+                  border: "none",
+                  color: "var(--text-muted)",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  fontSize: 11,
+                }}
+              >
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" style={{ flexShrink: 0 }}>
+                  <line x1="5" y1="1" x2="5" y2="9" />
+                  <line x1="1" y1="5" x2="9" y2="5" />
+                </svg>
+                <span>Custom path…</span>
+              </button>
           </AnimatedDropdown>
         </div>
 

--- a/lib/directory-browser.test.mjs
+++ b/lib/directory-browser.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+async function loadSubject() {
+  return import("./directory-browser.ts");
+}
+
+test("lists directories and directory symlinks without returning files", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "pi-web-browse-"));
+  try {
+    await mkdir(path.join(root, "project"));
+    await writeFile(path.join(root, "notes.txt"), "test", "utf8");
+    await symlink(path.join(root, "project"), path.join(root, "linked-project"));
+
+    const { listDirectories } = await loadSubject();
+    const directories = await listDirectories(root);
+
+    assert.deepEqual(directories.map((entry) => entry.name), ["linked-project", "project"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("expands home-relative paths and rejects missing directories", async () => {
+  const { normalizeDirectory, resolveDirectory } = await loadSubject();
+  assert.equal(normalizeDirectory("~/project"), path.join(homedir(), "project"));
+  await assert.rejects(resolveDirectory(path.join(tmpdir(), `pi-web-missing-${Date.now()}`)));
+});

--- a/lib/directory-browser.test.mjs
+++ b/lib/directory-browser.test.mjs
@@ -25,7 +25,18 @@ test("lists directories and directory symlinks without returning files", async (
 });
 
 test("expands home-relative paths and rejects missing directories", async () => {
-  const { normalizeDirectory, resolveDirectory } = await loadSubject();
+  const { getBrowseStartDirectory, normalizeDirectory, resolveDirectory } = await loadSubject();
+  assert.equal(getBrowseStartDirectory(), homedir());
+  assert.equal(getBrowseStartDirectory("/project"), "/project");
   assert.equal(normalizeDirectory("~/project"), path.join(homedir(), "project"));
   await assert.rejects(resolveDirectory(path.join(tmpdir(), `pi-web-missing-${Date.now()}`)));
+});
+
+test("finds parent directories across POSIX and Windows paths", async () => {
+  const { getParentDirectory } = await loadSubject();
+
+  assert.equal(getParentDirectory("/Users/alex/project"), "/Users/alex");
+  assert.equal(getParentDirectory("/"), null);
+  assert.equal(getParentDirectory("C:\\Users\\Alex\\project"), "C:\\Users\\Alex");
+  assert.equal(getParentDirectory("C:\\"), null);
 });

--- a/lib/directory-browser.ts
+++ b/lib/directory-browser.ts
@@ -7,10 +7,23 @@ export interface BrowsableDirectory {
   path: string;
 }
 
+export function getBrowseStartDirectory(directory?: string): string {
+  return directory || homedir();
+}
+
 export function normalizeDirectory(directory: string): string {
   if (directory === "~") return homedir();
   if (directory.startsWith("~/")) return path.resolve(homedir(), directory.slice(2));
   return path.resolve(directory);
+}
+
+export function getParentDirectory(directory: string): string | null {
+  const pathApi = /^[a-zA-Z]:[\\/]/.test(directory) || directory.startsWith("\\\\")
+    ? path.win32
+    : path;
+  const normalized = pathApi.normalize(directory);
+  const parent = pathApi.dirname(normalized);
+  return parent === normalized ? null : parent;
 }
 
 export async function resolveDirectory(directory: string): Promise<string> {

--- a/lib/directory-browser.ts
+++ b/lib/directory-browser.ts
@@ -1,0 +1,43 @@
+import { readdir, realpath, stat } from "fs/promises";
+import { homedir } from "os";
+import path from "path";
+
+export interface BrowsableDirectory {
+  name: string;
+  path: string;
+}
+
+export function normalizeDirectory(directory: string): string {
+  if (directory === "~") return homedir();
+  if (directory.startsWith("~/")) return path.resolve(homedir(), directory.slice(2));
+  return path.resolve(directory);
+}
+
+export async function resolveDirectory(directory: string): Promise<string> {
+  return realpath(normalizeDirectory(directory));
+}
+
+export async function listDirectories(directory: string): Promise<BrowsableDirectory[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  // 忽略损坏、不可访问或不指向目录的符号链接。
+  const candidates = await Promise.all(entries.map(async (entry) => {
+    if (entry.isDirectory()) {
+      return { name: entry.name, path: path.join(directory, entry.name) };
+    }
+    if (!entry.isSymbolicLink()) return null;
+
+    try {
+      const entryPath = path.join(directory, entry.name);
+      const realEntryPath = await realpath(entryPath);
+      const entryStat = await stat(realEntryPath);
+      if (!entryStat.isDirectory()) return null;
+      return { name: entry.name, path: entryPath };
+    } catch {
+      return null;
+    }
+  }));
+
+  return candidates
+    .filter((entry): entry is BrowsableDirectory => entry !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}


### PR DESCRIPTION
## Summary

- replace the inline custom-path field with a browsable directory picker
- support direct absolute and `~/...` path entry alongside folder navigation
- resolve directory symlinks, ignore broken/inaccessible links, and sort results
- adapt the picker to mobile safe areas and touch target sizes
- document the new route and component in both READMEs

## Testing

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `node --test lib/directory-browser.test.mjs`

## Notes

The selected path still goes through the existing `/api/cwd/validate` boundary before it becomes an allowed workspace root.
