### PR TITLE
feat: add Telegram bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ npx @agegr/pi-web@latest
 
 ## Features
 
+- **Telegram bridge** — connect an allow-listed Telegram user or group to Pi. Configure the bot token, chat IDs, and working directory from the Telegram panel in the sidebar; each chat keeps an independent Pi session and supports `/new`, `/status`, and `/help`.
+
 - **Pick work back up**: browse previous pi conversations by project without digging through terminal history or session paths.
 - **Try different directions safely**: continue from an earlier message or fork a session into a separate route.
 - **Work across branches**: switch Git worktrees from the sidebar so new sessions and the Explorer follow the checkout you choose.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,8 @@ npx @agegr/pi-web@latest
 
 ## 功能介绍
 
+- **Telegram 桥接**：将允许列表中的 Telegram 用户或群组连接到 Pi。在侧边栏的 Telegram 面板中配置 Bot Token、Chat ID 和工作目录；每个聊天保持独立的 Pi 会话，并支持 `/new`、`/status` 和 `/help`。
+
 - **把历史工作接回来**：打开网页就能按项目找到以前的 pi 对话，不必在终端里翻文件或记住会话路径。
 - **放心试不同方向**：可以从某条历史消息重新开始，也可以复制出一条独立的新路线，探索方案时不怕弄乱原来的对话。
 - **跨分支工作**：在侧边栏切换 Git worktree，让新会话和 Explorer 跟随你选择的 checkout。

--- a/app/api/telegram/route.ts
+++ b/app/api/telegram/route.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { NextResponse } from "next/server";
+import { getTelegramBridge, testTelegramToken } from "@/lib/telegram-bridge";
+import {
+  normalizeAllowedChatIds,
+  readTelegramConfig,
+  toPublicTelegramConfig,
+  validateTelegramConfig,
+  writeTelegramConfig,
+} from "@/lib/telegram-config";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const config = readTelegramConfig();
+  return NextResponse.json({
+    config: toPublicTelegramConfig(config),
+    status: getTelegramBridge().getStatus(),
+  });
+}
+export async function PUT(req: Request) {
+  try {
+    const body = await req.json() as {
+      enabled?: unknown;
+      token?: unknown;
+      clearToken?: unknown;
+      allowedChatIds?: unknown;
+      cwd?: unknown;
+    };
+    const current = readTelegramConfig();
+    const next = {
+      enabled: body.enabled === true,
+      token: body.clearToken === true
+        ? ""
+        : typeof body.token === "string" && body.token.trim()
+          ? body.token.trim()
+          : current.token,
+      allowedChatIds: normalizeAllowedChatIds(body.allowedChatIds),
+      cwd: typeof body.cwd === "string" ? body.cwd.trim() : current.cwd,
+    };
+    const validationError = validateTelegramConfig(next);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    writeTelegramConfig(next);
+    await getTelegramBridge().restart();
+    return NextResponse.json({
+      config: toPublicTelegramConfig(next),
+      status: getTelegramBridge().getStatus(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json() as { action?: unknown; token?: unknown; cwd?: unknown };
+    if (body.action === "test") {
+      const saved = readTelegramConfig();
+      const token = typeof body.token === "string" && body.token.trim()
+        ? body.token.trim()
+        : saved.token;
+      if (!token) return NextResponse.json({ error: "Enter a bot token first." }, { status: 400 });
+      const bot = await testTelegramToken(token);
+      return NextResponse.json({ bot });
+    }
+    if (body.action === "validate-cwd") {
+      const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
+      return NextResponse.json({ valid: Boolean(cwd && existsSync(cwd)) });
+    }
+    return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { TabBar, type Tab } from "./TabBar";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
+import { TelegramConfig } from "./TelegramConfig";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -48,6 +49,7 @@ export function AppShell() {
   const [modelsRefreshKey, setModelsRefreshKey] = useState(0);
   const [skillsConfigOpen, setSkillsConfigOpen] = useState(false);
   const [pluginsConfigOpen, setPluginsConfigOpen] = useState(false);
+  const [telegramConfigOpen, setTelegramConfigOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);
   // On mobile the sidebar is an overlay drawer; hide it by default so the chat
@@ -490,6 +492,16 @@ export function AppShell() {
                 <path d="M15 7V2" />
                 <path d="M6 13V8a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v5a6 6 0 0 1-12 0Z" />
                 <path d="M12 19v3" />
+              </svg>
+            ),
+          },
+          {
+            label: "Telegram",
+            onClick: () => setTelegramConfigOpen(true),
+            disabled: false,
+            icon: (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M21.8 3.6 18.5 20c-.2 1.2-.9 1.5-1.9.9l-5-3.7-2.4 2.3c-.3.3-.5.5-1 .5l.4-5.1 9.2-8.3c.4-.4-.1-.6-.6-.2L5.8 13.5.9 12c-1.1-.3-1.1-1.1.2-1.6L20.3 3c.9-.3 1.7.2 1.5.6Z" />
               </svg>
             ),
           },
@@ -1283,6 +1295,12 @@ export function AppShell() {
         sessionId={selectedSession?.id ?? null}
         onClose={() => setPluginsConfigOpen(false)}
         onReloaded={() => setSessionKey((k) => k + 1)}
+      />
+    )}
+    {telegramConfigOpen && (
+      <TelegramConfig
+        defaultCwd={activeCwd ?? selectedSession?.cwd ?? newSessionCwd}
+        onClose={() => setTelegramConfigOpen(false)}
       />
     )}
     </>

--- a/components/TelegramConfig.tsx
+++ b/components/TelegramConfig.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+type PublicConfig = {
+  enabled: boolean;
+  allowedChatIds: string[];
+  cwd: string;
+  tokenConfigured: boolean;
+  tokenHint: string | null;
+};
+
+type BridgeStatus = {
+  running: boolean;
+  botUsername: string | null;
+  lastConnectedAt: string | null;
+  lastMessageAt: string | null;
+  lastError: string | null;
+};
+
+type TelegramResponse = {
+  config: PublicConfig;
+  status: BridgeStatus;
+  error?: string;
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  background: "var(--bg-panel)",
+  color: "var(--text)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  padding: "9px 10px",
+  outline: "none",
+};
+
+function buttonStyle(disabled = false, primary = false): React.CSSProperties {
+  return {
+    border: primary ? "1px solid var(--accent)" : "1px solid var(--border)",
+    borderRadius: 6,
+    background: primary ? "var(--accent)" : "var(--bg-panel)",
+    color: primary ? "white" : "var(--text)",
+    padding: "8px 13px",
+    fontSize: 12,
+    fontWeight: primary ? 600 : 400,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+  };
+}
+function formatTime(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | null; onClose: () => void }) {
+  const isMobile = useIsMobile();
+  const [config, setConfig] = useState<PublicConfig | null>(null);
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [token, setToken] = useState("");
+  const [chatIds, setChatIds] = useState("");
+  const [cwd, setCwd] = useState(defaultCwd ?? "");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const applyResponse = useCallback((data: TelegramResponse) => {
+    setConfig(data.config);
+    setStatus(data.status);
+    setEnabled(data.config.enabled);
+    setChatIds(data.config.allowedChatIds.join("\n"));
+    setCwd(data.config.cwd || defaultCwd || "");
+  }, [defaultCwd]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/telegram")
+      .then(async (res) => {
+        const data = await res.json() as TelegramResponse;
+        if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+        if (!cancelled) applyResponse(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [applyResponse]);
+
+  const testConnection = useCallback(async () => {
+    setTesting(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/telegram", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "test", token: token.trim() || undefined }),
+      });
+      const data = await res.json() as { bot?: { username: string; name: string }; error?: string };
+      if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+      setMessage(`Connected to ${data.bot?.name}${data.bot?.username ? ` (@${data.bot.username})` : ""}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTesting(false);
+    }
+  }, [token]);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/telegram", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled,
+          token: token.trim() || undefined,
+          allowedChatIds: chatIds,
+          cwd,
+        }),
+      });
+      const data = await res.json() as TelegramResponse;
+      if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+      applyResponse(data);
+      setToken("");
+      setMessage(enabled ? "Telegram bridge saved and started." : "Telegram bridge settings saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [applyResponse, chatIds, cwd, enabled, token]);
+
+  const busy = loading || saving || testing;
+  const statusColor = status?.running ? "#16a34a" : status?.lastError ? "#ef4444" : "var(--text-dim)";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: isMobile ? "calc(100vw - 16px)" : 720,
+          maxWidth: "calc(100vw - 16px)",
+          maxHeight: isMobile ? "calc(100dvh - 16px)" : "82vh",
+          background: "var(--bg)",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "13px 18px", borderBottom: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{ width: 28, height: 28, borderRadius: 8, display: "grid", placeItems: "center", background: "rgba(34,158,217,0.14)", color: "#229ED9" }}>
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M21.8 3.6 18.5 20c-.2 1.2-.9 1.5-1.9.9l-5-3.7-2.4 2.3c-.3.3-.5.5-1 .5l.4-5.1 9.2-8.3c.4-.4-.1-.6-.6-.2L5.8 13.5.9 12c-1.1-.3-1.1-1.1.2-1.6L20.3 3c.9-.3 1.7.2 1.5.6Z" />
+              </svg>
+            </span>
+            <div>
+              <div style={{ fontSize: 15, fontWeight: 700, color: "var(--text)" }}>Telegram Bridge</div>
+              <div style={{ marginTop: 2, fontSize: 11, color: "var(--text-dim)" }}>Talk to Pi from an allow-listed Telegram chat</div>
+            </div>
+          </div>
+          <button onClick={onClose} aria-label="Close" style={{ border: 0, background: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: 20, padding: "2px 6px" }}>×</button>
+        </div>
+
+        <div style={{ overflowY: "auto", padding: isMobile ? 15 : 20 }}>
+          {loading ? (
+            <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", fontSize: 12 }}>Loading Telegram settings...</div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  padding: "12px 14px",
+                  border: "1px solid var(--border)",
+                  borderRadius: 7,
+                  background: "var(--bg-panel)",
+                }}
+              >
+                <div>
+                  <div style={{ color: "var(--text)", fontSize: 13, fontWeight: 600 }}>Enable Telegram bridge</div>
+                  <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 3 }}>Starts secure long polling when Pi Web is running.</div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={enabled}
+                  onClick={() => setEnabled((value) => !value)}
+                  style={{
+                    width: 40,
+                    height: 22,
+                    padding: 2,
+                    border: 0,
+                    borderRadius: 12,
+                    cursor: "pointer",
+                    background: enabled ? "#229ED9" : "var(--border)",
+                    transition: "background 0.15s",
+                  }}
+                >
+                  <span style={{ display: "block", width: 18, height: 18, borderRadius: "50%", background: "white", transform: `translateX(${enabled ? 18 : 0}px)`, transition: "transform 0.15s", boxShadow: "0 1px 3px rgba(0,0,0,.25)" }} />
+                </button>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : "minmax(0, 1.25fr) minmax(210px, .75fr)", gap: 16 }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Bot token</div>
+                    <input
+                      type="password"
+                      autoComplete="off"
+                      value={token}
+                      onChange={(event) => setToken(event.target.value)}
+                      placeholder={config?.tokenConfigured ? `Saved ${config.tokenHint ?? ""} — leave blank to keep` : "123456789:AA..."}
+                      style={inputStyle}
+                    />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      Create a bot with @BotFather. The token stays on this machine and is never returned to the browser.
+                    </div>
+                  </label>
+
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Allowed chat IDs</div>
+                    <textarea
+                      value={chatIds}
+                      onChange={(event) => setChatIds(event.target.value)}
+                      placeholder={"123456789\n-1001234567890"}
+                      rows={3}
+                      style={{ ...inputStyle, resize: "vertical", minHeight: 72 }}
+                    />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      One numeric user or group chat ID per line. Messages from every other chat are ignored.
+                    </div>
+                  </label>
+
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Working directory</div>
+                    <input value={cwd} onChange={(event) => setCwd(event.target.value)} placeholder="C:\path\to\project" style={inputStyle} />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      Telegram conversations run Pi with this directory. Each allowed chat keeps its own Pi session; send /new to reset it.
+                    </div>
+                  </label>
+                </div>
+
+                <div style={{ border: "1px solid var(--border)", borderRadius: 7, padding: 14, background: "var(--bg-panel)", alignSelf: "start" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 13 }}>
+                    <span style={{ width: 8, height: 8, borderRadius: "50%", background: statusColor, boxShadow: status?.running ? `0 0 0 3px color-mix(in srgb, ${statusColor} 18%, transparent)` : "none" }} />
+                    <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+                      {status?.running ? "Bridge running" : status?.lastError ? "Bridge error" : "Bridge stopped"}
+                    </span>
+                  </div>
+                  {[
+                    ["Bot", status?.botUsername ? `@${status.botUsername}` : "Not connected"],
+                    ["Last poll", formatTime(status?.lastConnectedAt ?? null)],
+                    ["Last message", formatTime(status?.lastMessageAt ?? null)],
+                  ].map(([label, value]) => (
+                    <div key={label} style={{ marginBottom: 10 }}>
+                      <div style={{ color: "var(--text-dim)", fontSize: 10, textTransform: "uppercase", letterSpacing: ".04em" }}>{label}</div>
+                      <div style={{ color: "var(--text-muted)", fontSize: 11, marginTop: 2, overflowWrap: "anywhere" }}>{value}</div>
+                    </div>
+                  ))}
+                  {status?.lastError && (
+                    <div style={{ marginTop: 8, padding: 9, borderRadius: 5, background: "rgba(239,68,68,.08)", color: "#ef4444", fontSize: 10.5, lineHeight: 1.45, overflowWrap: "anywhere" }}>
+                      {status.lastError}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {(error || message) && (
+                <div style={{ padding: "9px 11px", borderRadius: 6, background: error ? "rgba(239,68,68,.08)" : "rgba(22,163,74,.08)", color: error ? "#ef4444" : "#16a34a", fontSize: 11.5 }}>
+                  {error ?? message}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, padding: "11px 18px", borderTop: "1px solid var(--border)", background: "var(--bg)" }}>
+          <button onClick={() => void testConnection()} disabled={busy || (!token.trim() && !config?.tokenConfigured)} style={buttonStyle(busy || (!token.trim() && !config?.tokenConfigured))}>
+            {testing ? "Testing..." : "Test connection"}
+          </button>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button onClick={onClose} disabled={saving} style={buttonStyle(saving)}>Cancel</button>
+            <button onClick={() => void save()} disabled={busy} style={buttonStyle(busy, true)}>
+              {saving ? "Saving..." : "Save settings"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,4 +3,7 @@ export async function register(): Promise<void> {
 
   const { configureHttpDispatcher } = await import("@/lib/http-dispatcher");
   configureHttpDispatcher();
+
+  const { startTelegramBridge } = await import("@/lib/telegram-bridge");
+  startTelegramBridge();
 }

--- a/lib/telegram-bridge.ts
+++ b/lib/telegram-bridge.ts
@@ -1,0 +1,356 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { startRpcSession, type AgentSessionWrapper } from "./rpc-manager";
+import { readTelegramConfig, type TelegramBridgeConfig } from "./telegram-config";
+
+type TelegramUser = {
+  username?: string;
+  first_name?: string;
+};
+
+type TelegramMessage = {
+  message_id: number;
+  text?: string;
+  chat: { id: number; type: string };
+  from?: TelegramUser;
+};
+
+type TelegramUpdate = {
+  update_id: number;
+  message?: TelegramMessage;
+};
+
+type TelegramApiEnvelope<T> = {
+  ok: boolean;
+  result?: T;
+  description?: string;
+};
+
+type TelegramSessionRecord = {
+  sessionId: string;
+  sessionFile: string;
+  cwd: string;
+};
+
+type TelegramBridgeState = {
+  offset: number;
+  chats: Record<string, TelegramSessionRecord>;
+};
+
+export type TelegramBridgeStatus = {
+  running: boolean;
+  botUsername: string | null;
+  lastConnectedAt: string | null;
+  lastMessageAt: string | null;
+  lastError: string | null;
+};
+
+const EMPTY_STATUS: TelegramBridgeStatus = {
+  running: false,
+  botUsername: null,
+  lastConnectedAt: null,
+  lastMessageAt: null,
+  lastError: null,
+};
+
+const TELEGRAM_MESSAGE_LIMIT = 4096;
+
+export function splitTelegramMessage(text: string, limit = TELEGRAM_MESSAGE_LIMIT): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+  const parts: string[] = [];
+  let remaining = normalized;
+
+  while (remaining.length > limit) {
+    const window = remaining.slice(0, limit + 1);
+    const newline = window.lastIndexOf("\n");
+    const space = window.lastIndexOf(" ");
+    const splitAt = newline > limit * 0.55
+      ? newline
+      : space > limit * 0.55
+        ? space
+        : limit;
+    parts.push(remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+function telegramStatePath(): string {
+  return join(getAgentDir(), "pi-web-telegram-state.json");
+}
+
+function readBridgeState(): TelegramBridgeState {
+  const path = telegramStatePath();
+  if (!existsSync(path)) return { offset: 0, chats: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<TelegramBridgeState>;
+    return {
+      offset: typeof parsed.offset === "number" ? parsed.offset : 0,
+      chats: parsed.chats && typeof parsed.chats === "object" ? parsed.chats : {},
+    };
+  } catch {
+    return { offset: 0, chats: {} };
+  }
+}
+
+function writeBridgeState(state: TelegramBridgeState): void {
+  const path = telegramStatePath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  renameSync(tempPath, path);
+}
+
+async function telegramApi<T>(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const response = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+  const envelope = await response.json() as TelegramApiEnvelope<T>;
+  if (!response.ok || !envelope.ok || envelope.result === undefined) {
+    throw new Error(envelope.description || `Telegram API ${method} failed (${response.status})`);
+  }
+  return envelope.result;
+}
+
+export async function testTelegramToken(token: string): Promise<{ username: string; name: string }> {
+  const bot = await telegramApi<{ username?: string; first_name?: string }>(token, "getMe", {});
+  return {
+    username: bot.username ?? "",
+    name: bot.first_name ?? bot.username ?? "Telegram bot",
+  };
+}
+
+class TelegramBridge {
+  private controller: AbortController | null = null;
+  private loopPromise: Promise<void> | null = null;
+  private state: TelegramBridgeState = readBridgeState();
+  private status: TelegramBridgeStatus = { ...EMPTY_STATUS };
+  private chatQueues = new Map<string, Promise<void>>();
+
+  getStatus(): TelegramBridgeStatus {
+    return { ...this.status };
+  }
+
+  async restart(): Promise<void> {
+    await this.stop();
+    const config = readTelegramConfig();
+    if (config.enabled && config.token && config.cwd && config.allowedChatIds.length > 0) {
+      this.start(config);
+    }
+  }
+
+  start(config = readTelegramConfig()): void {
+    if (this.loopPromise || !config.enabled) return;
+    this.controller = new AbortController();
+    this.status = { ...EMPTY_STATUS, running: true };
+    const signal = this.controller.signal;
+    this.loopPromise = this.poll(config, signal)
+      .catch((error) => {
+        if (!signal.aborted) {
+          this.status.lastError = error instanceof Error ? error.message : String(error);
+          console.error("[pi-web] Telegram bridge stopped:", this.status.lastError);
+        }
+      })
+      .finally(() => {
+        this.status.running = false;
+        this.controller = null;
+        this.loopPromise = null;
+      });
+  }
+
+  async stop(): Promise<void> {
+    const promise = this.loopPromise;
+    this.controller?.abort();
+    if (promise) {
+      try {
+        await promise;
+      } catch {
+        // Poll cancellation is expected while applying new settings.
+      }
+    }
+    this.status.running = false;
+  }
+
+  private async poll(config: TelegramBridgeConfig, signal: AbortSignal): Promise<void> {
+    const bot = await testTelegramToken(config.token);
+    this.status.botUsername = bot.username || null;
+    this.status.lastConnectedAt = new Date().toISOString();
+    this.status.lastError = null;
+
+    while (!signal.aborted) {
+      try {
+        const updates = await telegramApi<TelegramUpdate[]>(
+          config.token,
+          "getUpdates",
+          {
+            offset: this.state.offset,
+            timeout: 25,
+            allowed_updates: ["message"],
+          },
+          signal,
+        );
+        this.status.lastConnectedAt = new Date().toISOString();
+        this.status.lastError = null;
+
+        for (const update of updates) {
+          this.state.offset = Math.max(this.state.offset, update.update_id + 1);
+          writeBridgeState(this.state);
+          if (update.message) this.enqueueMessage(config, update.message);
+        }
+      } catch (error) {
+        if (signal.aborted) break;
+        this.status.lastError = error instanceof Error ? error.message : String(error);
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+      }
+    }
+  }
+
+  private enqueueMessage(config: TelegramBridgeConfig, message: TelegramMessage): void {
+    const chatId = String(message.chat.id);
+    const previous = this.chatQueues.get(chatId) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {})
+      .then(() => this.handleMessage(config, message))
+      .catch((error) => {
+        console.error(`[pi-web] Telegram chat ${chatId} failed:`, error);
+      })
+      .finally(() => {
+        if (this.chatQueues.get(chatId) === next) this.chatQueues.delete(chatId);
+      });
+    this.chatQueues.set(chatId, next);
+  }
+
+  private async handleMessage(config: TelegramBridgeConfig, message: TelegramMessage): Promise<void> {
+    const chatId = String(message.chat.id);
+    if (!config.allowedChatIds.includes(chatId)) return;
+    const text = message.text?.trim();
+    if (!text) {
+      await this.sendText(config.token, chatId, "Pi Web currently accepts text messages only.");
+      return;
+    }
+
+    this.status.lastMessageAt = new Date().toISOString();
+
+    if (text === "/start" || text === "/help") {
+      await this.sendText(
+        config.token,
+        chatId,
+        "Pi Web bridge is ready.\n\nSend a message to talk to Pi.\n/new — start a fresh Pi session\n/status — show the linked session",
+      );
+      return;
+    }
+    if (text === "/new") {
+      delete this.state.chats[chatId];
+      writeBridgeState(this.state);
+      await this.sendText(config.token, chatId, "Started a fresh Pi session. Send your next message when ready.");
+      return;
+    }
+    if (text === "/status") {
+      const linked = this.state.chats[chatId];
+      await this.sendText(
+        config.token,
+        chatId,
+        linked
+          ? `Connected to Pi session ${linked.sessionId}\nWorking directory: ${linked.cwd}`
+          : `No Pi session is linked yet.\nWorking directory: ${config.cwd}`,
+      );
+      return;
+    }
+
+    await telegramApi(config.token, "sendChatAction", { chat_id: chatId, action: "typing" });
+    try {
+      const session = await this.getSession(chatId, config.cwd);
+      const answer = await this.prompt(session, text);
+      await this.sendText(config.token, chatId, answer || "Pi completed the request without a text response.");
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : String(error);
+      await this.sendText(config.token, chatId, `Pi bridge error: ${messageText}`);
+    }
+  }
+
+  private async getSession(chatId: string, cwd: string): Promise<AgentSessionWrapper> {
+    const record = this.state.chats[chatId];
+    if (record && record.cwd === cwd && record.sessionFile && existsSync(record.sessionFile)) {
+      const { session } = await startRpcSession(record.sessionId, record.sessionFile, cwd);
+      return session;
+    }
+
+    const tempKey = `__telegram__${chatId}_${Date.now()}`;
+    const { session, realSessionId } = await startRpcSession(tempKey, "", cwd);
+    this.state.chats[chatId] = {
+      sessionId: realSessionId,
+      sessionFile: session.sessionFile,
+      cwd,
+    };
+    writeBridgeState(this.state);
+    return session;
+  }
+
+  private async prompt(session: AgentSessionWrapper, message: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        unsubscribe();
+        reject(new Error("Pi did not finish within 30 minutes."));
+      }, 30 * 60 * 1000);
+      const finish = async (error?: string) => {
+        clearTimeout(timeout);
+        unsubscribe();
+        if (error) {
+          reject(new Error(error));
+          return;
+        }
+        try {
+          const result = await session.send({ type: "get_last_assistant_text" }) as { text?: string };
+          resolve(result.text ?? "");
+        } catch (err) {
+          reject(err);
+        }
+      };
+      const unsubscribe = session.onEvent((event) => {
+        if (event.type === "prompt_error") void finish(String(event.errorMessage ?? "Pi prompt failed."));
+        else if (event.type === "prompt_done") void finish();
+      });
+
+      session.send({ type: "prompt", message }).catch((error) => {
+        void finish(error instanceof Error ? error.message : String(error));
+      });
+    });
+  }
+
+  private async sendText(token: string, chatId: string, text: string): Promise<void> {
+    const parts = splitTelegramMessage(text);
+    for (const part of parts) {
+      await telegramApi(token, "sendMessage", {
+        chat_id: chatId,
+        text: part,
+        link_preview_options: { is_disabled: true },
+      });
+    }
+  }
+}
+
+declare global {
+  var __piWebTelegramBridge: TelegramBridge | undefined;
+}
+
+export function getTelegramBridge(): TelegramBridge {
+  if (!globalThis.__piWebTelegramBridge) {
+    globalThis.__piWebTelegramBridge = new TelegramBridge();
+  }
+  return globalThis.__piWebTelegramBridge;
+}
+
+export function startTelegramBridge(): void {
+  getTelegramBridge().start();
+}

--- a/lib/telegram-config.test.mjs
+++ b/lib/telegram-config.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { normalizeAllowedChatIds, toPublicTelegramConfig, validateTelegramConfig } =
+  await jiti.import("./telegram-config.ts");
+const { splitTelegramMessage } = await jiti.import("./telegram-bridge.ts");
+
+test("normalizes and deduplicates Telegram chat IDs", () => {
+  assert.deepEqual(
+    normalizeAllowedChatIds("123, -456\n123 invalid 7.5"),
+    ["123", "-456"],
+  );
+});
+test("never exposes the Telegram token in public config", () => {
+  const publicConfig = toPublicTelegramConfig({
+    enabled: true,
+    token: "123456:secret-token-value",
+    allowedChatIds: ["123"],
+    cwd: "C:\\project",
+  });
+
+  assert.equal(publicConfig.tokenConfigured, true);
+  assert.equal(publicConfig.tokenHint, "••••-value");
+  assert.equal("token" in publicConfig, false);
+});
+
+test("disabled Telegram bridge can be saved without credentials", () => {
+  assert.equal(validateTelegramConfig({
+    enabled: false,
+    token: "",
+    allowedChatIds: [],
+    cwd: "",
+  }), null);
+});
+
+test("splits long Telegram messages without losing content", () => {
+  const text = `${"a".repeat(3_900)}\n${"b".repeat(500)}`;
+  const parts = splitTelegramMessage(text);
+
+  assert.equal(parts.length, 2);
+  assert.ok(parts.every((part) => part.length <= 4_096));
+  assert.equal(parts.join("\n"), text);
+});

--- a/lib/telegram-config.ts
+++ b/lib/telegram-config.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export type TelegramBridgeConfig = {
+  enabled: boolean;
+  token: string;
+  allowedChatIds: string[];
+  cwd: string;
+};
+
+export type TelegramBridgePublicConfig = Omit<TelegramBridgeConfig, "token"> & {
+  tokenConfigured: boolean;
+  tokenHint: string | null;
+};
+
+const DEFAULT_CONFIG: TelegramBridgeConfig = {
+  enabled: false,
+  token: "",
+  allowedChatIds: [],
+  cwd: "",
+};
+
+export function normalizeAllowedChatIds(value: unknown): string[] {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/[\s,]+/)
+      : [];
+
+  return [...new Set(values
+    .map((entry) => String(entry).trim())
+    .filter((entry) => /^-?\d+$/.test(entry)))];
+}
+export function telegramConfigPath(): string {
+  return join(getAgentDir(), "pi-web-telegram.json");
+}
+
+export function readTelegramConfig(): TelegramBridgeConfig {
+  const path = telegramConfigPath();
+  if (!existsSync(path)) return { ...DEFAULT_CONFIG };
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<TelegramBridgeConfig>;
+    return {
+      enabled: parsed.enabled === true,
+      token: typeof parsed.token === "string" ? parsed.token.trim() : "",
+      allowedChatIds: normalizeAllowedChatIds(parsed.allowedChatIds),
+      cwd: typeof parsed.cwd === "string" ? parsed.cwd.trim() : "",
+    };
+  } catch (error) {
+    console.error("[pi-web] failed to read Telegram bridge config:", error);
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function toPublicTelegramConfig(config: TelegramBridgeConfig): TelegramBridgePublicConfig {
+  const token = config.token.trim();
+  return {
+    enabled: config.enabled,
+    allowedChatIds: config.allowedChatIds,
+    cwd: config.cwd,
+    tokenConfigured: token.length > 0,
+    tokenHint: token ? `••••${token.slice(-6)}` : null,
+  };
+}
+
+export function validateTelegramConfig(config: TelegramBridgeConfig): string | null {
+  if (!config.enabled) return null;
+  if (!config.token) return "Bot token is required when the Telegram bridge is enabled.";
+  if (!/^\d+:[A-Za-z0-9_-]+$/.test(config.token)) return "Bot token format is invalid.";
+  if (config.allowedChatIds.length === 0) return "Add at least one allowed Telegram chat ID.";
+  if (!config.cwd) return "Working directory is required when the Telegram bridge is enabled.";
+  if (!existsSync(config.cwd)) return `Working directory does not exist: ${config.cwd}`;
+  return null;
+}
+
+export function writeTelegramConfig(config: TelegramBridgeConfig): void {
+  const path = telegramConfigPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(tempPath, path);
+}


### PR DESCRIPTION
## Summary
- add a persistent Telegram bot bridge using secure long polling
- keep one Pi session per allow-listed Telegram chat, with /new, /status, and /help commands
- add a responsive Telegram settings panel for bot token, chat IDs, working directory, connection testing, and runtime status
- keep bot tokens server-side and return only a masked hint to the UI
- document the feature in English and Chinese READMEs

## Validation
- TypeScript: pass
- ESLint: pass
- Telegram unit tests: 4/4 pass
- Browser QA: desktop and mobile layouts pass; no console errors
- Existing test suite: 102/103 pass; the one failure is the pre-existing Windows path assertion in lib/bash-output.test.mjs (C:\tmp versus /tmp)