### PR TITLE
feat: add an optional live bot bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ npx @agegr/pi-web@latest
 
 ## Features
 
+- **Telegram bridge** — connect an allow-listed Telegram user or group to Pi. Configure the bot token, chat IDs, and working directory from the Telegram panel in the sidebar; each chat keeps an independent Pi session and supports `/new`, `/status`, and `/help`.
+
 - **Pick work back up**: browse previous pi conversations by project without digging through terminal history or session paths.
 - **Try different directions safely**: continue from an earlier message or fork a session into a separate route.
 - **Work across branches**: switch Git worktrees from the sidebar so new sessions and the Explorer follow the checkout you choose.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npx @agegr/pi-web@latest
 
 ## Features
 
-- **Telegram bridge** — connect an allow-listed Telegram user or group to Pi. Configure the bot token, chat IDs, and working directory from the Telegram panel in the sidebar; each chat keeps an independent Pi session and supports `/new`, `/status`, and `/help`.
+- **Telegram bridge** — connect an allow-listed Telegram user or group to Pi from the top-bar **Bridge** panel. Bot messages update live with model names, Thinking, tool calls and arguments, tool duration, token/cache usage, cost, and streamed response text. An optional guard rejects new messages while the model is responding. Each chat keeps an independent Pi session and supports `/new`, `/status`, `/model`, `/stats`, `/stop`, and `/help`.
 
 - **Pick work back up**: browse previous pi conversations by project without digging through terminal history or session paths.
 - **Try different directions safely**: continue from an earlier message or fork a session into a separate route.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@ npx @agegr/pi-web@latest
 
 ## 功能介绍
 
-- **Telegram 桥接**：将允许列表中的 Telegram 用户或群组连接到 Pi。在侧边栏的 Telegram 面板中配置 Bot Token、Chat ID 和工作目录；每个聊天保持独立的 Pi 会话，并支持 `/new`、`/status` 和 `/help`。
+- **Telegram 桥接**：通过顶部操作栏的 **Bridge** 面板，将允许列表中的 Telegram 用户或群组连接到 Pi。Bot 消息会实时显示模型名称、Thinking、工具及参数、工具耗时、token/cache 用量、费用和流式回复；可选择在模型回复期间拒绝同一 Chat 的新消息。每个聊天保持独立的 Pi 会话，并支持 `/new`、`/status`、`/model`、`/stats`、`/stop` 和 `/help`。
 
 - **把历史工作接回来**：打开网页就能按项目找到以前的 pi 对话，不必在终端里翻文件或记住会话路径。
 - **放心试不同方向**：可以从某条历史消息重新开始，也可以复制出一条独立的新路线，探索方案时不怕弄乱原来的对话。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,8 @@ npx @agegr/pi-web@latest
 
 ## 功能介绍
 
+- **Telegram 桥接**：将允许列表中的 Telegram 用户或群组连接到 Pi。在侧边栏的 Telegram 面板中配置 Bot Token、Chat ID 和工作目录；每个聊天保持独立的 Pi 会话，并支持 `/new`、`/status` 和 `/help`。
+
 - **把历史工作接回来**：打开网页就能按项目找到以前的 pi 对话，不必在终端里翻文件或记住会话路径。
 - **放心试不同方向**：可以从某条历史消息重新开始，也可以复制出一条独立的新路线，探索方案时不怕弄乱原来的对话。
 - **跨分支工作**：在侧边栏切换 Git worktree，让新会话和 Explorer 跟随你选择的 checkout。

--- a/app/api/telegram/route.ts
+++ b/app/api/telegram/route.ts
@@ -26,6 +26,7 @@ export async function PUT(req: Request) {
       clearToken?: unknown;
       allowedChatIds?: unknown;
       cwd?: unknown;
+      blockWhileRunning?: unknown;
     };
     const current = readTelegramConfig();
     const next = {
@@ -37,6 +38,7 @@ export async function PUT(req: Request) {
           : current.token,
       allowedChatIds: normalizeAllowedChatIds(body.allowedChatIds),
       cwd: typeof body.cwd === "string" ? body.cwd.trim() : current.cwd,
+      blockWhileRunning: body.blockWhileRunning !== false,
     };
     const validationError = validateTelegramConfig(next);
     if (validationError) {

--- a/app/api/telegram/route.ts
+++ b/app/api/telegram/route.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { NextResponse } from "next/server";
+import { getTelegramBridge, testTelegramToken } from "@/lib/telegram-bridge";
+import {
+  normalizeAllowedChatIds,
+  readTelegramConfig,
+  toPublicTelegramConfig,
+  validateTelegramConfig,
+  writeTelegramConfig,
+} from "@/lib/telegram-config";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const config = readTelegramConfig();
+  return NextResponse.json({
+    config: toPublicTelegramConfig(config),
+    status: getTelegramBridge().getStatus(),
+  });
+}
+export async function PUT(req: Request) {
+  try {
+    const body = await req.json() as {
+      enabled?: unknown;
+      token?: unknown;
+      clearToken?: unknown;
+      allowedChatIds?: unknown;
+      cwd?: unknown;
+    };
+    const current = readTelegramConfig();
+    const next = {
+      enabled: body.enabled === true,
+      token: body.clearToken === true
+        ? ""
+        : typeof body.token === "string" && body.token.trim()
+          ? body.token.trim()
+          : current.token,
+      allowedChatIds: normalizeAllowedChatIds(body.allowedChatIds),
+      cwd: typeof body.cwd === "string" ? body.cwd.trim() : current.cwd,
+    };
+    const validationError = validateTelegramConfig(next);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    writeTelegramConfig(next);
+    await getTelegramBridge().restart();
+    return NextResponse.json({
+      config: toPublicTelegramConfig(next),
+      status: getTelegramBridge().getStatus(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json() as { action?: unknown; token?: unknown; cwd?: unknown };
+    if (body.action === "test") {
+      const saved = readTelegramConfig();
+      const token = typeof body.token === "string" && body.token.trim()
+        ? body.token.trim()
+        : saved.token;
+      if (!token) return NextResponse.json({ error: "Enter a bot token first." }, { status: 400 });
+      const bot = await testTelegramToken(token);
+      return NextResponse.json({ bot });
+    }
+    if (body.action === "validate-cwd") {
+      const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
+      return NextResponse.json({ valid: Boolean(cwd && existsSync(cwd)) });
+    }
+    return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { TabBar, type Tab } from "./TabBar";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
+import { TelegramConfig } from "./TelegramConfig";
 import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -48,6 +49,7 @@ export function AppShell() {
   const [modelsRefreshKey, setModelsRefreshKey] = useState(0);
   const [skillsConfigOpen, setSkillsConfigOpen] = useState(false);
   const [pluginsConfigOpen, setPluginsConfigOpen] = useState(false);
+  const [telegramConfigOpen, setTelegramConfigOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);
   // On mobile the sidebar is an overlay drawer; hide it by default so the chat
@@ -490,6 +492,16 @@ export function AppShell() {
                 <path d="M15 7V2" />
                 <path d="M6 13V8a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v5a6 6 0 0 1-12 0Z" />
                 <path d="M12 19v3" />
+              </svg>
+            ),
+          },
+          {
+            label: "Telegram",
+            onClick: () => setTelegramConfigOpen(true),
+            disabled: false,
+            icon: (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M21.8 3.6 18.5 20c-.2 1.2-.9 1.5-1.9.9l-5-3.7-2.4 2.3c-.3.3-.5.5-1 .5l.4-5.1 9.2-8.3c.4-.4-.1-.6-.6-.2L5.8 13.5.9 12c-1.1-.3-1.1-1.1.2-1.6L20.3 3c.9-.3 1.7.2 1.5.6Z" />
               </svg>
             ),
           },
@@ -1283,6 +1295,12 @@ export function AppShell() {
         sessionId={selectedSession?.id ?? null}
         onClose={() => setPluginsConfigOpen(false)}
         onReloaded={() => setSessionKey((k) => k + 1)}
+      />
+    )}
+    {telegramConfigOpen && (
+      <TelegramConfig
+        defaultCwd={activeCwd ?? selectedSession?.cwd ?? newSessionCwd}
+        onClose={() => setTelegramConfigOpen(false)}
       />
     )}
     </>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -495,16 +495,6 @@ export function AppShell() {
               </svg>
             ),
           },
-          {
-            label: "Telegram",
-            onClick: () => setTelegramConfigOpen(true),
-            disabled: false,
-            icon: (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M21.8 3.6 18.5 20c-.2 1.2-.9 1.5-1.9.9l-5-3.7-2.4 2.3c-.3.3-.5.5-1 .5l.4-5.1 9.2-8.3c.4-.4-.1-.6-.6-.2L5.8 13.5.9 12c-1.1-.3-1.1-1.1.2-1.6L20.3 3c.9-.3 1.7.2 1.5.6Z" />
-              </svg>
-            ),
-          },
         ] as { label: string; onClick: () => void; disabled: boolean; icon: React.ReactNode }[]).map(({ label, onClick, disabled, icon }) => (
           <button
             key={label}
@@ -856,6 +846,34 @@ export function AppShell() {
                   <line x1="8" y1="17" x2="13" y2="17" />
                 </svg>
                 {!isMobile && <span>System</span>}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setActiveTopPanel(null);
+                  setTelegramConfigOpen(true);
+                }}
+                title="Bridge settings"
+                aria-label="Bridge settings"
+                style={{
+                  display: "flex", alignItems: "center", gap: 6,
+                  height: "100%", padding: "0 12px",
+                  background: telegramConfigOpen ? "var(--bg-selected)" : "none",
+                  border: "none",
+                  borderTop: telegramConfigOpen ? "2px solid var(--accent)" : "2px solid transparent",
+                  borderRight: "1px solid var(--border)",
+                  cursor: "pointer",
+                  color: telegramConfigOpen ? "var(--text)" : "var(--text-muted)",
+                  fontSize: 11, whiteSpace: "nowrap", transition: "color 0.1s, background 0.1s",
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.color = telegramConfigOpen ? "var(--text)" : "var(--text-muted)"; }}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M10 13a5 5 0 0 0 7.1.1l2-2a5 5 0 0 0-7.1-7.1l-1.1 1.1" />
+                  <path d="M14 11a5 5 0 0 0-7.1-.1l-2 2A5 5 0 0 0 12 20l1.1-1.1" />
+                </svg>
+                {!isMobile && <span>Bridge</span>}
               </button>
             </div>
           )}

--- a/components/TelegramConfig.tsx
+++ b/components/TelegramConfig.tsx
@@ -7,6 +7,7 @@ type PublicConfig = {
   enabled: boolean;
   allowedChatIds: string[];
   cwd: string;
+  blockWhileRunning: boolean;
   tokenConfigured: boolean;
   tokenHint: string | null;
 };
@@ -65,6 +66,7 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
   const [token, setToken] = useState("");
   const [chatIds, setChatIds] = useState("");
   const [cwd, setCwd] = useState(defaultCwd ?? "");
+  const [blockWhileRunning, setBlockWhileRunning] = useState(true);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -77,6 +79,7 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
     setEnabled(data.config.enabled);
     setChatIds(data.config.allowedChatIds.join("\n"));
     setCwd(data.config.cwd || defaultCwd || "");
+    setBlockWhileRunning(data.config.blockWhileRunning);
   }, [defaultCwd]);
 
   useEffect(() => {
@@ -129,19 +132,20 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
           token: token.trim() || undefined,
           allowedChatIds: chatIds,
           cwd,
+          blockWhileRunning,
         }),
       });
       const data = await res.json() as TelegramResponse;
       if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
       applyResponse(data);
       setToken("");
-      setMessage(enabled ? "Telegram bridge saved and started." : "Telegram bridge settings saved.");
+      setMessage(enabled ? "Bridge saved and started." : "Bridge settings saved.");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSaving(false);
     }
-  }, [applyResponse, chatIds, cwd, enabled, token]);
+  }, [applyResponse, blockWhileRunning, chatIds, cwd, enabled, token]);
 
   const busy = loading || saving || testing;
   const statusColor = status?.running ? "#16a34a" : status?.lastError ? "#ef4444" : "var(--text-dim)";
@@ -183,8 +187,8 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
               </svg>
             </span>
             <div>
-              <div style={{ fontSize: 15, fontWeight: 700, color: "var(--text)" }}>Telegram Bridge</div>
-              <div style={{ marginTop: 2, fontSize: 11, color: "var(--text-dim)" }}>Talk to Pi from an allow-listed Telegram chat</div>
+              <div style={{ fontSize: 15, fontWeight: 700, color: "var(--text)" }}>Bridge Settings</div>
+              <div style={{ marginTop: 2, fontSize: 11, color: "var(--text-dim)" }}>Live Thinking, tool calls, timing, usage, and replies</div>
             </div>
           </div>
           <button onClick={onClose} aria-label="Close" style={{ border: 0, background: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: 20, padding: "2px 6px" }}>×</button>
@@ -192,7 +196,7 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
 
         <div style={{ overflowY: "auto", padding: isMobile ? 15 : 20 }}>
           {loading ? (
-            <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", fontSize: 12 }}>Loading Telegram settings...</div>
+            <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", fontSize: 12 }}>Loading bridge settings...</div>
           ) : (
             <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
               <div
@@ -208,8 +212,8 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
                 }}
               >
                 <div>
-                  <div style={{ color: "var(--text)", fontSize: 13, fontWeight: 600 }}>Enable Telegram bridge</div>
-                  <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 3 }}>Starts secure long polling when Pi Web is running.</div>
+                  <div style={{ color: "var(--text)", fontSize: 13, fontWeight: 600 }}>Enable bridge</div>
+                  <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 3 }}>Streams each Pi run by continuously updating one bot message.</div>
                 </div>
                 <button
                   type="button"
@@ -228,6 +232,43 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
                   }}
                 >
                   <span style={{ display: "block", width: 18, height: 18, borderRadius: "50%", background: "white", transform: `translateX(${enabled ? 18 : 0}px)`, transition: "transform 0.15s", boxShadow: "0 1px 3px rgba(0,0,0,.25)" }} />
+                </button>
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  padding: "12px 14px",
+                  border: "1px solid var(--border)",
+                  borderRadius: 7,
+                  background: "var(--bg-panel)",
+                }}
+              >
+                <div>
+                  <div style={{ color: "var(--text)", fontSize: 13, fontWeight: 600 }}>Block messages while responding</div>
+                  <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 3 }}>Rejects new messages in the same chat until the current model response finishes.</div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={blockWhileRunning}
+                  onClick={() => setBlockWhileRunning((value) => !value)}
+                  style={{
+                    width: 40,
+                    height: 22,
+                    padding: 2,
+                    border: 0,
+                    borderRadius: 12,
+                    cursor: "pointer",
+                    background: blockWhileRunning ? "#229ED9" : "var(--border)",
+                    transition: "background 0.15s",
+                    flexShrink: 0,
+                  }}
+                >
+                  <span style={{ display: "block", width: 18, height: 18, borderRadius: "50%", background: "white", transform: `translateX(${blockWhileRunning ? 18 : 0}px)`, transition: "transform 0.15s", boxShadow: "0 1px 3px rgba(0,0,0,.25)" }} />
                 </button>
               </div>
 
@@ -266,7 +307,7 @@ export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | n
                     <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Working directory</div>
                     <input value={cwd} onChange={(event) => setCwd(event.target.value)} placeholder="C:\path\to\project" style={inputStyle} />
                     <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
-                      Telegram conversations run Pi with this directory. Each allowed chat keeps its own Pi session; send /new to reset it.
+                      Bridge conversations run Pi with this directory. Each allowed chat keeps its own Pi session; send /new to reset it.
                     </div>
                   </label>
                 </div>

--- a/components/TelegramConfig.tsx
+++ b/components/TelegramConfig.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+type PublicConfig = {
+  enabled: boolean;
+  allowedChatIds: string[];
+  cwd: string;
+  tokenConfigured: boolean;
+  tokenHint: string | null;
+};
+
+type BridgeStatus = {
+  running: boolean;
+  botUsername: string | null;
+  lastConnectedAt: string | null;
+  lastMessageAt: string | null;
+  lastError: string | null;
+};
+
+type TelegramResponse = {
+  config: PublicConfig;
+  status: BridgeStatus;
+  error?: string;
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  background: "var(--bg-panel)",
+  color: "var(--text)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  padding: "9px 10px",
+  outline: "none",
+};
+
+function buttonStyle(disabled = false, primary = false): React.CSSProperties {
+  return {
+    border: primary ? "1px solid var(--accent)" : "1px solid var(--border)",
+    borderRadius: 6,
+    background: primary ? "var(--accent)" : "var(--bg-panel)",
+    color: primary ? "white" : "var(--text)",
+    padding: "8px 13px",
+    fontSize: 12,
+    fontWeight: primary ? 600 : 400,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+  };
+}
+function formatTime(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export function TelegramConfig({ defaultCwd, onClose }: { defaultCwd: string | null; onClose: () => void }) {
+  const isMobile = useIsMobile();
+  const [config, setConfig] = useState<PublicConfig | null>(null);
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [token, setToken] = useState("");
+  const [chatIds, setChatIds] = useState("");
+  const [cwd, setCwd] = useState(defaultCwd ?? "");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const applyResponse = useCallback((data: TelegramResponse) => {
+    setConfig(data.config);
+    setStatus(data.status);
+    setEnabled(data.config.enabled);
+    setChatIds(data.config.allowedChatIds.join("\n"));
+    setCwd(data.config.cwd || defaultCwd || "");
+  }, [defaultCwd]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/telegram")
+      .then(async (res) => {
+        const data = await res.json() as TelegramResponse;
+        if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+        if (!cancelled) applyResponse(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [applyResponse]);
+
+  const testConnection = useCallback(async () => {
+    setTesting(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/telegram", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "test", token: token.trim() || undefined }),
+      });
+      const data = await res.json() as { bot?: { username: string; name: string }; error?: string };
+      if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+      setMessage(`Connected to ${data.bot?.name}${data.bot?.username ? ` (@${data.bot.username})` : ""}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTesting(false);
+    }
+  }, [token]);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/telegram", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled,
+          token: token.trim() || undefined,
+          allowedChatIds: chatIds,
+          cwd,
+        }),
+      });
+      const data = await res.json() as TelegramResponse;
+      if (!res.ok || data.error) throw new Error(data.error ?? `HTTP ${res.status}`);
+      applyResponse(data);
+      setToken("");
+      setMessage(enabled ? "Telegram bridge saved and started." : "Telegram bridge settings saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [applyResponse, chatIds, cwd, enabled, token]);
+
+  const busy = loading || saving || testing;
+  const statusColor = status?.running ? "#16a34a" : status?.lastError ? "#ef4444" : "var(--text-dim)";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: isMobile ? "calc(100vw - 16px)" : 720,
+          maxWidth: "calc(100vw - 16px)",
+          maxHeight: isMobile ? "calc(100dvh - 16px)" : "82vh",
+          background: "var(--bg)",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "13px 18px", borderBottom: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{ width: 28, height: 28, borderRadius: 8, display: "grid", placeItems: "center", background: "rgba(34,158,217,0.14)", color: "#229ED9" }}>
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M21.8 3.6 18.5 20c-.2 1.2-.9 1.5-1.9.9l-5-3.7-2.4 2.3c-.3.3-.5.5-1 .5l.4-5.1 9.2-8.3c.4-.4-.1-.6-.6-.2L5.8 13.5.9 12c-1.1-.3-1.1-1.1.2-1.6L20.3 3c.9-.3 1.7.2 1.5.6Z" />
+              </svg>
+            </span>
+            <div>
+              <div style={{ fontSize: 15, fontWeight: 700, color: "var(--text)" }}>Telegram Bridge</div>
+              <div style={{ marginTop: 2, fontSize: 11, color: "var(--text-dim)" }}>Talk to Pi from an allow-listed Telegram chat</div>
+            </div>
+          </div>
+          <button onClick={onClose} aria-label="Close" style={{ border: 0, background: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: 20, padding: "2px 6px" }}>×</button>
+        </div>
+
+        <div style={{ overflowY: "auto", padding: isMobile ? 15 : 20 }}>
+          {loading ? (
+            <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", fontSize: 12 }}>Loading Telegram settings...</div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  padding: "12px 14px",
+                  border: "1px solid var(--border)",
+                  borderRadius: 7,
+                  background: "var(--bg-panel)",
+                }}
+              >
+                <div>
+                  <div style={{ color: "var(--text)", fontSize: 13, fontWeight: 600 }}>Enable Telegram bridge</div>
+                  <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 3 }}>Starts secure long polling when Pi Web is running.</div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={enabled}
+                  onClick={() => setEnabled((value) => !value)}
+                  style={{
+                    width: 40,
+                    height: 22,
+                    padding: 2,
+                    border: 0,
+                    borderRadius: 12,
+                    cursor: "pointer",
+                    background: enabled ? "#229ED9" : "var(--border)",
+                    transition: "background 0.15s",
+                  }}
+                >
+                  <span style={{ display: "block", width: 18, height: 18, borderRadius: "50%", background: "white", transform: `translateX(${enabled ? 18 : 0}px)`, transition: "transform 0.15s", boxShadow: "0 1px 3px rgba(0,0,0,.25)" }} />
+                </button>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : "minmax(0, 1.25fr) minmax(210px, .75fr)", gap: 16 }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Bot token</div>
+                    <input
+                      type="password"
+                      autoComplete="off"
+                      value={token}
+                      onChange={(event) => setToken(event.target.value)}
+                      placeholder={config?.tokenConfigured ? `Saved ${config.tokenHint ?? ""} — leave blank to keep` : "123456789:AA..."}
+                      style={inputStyle}
+                    />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      Create a bot with @BotFather. The token stays on this machine and is never returned to the browser.
+                    </div>
+                  </label>
+
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Allowed chat IDs</div>
+                    <textarea
+                      value={chatIds}
+                      onChange={(event) => setChatIds(event.target.value)}
+                      placeholder={"123456789\n-1001234567890"}
+                      rows={3}
+                      style={{ ...inputStyle, resize: "vertical", minHeight: 72 }}
+                    />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      One numeric user or group chat ID per line. Messages from every other chat are ignored.
+                    </div>
+                  </label>
+
+                  <label>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Working directory</div>
+                    <input value={cwd} onChange={(event) => setCwd(event.target.value)} placeholder="C:\path\to\project" style={inputStyle} />
+                    <div style={{ fontSize: 10.5, lineHeight: 1.45, color: "var(--text-dim)", marginTop: 5 }}>
+                      Telegram conversations run Pi with this directory. Each allowed chat keeps its own Pi session; send /new to reset it.
+                    </div>
+                  </label>
+                </div>
+
+                <div style={{ border: "1px solid var(--border)", borderRadius: 7, padding: 14, background: "var(--bg-panel)", alignSelf: "start" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 13 }}>
+                    <span style={{ width: 8, height: 8, borderRadius: "50%", background: statusColor, boxShadow: status?.running ? `0 0 0 3px color-mix(in srgb, ${statusColor} 18%, transparent)` : "none" }} />
+                    <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+                      {status?.running ? "Bridge running" : status?.lastError ? "Bridge error" : "Bridge stopped"}
+                    </span>
+                  </div>
+                  {[
+                    ["Bot", status?.botUsername ? `@${status.botUsername}` : "Not connected"],
+                    ["Last poll", formatTime(status?.lastConnectedAt ?? null)],
+                    ["Last message", formatTime(status?.lastMessageAt ?? null)],
+                  ].map(([label, value]) => (
+                    <div key={label} style={{ marginBottom: 10 }}>
+                      <div style={{ color: "var(--text-dim)", fontSize: 10, textTransform: "uppercase", letterSpacing: ".04em" }}>{label}</div>
+                      <div style={{ color: "var(--text-muted)", fontSize: 11, marginTop: 2, overflowWrap: "anywhere" }}>{value}</div>
+                    </div>
+                  ))}
+                  {status?.lastError && (
+                    <div style={{ marginTop: 8, padding: 9, borderRadius: 5, background: "rgba(239,68,68,.08)", color: "#ef4444", fontSize: 10.5, lineHeight: 1.45, overflowWrap: "anywhere" }}>
+                      {status.lastError}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {(error || message) && (
+                <div style={{ padding: "9px 11px", borderRadius: 6, background: error ? "rgba(239,68,68,.08)" : "rgba(22,163,74,.08)", color: error ? "#ef4444" : "#16a34a", fontSize: 11.5 }}>
+                  {error ?? message}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, padding: "11px 18px", borderTop: "1px solid var(--border)", background: "var(--bg)" }}>
+          <button onClick={() => void testConnection()} disabled={busy || (!token.trim() && !config?.tokenConfigured)} style={buttonStyle(busy || (!token.trim() && !config?.tokenConfigured))}>
+            {testing ? "Testing..." : "Test connection"}
+          </button>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button onClick={onClose} disabled={saving} style={buttonStyle(saving)}>Cancel</button>
+            <button onClick={() => void save()} disabled={busy} style={buttonStyle(busy, true)}>
+              {saving ? "Saving..." : "Save settings"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,4 +3,7 @@ export async function register(): Promise<void> {
 
   const { configureHttpDispatcher } = await import("@/lib/http-dispatcher");
   configureHttpDispatcher();
+
+  const { startTelegramBridge } = await import("@/lib/telegram-bridge");
+  startTelegramBridge();
 }

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -15,6 +15,7 @@ export interface ContextUsage {
 export interface ModelLike {
   id: string;
   provider: string;
+  name?: string;
 }
 
 export interface ToolInfo {

--- a/lib/telegram-bridge.ts
+++ b/lib/telegram-bridge.ts
@@ -1,0 +1,356 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { startRpcSession, type AgentSessionWrapper } from "./rpc-manager";
+import { readTelegramConfig, type TelegramBridgeConfig } from "./telegram-config";
+
+type TelegramUser = {
+  username?: string;
+  first_name?: string;
+};
+
+type TelegramMessage = {
+  message_id: number;
+  text?: string;
+  chat: { id: number; type: string };
+  from?: TelegramUser;
+};
+
+type TelegramUpdate = {
+  update_id: number;
+  message?: TelegramMessage;
+};
+
+type TelegramApiEnvelope<T> = {
+  ok: boolean;
+  result?: T;
+  description?: string;
+};
+
+type TelegramSessionRecord = {
+  sessionId: string;
+  sessionFile: string;
+  cwd: string;
+};
+
+type TelegramBridgeState = {
+  offset: number;
+  chats: Record<string, TelegramSessionRecord>;
+};
+
+export type TelegramBridgeStatus = {
+  running: boolean;
+  botUsername: string | null;
+  lastConnectedAt: string | null;
+  lastMessageAt: string | null;
+  lastError: string | null;
+};
+
+const EMPTY_STATUS: TelegramBridgeStatus = {
+  running: false,
+  botUsername: null,
+  lastConnectedAt: null,
+  lastMessageAt: null,
+  lastError: null,
+};
+
+const TELEGRAM_MESSAGE_LIMIT = 4096;
+
+export function splitTelegramMessage(text: string, limit = TELEGRAM_MESSAGE_LIMIT): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+  const parts: string[] = [];
+  let remaining = normalized;
+
+  while (remaining.length > limit) {
+    const window = remaining.slice(0, limit + 1);
+    const newline = window.lastIndexOf("\n");
+    const space = window.lastIndexOf(" ");
+    const splitAt = newline > limit * 0.55
+      ? newline
+      : space > limit * 0.55
+        ? space
+        : limit;
+    parts.push(remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+function telegramStatePath(): string {
+  return join(getAgentDir(), "pi-web-telegram-state.json");
+}
+
+function readBridgeState(): TelegramBridgeState {
+  const path = telegramStatePath();
+  if (!existsSync(path)) return { offset: 0, chats: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<TelegramBridgeState>;
+    return {
+      offset: typeof parsed.offset === "number" ? parsed.offset : 0,
+      chats: parsed.chats && typeof parsed.chats === "object" ? parsed.chats : {},
+    };
+  } catch {
+    return { offset: 0, chats: {} };
+  }
+}
+
+function writeBridgeState(state: TelegramBridgeState): void {
+  const path = telegramStatePath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  renameSync(tempPath, path);
+}
+
+async function telegramApi<T>(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const response = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+  const envelope = await response.json() as TelegramApiEnvelope<T>;
+  if (!response.ok || !envelope.ok || envelope.result === undefined) {
+    throw new Error(envelope.description || `Telegram API ${method} failed (${response.status})`);
+  }
+  return envelope.result;
+}
+
+export async function testTelegramToken(token: string): Promise<{ username: string; name: string }> {
+  const bot = await telegramApi<{ username?: string; first_name?: string }>(token, "getMe", {});
+  return {
+    username: bot.username ?? "",
+    name: bot.first_name ?? bot.username ?? "Telegram bot",
+  };
+}
+
+class TelegramBridge {
+  private controller: AbortController | null = null;
+  private loopPromise: Promise<void> | null = null;
+  private state: TelegramBridgeState = readBridgeState();
+  private status: TelegramBridgeStatus = { ...EMPTY_STATUS };
+  private chatQueues = new Map<string, Promise<void>>();
+
+  getStatus(): TelegramBridgeStatus {
+    return { ...this.status };
+  }
+
+  async restart(): Promise<void> {
+    await this.stop();
+    const config = readTelegramConfig();
+    if (config.enabled && config.token && config.cwd && config.allowedChatIds.length > 0) {
+      this.start(config);
+    }
+  }
+
+  start(config = readTelegramConfig()): void {
+    if (this.loopPromise || !config.enabled) return;
+    this.controller = new AbortController();
+    this.status = { ...EMPTY_STATUS, running: true };
+    const signal = this.controller.signal;
+    this.loopPromise = this.poll(config, signal)
+      .catch((error) => {
+        if (!signal.aborted) {
+          this.status.lastError = error instanceof Error ? error.message : String(error);
+          console.error("[pi-web] Telegram bridge stopped:", this.status.lastError);
+        }
+      })
+      .finally(() => {
+        this.status.running = false;
+        this.controller = null;
+        this.loopPromise = null;
+      });
+  }
+
+  async stop(): Promise<void> {
+    const promise = this.loopPromise;
+    this.controller?.abort();
+    if (promise) {
+      try {
+        await promise;
+      } catch {
+        // Poll cancellation is expected while applying new settings.
+      }
+    }
+    this.status.running = false;
+  }
+
+  private async poll(config: TelegramBridgeConfig, signal: AbortSignal): Promise<void> {
+    const bot = await testTelegramToken(config.token);
+    this.status.botUsername = bot.username || null;
+    this.status.lastConnectedAt = new Date().toISOString();
+    this.status.lastError = null;
+
+    while (!signal.aborted) {
+      try {
+        const updates = await telegramApi<TelegramUpdate[]>(
+          config.token,
+          "getUpdates",
+          {
+            offset: this.state.offset,
+            timeout: 25,
+            allowed_updates: ["message"],
+          },
+          signal,
+        );
+        this.status.lastConnectedAt = new Date().toISOString();
+        this.status.lastError = null;
+
+        for (const update of updates) {
+          this.state.offset = Math.max(this.state.offset, update.update_id + 1);
+          writeBridgeState(this.state);
+          if (update.message) this.enqueueMessage(config, update.message);
+        }
+      } catch (error) {
+        if (signal.aborted) break;
+        this.status.lastError = error instanceof Error ? error.message : String(error);
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+      }
+    }
+  }
+
+  private enqueueMessage(config: TelegramBridgeConfig, message: TelegramMessage): void {
+    const chatId = String(message.chat.id);
+    const previous = this.chatQueues.get(chatId) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {})
+      .then(() => this.handleMessage(config, message))
+      .catch((error) => {
+        console.error(`[pi-web] Telegram chat ${chatId} failed:`, error);
+      })
+      .finally(() => {
+        if (this.chatQueues.get(chatId) === next) this.chatQueues.delete(chatId);
+      });
+    this.chatQueues.set(chatId, next);
+  }
+
+  private async handleMessage(config: TelegramBridgeConfig, message: TelegramMessage): Promise<void> {
+    const chatId = String(message.chat.id);
+    if (!config.allowedChatIds.includes(chatId)) return;
+    const text = message.text?.trim();
+    if (!text) {
+      await this.sendText(config.token, chatId, "Pi Web currently accepts text messages only.");
+      return;
+    }
+
+    this.status.lastMessageAt = new Date().toISOString();
+
+    if (text === "/start" || text === "/help") {
+      await this.sendText(
+        config.token,
+        chatId,
+        "Pi Web bridge is ready.\n\nSend a message to talk to Pi.\n/new — start a fresh Pi session\n/status — show the linked session",
+      );
+      return;
+    }
+    if (text === "/new") {
+      delete this.state.chats[chatId];
+      writeBridgeState(this.state);
+      await this.sendText(config.token, chatId, "Started a fresh Pi session. Send your next message when ready.");
+      return;
+    }
+    if (text === "/status") {
+      const linked = this.state.chats[chatId];
+      await this.sendText(
+        config.token,
+        chatId,
+        linked
+          ? `Connected to Pi session ${linked.sessionId}\nWorking directory: ${linked.cwd}`
+          : `No Pi session is linked yet.\nWorking directory: ${config.cwd}`,
+      );
+      return;
+    }
+
+    await telegramApi(config.token, "sendChatAction", { chat_id: chatId, action: "typing" });
+    try {
+      const session = await this.getSession(chatId, config.cwd);
+      const answer = await this.prompt(session, text);
+      await this.sendText(config.token, chatId, answer || "Pi completed the request without a text response.");
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : String(error);
+      await this.sendText(config.token, chatId, `Pi bridge error: ${messageText}`);
+    }
+  }
+
+  private async getSession(chatId: string, cwd: string): Promise<AgentSessionWrapper> {
+    const record = this.state.chats[chatId];
+    if (record && record.cwd === cwd && record.sessionFile && existsSync(record.sessionFile)) {
+      const { session } = await startRpcSession(record.sessionId, record.sessionFile, cwd);
+      return session;
+    }
+
+    const tempKey = `__telegram__${chatId}_${Date.now()}`;
+    const { session, realSessionId } = await startRpcSession(tempKey, "", cwd);
+    this.state.chats[chatId] = {
+      sessionId: realSessionId,
+      sessionFile: session.sessionFile,
+      cwd,
+    };
+    writeBridgeState(this.state);
+    return session;
+  }
+
+  private async prompt(session: AgentSessionWrapper, message: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        unsubscribe();
+        reject(new Error("Pi did not finish within 30 minutes."));
+      }, 30 * 60 * 1000);
+      const finish = async (error?: string) => {
+        clearTimeout(timeout);
+        unsubscribe();
+        if (error) {
+          reject(new Error(error));
+          return;
+        }
+        try {
+          const result = await session.send({ type: "get_last_assistant_text" }) as { text?: string };
+          resolve(result.text ?? "");
+        } catch (err) {
+          reject(err);
+        }
+      };
+      const unsubscribe = session.onEvent((event) => {
+        if (event.type === "prompt_error") void finish(String(event.errorMessage ?? "Pi prompt failed."));
+        else if (event.type === "prompt_done") void finish();
+      });
+
+      session.send({ type: "prompt", message }).catch((error) => {
+        void finish(error instanceof Error ? error.message : String(error));
+      });
+    });
+  }
+
+  private async sendText(token: string, chatId: string, text: string): Promise<void> {
+    const parts = splitTelegramMessage(text);
+    for (const part of parts) {
+      await telegramApi(token, "sendMessage", {
+        chat_id: chatId,
+        text: part,
+        link_preview_options: { is_disabled: true },
+      });
+    }
+  }
+}
+
+declare global {
+  var __piWebTelegramBridge: TelegramBridge | undefined;
+}
+
+export function getTelegramBridge(): TelegramBridge {
+  if (!globalThis.__piWebTelegramBridge) {
+    globalThis.__piWebTelegramBridge = new TelegramBridge();
+  }
+  return globalThis.__piWebTelegramBridge;
+}
+
+export function startTelegramBridge(): void {
+  getTelegramBridge().start();
+}

--- a/lib/telegram-bridge.ts
+++ b/lib/telegram-bridge.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { startRpcSession, type AgentSessionWrapper } from "./rpc-manager";
+import { getRpcSession, startRpcSession, type AgentEvent, type AgentSessionWrapper } from "./rpc-manager";
 import { readTelegramConfig, type TelegramBridgeConfig } from "./telegram-config";
 
 type TelegramUser = {
@@ -14,6 +14,10 @@ type TelegramMessage = {
   text?: string;
   chat: { id: number; type: string };
   from?: TelegramUser;
+};
+
+type TelegramSentMessage = {
+  message_id: number;
 };
 
 type TelegramUpdate = {
@@ -55,6 +59,42 @@ const EMPTY_STATUS: TelegramBridgeStatus = {
 };
 
 const TELEGRAM_MESSAGE_LIMIT = 4096;
+const TELEGRAM_LIVE_EDIT_INTERVAL_MS = 1_100;
+const TELEGRAM_THINKING_PREVIEW_LIMIT = 1_200;
+
+type TelegramUsage = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  cost?: { total?: number };
+};
+
+type ModelStreamBlock = {
+  kind: "model";
+  model: string;
+  thinking: string;
+  text: string;
+  usage?: TelegramUsage;
+  active: boolean;
+};
+
+type ToolStreamBlock = {
+  kind: "tool";
+  id: string;
+  name: string;
+  preview: string;
+  startedAt: number;
+  finishedAt?: number;
+  isError?: boolean;
+};
+
+type NoticeStreamBlock = {
+  kind: "notice";
+  text: string;
+};
+
+type StreamBlock = ModelStreamBlock | ToolStreamBlock | NoticeStreamBlock;
 
 export function splitTelegramMessage(text: string, limit = TELEGRAM_MESSAGE_LIMIT): string[] {
   const normalized = text.trim();
@@ -77,6 +117,329 @@ export function splitTelegramMessage(text: string, limit = TELEGRAM_MESSAGE_LIMI
 
   if (remaining) parts.push(remaining);
   return parts;
+}
+
+function formatModelName(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "Pi";
+  const replacements: Record<string, string> = {
+    ai: "AI",
+    claude: "Claude",
+    deepseek: "DeepSeek",
+    flash: "Flash",
+    gemini: "Gemini",
+    gpt: "GPT",
+    kimi: "Kimi",
+    mini: "Mini",
+    qwen: "Qwen",
+    turbo: "Turbo",
+  };
+  return trimmed
+    .split(/[-_/\s]+/)
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (replacements[lower]) return replacements[lower];
+      if (/^v\d+(?:\.\d+)?$/i.test(part)) return part.toUpperCase();
+      if (/^\d+(?:\.\d+)*[a-z]?$/i.test(part)) return part.toUpperCase();
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+}
+
+function formatDuration(startedAt: number, finishedAt = Date.now()): string {
+  const seconds = Math.max(0, finishedAt - startedAt) / 1_000;
+  if (seconds < 1) return "<1s";
+  if (seconds < 10) return `${seconds.toFixed(1).replace(/\.0$/, "")}s`;
+  return `${Math.round(seconds)}s`;
+}
+
+function formatUsage(usage?: TelegramUsage): string {
+  if (!usage) return "";
+  const parts: string[] = [];
+  if (usage.input) parts.push(`${usage.input.toLocaleString()} in`);
+  if (usage.output) parts.push(`${usage.output.toLocaleString()} out`);
+  if (usage.cacheRead) parts.push(`${usage.cacheRead.toLocaleString()} cache`);
+  if (usage.cacheWrite) parts.push(`${usage.cacheWrite.toLocaleString()} cache write`);
+  if (usage.cost?.total) parts.push(`$${usage.cost.total.toFixed(4)}`);
+  return parts.join(" · ");
+}
+
+function previewToolArgs(args: unknown): string {
+  if (!args || typeof args !== "object") return "";
+  const input = args as Record<string, unknown>;
+  const preferredKeys = ["command", "path", "file_path", "pattern", "query", "url", "description"];
+  for (const key of preferredKeys) {
+    if (!(key in input)) continue;
+    const value = String(input[key] ?? "").trim();
+    if (value) return value.length > 700 ? `${value.slice(0, 697)}...` : value;
+  }
+  const safeEntries = Object.entries(input)
+    .filter(([key]) => !["content", "data", "image", "base64"].includes(key.toLowerCase()))
+    .slice(0, 5);
+  if (safeEntries.length === 0) return "";
+  const value = JSON.stringify(Object.fromEntries(safeEntries));
+  return value.length > 700 ? `${value.slice(0, 697)}...` : value;
+}
+
+function readAssistantSnapshot(message: unknown): {
+  model: string;
+  thinking: string;
+  text: string;
+  usage?: TelegramUsage;
+} | null {
+  if (!message || typeof message !== "object") return null;
+  const candidate = message as {
+    role?: unknown;
+    model?: unknown;
+    content?: unknown;
+    usage?: TelegramUsage;
+  };
+  if (candidate.role !== "assistant") return null;
+  const content = Array.isArray(candidate.content) ? candidate.content : [];
+  const thinking: string[] = [];
+  const text: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const item = block as { type?: unknown; thinking?: unknown; text?: unknown };
+    if (item.type === "thinking" && typeof item.thinking === "string") thinking.push(item.thinking);
+    if (item.type === "text" && typeof item.text === "string") text.push(item.text);
+  }
+  return {
+    model: typeof candidate.model === "string" ? candidate.model : "",
+    thinking: thinking.join("\n"),
+    text: text.join("\n"),
+    usage: candidate.usage,
+  };
+}
+
+function truncateThinking(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= TELEGRAM_THINKING_PREVIEW_LIMIT) return trimmed;
+  return `…\n${trimmed.slice(-TELEGRAM_THINKING_PREVIEW_LIMIT)}`;
+}
+
+function renderStreamBlocks(blocks: StreamBlock[], final: boolean): string {
+  const sections = blocks.map((block, index) => {
+    if (block.kind === "notice") return block.text;
+    if (block.kind === "tool") {
+      const duration = formatDuration(block.startedAt, block.finishedAt);
+      const nextBlock = blocks[index + 1];
+      const previousModel = [...blocks.slice(0, index)].reverse().find(
+        (candidate): candidate is ModelStreamBlock => candidate.kind === "model",
+      );
+      const usage = nextBlock?.kind === "tool" ? "" : formatUsage(previousModel?.usage);
+      return [
+        `${block.isError ? "✕ " : ""}${block.name}`,
+        block.preview,
+        block.finishedAt ? duration : `${duration} · running`,
+        usage,
+      ].filter(Boolean).join("\n");
+    }
+
+    const thinking = truncateThinking(block.thinking);
+    const nextBlock = blocks[index + 1];
+    const usage = nextBlock?.kind === "tool" ? "" : formatUsage(block.usage);
+    let section = `${block.model}\n\n${thinking ? `Thinking\n${thinking}` : `Thinking${block.active && !final ? "…" : ""}`}`;
+    if (block.text) section += `\n\n${block.text}`;
+    if (usage) section += `\n\n${usage}`;
+    return section;
+  });
+  return sections.filter(Boolean).join("\n\n").trim() || "Pi\n\nThinking…";
+}
+
+function fitLiveMessage(text: string): string {
+  if (text.length <= TELEGRAM_MESSAGE_LIMIT) return text;
+  const headLength = 1_250;
+  const marker = "\n\n… live output truncated …\n\n";
+  const tailLength = TELEGRAM_MESSAGE_LIMIT - headLength - marker.length;
+  return `${text.slice(0, headLength)}${marker}${text.slice(-tailLength)}`;
+}
+
+class TelegramLiveMessage {
+  private pendingText: string | null = null;
+  private lastText = "";
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly token: string,
+    private readonly chatId: string,
+    private readonly messageId: number,
+  ) {}
+
+  update(text: string): void {
+    this.pendingText = fitLiveMessage(text);
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.queuePendingEdit();
+    }, TELEGRAM_LIVE_EDIT_INTERVAL_MS);
+  }
+
+  async finish(text: string): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.pendingText = null;
+    await this.inFlight;
+
+    const parts = splitTelegramMessage(text);
+    if (parts.length === 0) return;
+    await this.edit(parts[0]);
+    for (const part of parts.slice(1)) {
+      await telegramApi(this.token, "sendMessage", {
+        chat_id: this.chatId,
+        text: part,
+        link_preview_options: { is_disabled: true },
+      });
+    }
+  }
+
+  private queuePendingEdit(): void {
+    const text = this.pendingText;
+    this.pendingText = null;
+    if (!text || text === this.lastText) return;
+    this.inFlight = this.inFlight
+      .then(() => this.edit(text))
+      .catch((error) => {
+        console.error("[pi-web] Telegram live edit failed:", error instanceof Error ? error.message : error);
+      })
+      .finally(() => {
+        if (this.pendingText && !this.timer) {
+          this.timer = setTimeout(() => {
+            this.timer = null;
+            this.queuePendingEdit();
+          }, TELEGRAM_LIVE_EDIT_INTERVAL_MS);
+        }
+      });
+  }
+
+  private async edit(text: string): Promise<void> {
+    if (!text || text === this.lastText) return;
+    try {
+      await telegramApi(this.token, "editMessageText", {
+        chat_id: this.chatId,
+        message_id: this.messageId,
+        text,
+        link_preview_options: { is_disabled: true },
+      });
+      this.lastText = text;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("message is not modified")) {
+        this.lastText = text;
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+class TelegramPromptStream {
+  private readonly blocks: StreamBlock[] = [];
+  private currentModel: ModelStreamBlock | null = null;
+
+  constructor(
+    private readonly liveMessage: TelegramLiveMessage,
+    private readonly fallbackModel: string,
+  ) {}
+
+  handle(event: AgentEvent): void {
+    switch (event.type) {
+      case "message_start":
+        this.beginOrUpdateModel(event.message);
+        break;
+      case "message_update":
+        this.beginOrUpdateModel(event.message);
+        break;
+      case "message_end":
+        this.beginOrUpdateModel(event.message);
+        if (this.currentModel) this.currentModel.active = false;
+        this.currentModel = null;
+        break;
+      case "tool_execution_start":
+        this.blocks.push({
+          kind: "tool",
+          id: String(event.toolCallId ?? ""),
+          name: String(event.toolName ?? "tool"),
+          preview: previewToolArgs(event.args),
+          startedAt: Date.now(),
+        });
+        break;
+      case "tool_execution_end": {
+        const id = String(event.toolCallId ?? "");
+        const tool = [...this.blocks].reverse().find(
+          (block): block is ToolStreamBlock => block.kind === "tool" && block.id === id,
+        );
+        if (tool) {
+          tool.finishedAt = Date.now();
+          tool.isError = event.isError === true;
+        }
+        break;
+      }
+      case "auto_retry_start":
+        this.blocks.push({
+          kind: "notice",
+          text: `Retry ${String(event.attempt ?? "")}/${String(event.maxAttempts ?? "")}\n${String(event.errorMessage ?? "")}`.trim(),
+        });
+        break;
+      case "compaction_start":
+      case "auto_compaction_start":
+        this.blocks.push({ kind: "notice", text: "Compacting context…" });
+        break;
+    }
+    this.liveMessage.update(renderStreamBlocks(this.blocks, false));
+  }
+
+  async finish(): Promise<void> {
+    if (this.currentModel) this.currentModel.active = false;
+    await this.liveMessage.finish(renderStreamBlocks(this.blocks, true));
+  }
+
+  ensureFinalAnswer(answer: string): void {
+    const trimmed = answer.trim();
+    if (!trimmed) return;
+    const lastModel = [...this.blocks].reverse().find(
+      (block): block is ModelStreamBlock => block.kind === "model",
+    );
+    if (lastModel?.text.trim()) return;
+    if (lastModel) {
+      lastModel.text = trimmed;
+      lastModel.active = false;
+      return;
+    }
+    this.blocks.push({
+      kind: "model",
+      model: formatModelName(this.fallbackModel),
+      thinking: "",
+      text: trimmed,
+      active: false,
+    });
+  }
+
+  addError(message: string): void {
+    this.blocks.push({ kind: "notice", text: `Pi bridge error\n${message}` });
+  }
+
+  private beginOrUpdateModel(message: unknown): void {
+    const snapshot = readAssistantSnapshot(message);
+    if (!snapshot) return;
+    if (!this.currentModel) {
+      this.currentModel = {
+        kind: "model",
+        model: formatModelName(snapshot.model || this.fallbackModel),
+        thinking: "",
+        text: "",
+        active: true,
+      };
+      this.blocks.push(this.currentModel);
+    }
+    this.currentModel.model = formatModelName(snapshot.model || this.fallbackModel);
+    this.currentModel.thinking = snapshot.thinking;
+    this.currentModel.text = snapshot.text;
+    this.currentModel.usage = snapshot.usage;
+  }
 }
 function telegramStatePath(): string {
   return join(getAgentDir(), "pi-web-telegram-state.json");
@@ -137,6 +500,7 @@ class TelegramBridge {
   private state: TelegramBridgeState = readBridgeState();
   private status: TelegramBridgeStatus = { ...EMPTY_STATUS };
   private chatQueues = new Map<string, Promise<void>>();
+  private respondingChats = new Map<string, number>();
 
   getStatus(): TelegramBridgeStatus {
     return { ...this.status };
@@ -184,6 +548,22 @@ class TelegramBridge {
 
   private async poll(config: TelegramBridgeConfig, signal: AbortSignal): Promise<void> {
     const bot = await testTelegramToken(config.token);
+    try {
+      await telegramApi(config.token, "setMyCommands", {
+        commands: [
+          { command: "new", description: "Start a fresh Pi session" },
+          { command: "status", description: "Show the linked session" },
+          { command: "model", description: "Show the active model" },
+          { command: "stats", description: "Show token and cost totals" },
+          { command: "stop", description: "Abort the current run" },
+          { command: "help", description: "Show bridge commands" },
+        ],
+      }, signal);
+    } catch (error) {
+      if (!signal.aborted) {
+        console.warn("[pi-web] failed to register Telegram bot commands:", error instanceof Error ? error.message : error);
+      }
+    }
     this.status.botUsername = bot.username || null;
     this.status.lastConnectedAt = new Date().toISOString();
     this.status.lastError = null;
@@ -218,6 +598,21 @@ class TelegramBridge {
 
   private enqueueMessage(config: TelegramBridgeConfig, message: TelegramMessage): void {
     const chatId = String(message.chat.id);
+    if (!config.allowedChatIds.includes(chatId)) return;
+    const text = message.text?.trim() ?? "";
+    if (text === "/stop") {
+      void this.stopChat(config.token, chatId);
+      return;
+    }
+    const isBridgeCommand = ["/start", "/help", "/new", "/status", "/model", "/stats"].includes(text);
+    const createsModelRun = Boolean(text) && !isBridgeCommand;
+    if (config.blockWhileRunning && (this.respondingChats.get(chatId) ?? 0) > 0) {
+      void this.sendModelBusy(config.token, chatId);
+      return;
+    }
+    if (createsModelRun) {
+      this.respondingChats.set(chatId, (this.respondingChats.get(chatId) ?? 0) + 1);
+    }
     const previous = this.chatQueues.get(chatId) ?? Promise.resolve();
     const next = previous
       .catch(() => {})
@@ -226,6 +621,11 @@ class TelegramBridge {
         console.error(`[pi-web] Telegram chat ${chatId} failed:`, error);
       })
       .finally(() => {
+        if (createsModelRun) {
+          const remaining = (this.respondingChats.get(chatId) ?? 1) - 1;
+          if (remaining > 0) this.respondingChats.set(chatId, remaining);
+          else this.respondingChats.delete(chatId);
+        }
         if (this.chatQueues.get(chatId) === next) this.chatQueues.delete(chatId);
       });
     this.chatQueues.set(chatId, next);
@@ -246,7 +646,16 @@ class TelegramBridge {
       await this.sendText(
         config.token,
         chatId,
-        "Pi Web bridge is ready.\n\nSend a message to talk to Pi.\n/new — start a fresh Pi session\n/status — show the linked session",
+        [
+          "Pi Web bridge is ready.",
+          "",
+          "Send a message to talk to Pi with live Thinking, tool calls, timing, and usage.",
+          "/new — start a fresh Pi session",
+          "/status — show the linked session",
+          "/model — show the active model",
+          "/stats — show session token and cost totals",
+          "/stop — abort the current run",
+        ].join("\n"),
       );
       return;
     }
@@ -267,16 +676,108 @@ class TelegramBridge {
       );
       return;
     }
+    if (text === "/model") {
+      const linked = this.state.chats[chatId];
+      if (!linked) {
+        await this.sendText(config.token, chatId, "No Pi session is linked yet.");
+        return;
+      }
+      const session = await this.getSession(chatId, config.cwd);
+      const model = session.inner.model;
+      await this.sendText(
+        config.token,
+        chatId,
+        model
+          ? `${formatModelName(model.name || model.id)}\n${model.provider}/${model.id}`
+          : "No model is selected for this session.",
+      );
+      return;
+    }
+    if (text === "/stats") {
+      const linked = this.state.chats[chatId];
+      if (!linked) {
+        await this.sendText(config.token, chatId, "No Pi session is linked yet.");
+        return;
+      }
+      const session = await this.getSession(chatId, config.cwd);
+      const stats = await session.send({ type: "get_session_stats" }) as {
+        userMessages?: number;
+        assistantMessages?: number;
+        toolCalls?: number;
+        tokens?: {
+          input?: number;
+          output?: number;
+          cacheRead?: number;
+          cacheWrite?: number;
+          total?: number;
+        };
+        cost?: number;
+      };
+      await this.sendText(config.token, chatId, [
+        "Session stats",
+        `${(stats.userMessages ?? 0).toLocaleString()} user · ${(stats.assistantMessages ?? 0).toLocaleString()} assistant · ${(stats.toolCalls ?? 0).toLocaleString()} tools`,
+        `${(stats.tokens?.input ?? 0).toLocaleString()} in · ${(stats.tokens?.output ?? 0).toLocaleString()} out · ${(stats.tokens?.cacheRead ?? 0).toLocaleString()} cache`,
+        `${(stats.tokens?.total ?? 0).toLocaleString()} total · $${(stats.cost ?? 0).toFixed(4)}`,
+      ].join("\n"));
+      return;
+    }
 
     await telegramApi(config.token, "sendChatAction", { chat_id: chatId, action: "typing" });
+    let stream: TelegramPromptStream | null = null;
+    let typingTimer: ReturnType<typeof setInterval> | null = null;
     try {
       const session = await this.getSession(chatId, config.cwd);
-      const answer = await this.prompt(session, text);
-      await this.sendText(config.token, chatId, answer || "Pi completed the request without a text response.");
+      const selectedModel = session.inner.model;
+      const fallbackModel = selectedModel?.name || selectedModel?.id || "Pi";
+      const initial = await telegramApi<TelegramSentMessage>(config.token, "sendMessage", {
+        chat_id: chatId,
+        text: `${formatModelName(fallbackModel)}\n\nThinking…`,
+        link_preview_options: { is_disabled: true },
+      });
+      stream = new TelegramPromptStream(
+        new TelegramLiveMessage(config.token, chatId, initial.message_id),
+        fallbackModel,
+      );
+      typingTimer = setInterval(() => {
+        void telegramApi(config.token, "sendChatAction", { chat_id: chatId, action: "typing" }).catch(() => {});
+      }, 4_000);
+      const answer = await this.prompt(session, text, stream);
+      stream.ensureFinalAnswer(answer || "Pi completed the request without a text response.");
+      await stream.finish();
     } catch (error) {
       const messageText = error instanceof Error ? error.message : String(error);
-      await this.sendText(config.token, chatId, `Pi bridge error: ${messageText}`);
+      if (stream) {
+        stream.addError(messageText);
+        await stream.finish();
+      } else {
+        await this.sendText(config.token, chatId, `Pi bridge error: ${messageText}`);
+      }
+    } finally {
+      if (typingTimer) clearInterval(typingTimer);
     }
+  }
+
+  private async stopChat(token: string, chatId: string): Promise<void> {
+    const linked = this.state.chats[chatId];
+    const session = linked ? getRpcSession(linked.sessionId) : undefined;
+    if (!session?.isRunning()) {
+      await this.sendText(token, chatId, "There is no active Pi run to stop.");
+      return;
+    }
+    await session.send({ type: "abort" });
+    await this.sendText(token, chatId, "Stopping the current Pi run.");
+  }
+
+  private async sendModelBusy(token: string, chatId: string): Promise<void> {
+    const linked = this.state.chats[chatId];
+    const session = linked ? getRpcSession(linked.sessionId) : undefined;
+    const model = session?.inner.model;
+    const modelName = formatModelName(model?.name || model?.id || "Model");
+    await this.sendText(
+      token,
+      chatId,
+      `${modelName} is responding.\nWait for it to finish or send /stop to abort the current run.`,
+    );
   }
 
   private async getSession(chatId: string, cwd: string): Promise<AgentSessionWrapper> {
@@ -297,7 +798,11 @@ class TelegramBridge {
     return session;
   }
 
-  private async prompt(session: AgentSessionWrapper, message: string): Promise<string> {
+  private async prompt(
+    session: AgentSessionWrapper,
+    message: string,
+    stream: TelegramPromptStream,
+  ): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {
         unsubscribe();
@@ -318,6 +823,7 @@ class TelegramBridge {
         }
       };
       const unsubscribe = session.onEvent((event) => {
+        stream.handle(event);
         if (event.type === "prompt_error") void finish(String(event.errorMessage ?? "Pi prompt failed."));
         else if (event.type === "prompt_done") void finish();
       });

--- a/lib/telegram-config.test.mjs
+++ b/lib/telegram-config.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { normalizeAllowedChatIds, toPublicTelegramConfig, validateTelegramConfig } =
+  await jiti.import("./telegram-config.ts");
+const { splitTelegramMessage } = await jiti.import("./telegram-bridge.ts");
+
+test("normalizes and deduplicates Telegram chat IDs", () => {
+  assert.deepEqual(
+    normalizeAllowedChatIds("123, -456\n123 invalid 7.5"),
+    ["123", "-456"],
+  );
+});
+test("never exposes the Telegram token in public config", () => {
+  const publicConfig = toPublicTelegramConfig({
+    enabled: true,
+    token: "123456:secret-token-value",
+    allowedChatIds: ["123"],
+    cwd: "C:\\project",
+  });
+
+  assert.equal(publicConfig.tokenConfigured, true);
+  assert.equal(publicConfig.tokenHint, "••••-value");
+  assert.equal("token" in publicConfig, false);
+});
+
+test("disabled Telegram bridge can be saved without credentials", () => {
+  assert.equal(validateTelegramConfig({
+    enabled: false,
+    token: "",
+    allowedChatIds: [],
+    cwd: "",
+  }), null);
+});
+
+test("splits long Telegram messages without losing content", () => {
+  const text = `${"a".repeat(3_900)}\n${"b".repeat(500)}`;
+  const parts = splitTelegramMessage(text);
+
+  assert.equal(parts.length, 2);
+  assert.ok(parts.every((part) => part.length <= 4_096));
+  assert.equal(parts.join("\n"), text);
+});

--- a/lib/telegram-config.ts
+++ b/lib/telegram-config.ts
@@ -7,6 +7,7 @@ export type TelegramBridgeConfig = {
   token: string;
   allowedChatIds: string[];
   cwd: string;
+  blockWhileRunning: boolean;
 };
 
 export type TelegramBridgePublicConfig = Omit<TelegramBridgeConfig, "token"> & {
@@ -19,6 +20,7 @@ const DEFAULT_CONFIG: TelegramBridgeConfig = {
   token: "",
   allowedChatIds: [],
   cwd: "",
+  blockWhileRunning: true,
 };
 
 export function normalizeAllowedChatIds(value: unknown): string[] {
@@ -47,6 +49,7 @@ export function readTelegramConfig(): TelegramBridgeConfig {
       token: typeof parsed.token === "string" ? parsed.token.trim() : "",
       allowedChatIds: normalizeAllowedChatIds(parsed.allowedChatIds),
       cwd: typeof parsed.cwd === "string" ? parsed.cwd.trim() : "",
+      blockWhileRunning: parsed.blockWhileRunning !== false,
     };
   } catch (error) {
     console.error("[pi-web] failed to read Telegram bridge config:", error);
@@ -60,6 +63,7 @@ export function toPublicTelegramConfig(config: TelegramBridgeConfig): TelegramBr
     enabled: config.enabled,
     allowedChatIds: config.allowedChatIds,
     cwd: config.cwd,
+    blockWhileRunning: config.blockWhileRunning,
     tokenConfigured: token.length > 0,
     tokenHint: token ? `••••${token.slice(-6)}` : null,
   };

--- a/lib/telegram-config.ts
+++ b/lib/telegram-config.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export type TelegramBridgeConfig = {
+  enabled: boolean;
+  token: string;
+  allowedChatIds: string[];
+  cwd: string;
+};
+
+export type TelegramBridgePublicConfig = Omit<TelegramBridgeConfig, "token"> & {
+  tokenConfigured: boolean;
+  tokenHint: string | null;
+};
+
+const DEFAULT_CONFIG: TelegramBridgeConfig = {
+  enabled: false,
+  token: "",
+  allowedChatIds: [],
+  cwd: "",
+};
+
+export function normalizeAllowedChatIds(value: unknown): string[] {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/[\s,]+/)
+      : [];
+
+  return [...new Set(values
+    .map((entry) => String(entry).trim())
+    .filter((entry) => /^-?\d+$/.test(entry)))];
+}
+export function telegramConfigPath(): string {
+  return join(getAgentDir(), "pi-web-telegram.json");
+}
+
+export function readTelegramConfig(): TelegramBridgeConfig {
+  const path = telegramConfigPath();
+  if (!existsSync(path)) return { ...DEFAULT_CONFIG };
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<TelegramBridgeConfig>;
+    return {
+      enabled: parsed.enabled === true,
+      token: typeof parsed.token === "string" ? parsed.token.trim() : "",
+      allowedChatIds: normalizeAllowedChatIds(parsed.allowedChatIds),
+      cwd: typeof parsed.cwd === "string" ? parsed.cwd.trim() : "",
+    };
+  } catch (error) {
+    console.error("[pi-web] failed to read Telegram bridge config:", error);
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function toPublicTelegramConfig(config: TelegramBridgeConfig): TelegramBridgePublicConfig {
+  const token = config.token.trim();
+  return {
+    enabled: config.enabled,
+    allowedChatIds: config.allowedChatIds,
+    cwd: config.cwd,
+    tokenConfigured: token.length > 0,
+    tokenHint: token ? `••••${token.slice(-6)}` : null,
+  };
+}
+
+export function validateTelegramConfig(config: TelegramBridgeConfig): string | null {
+  if (!config.enabled) return null;
+  if (!config.token) return "Bot token is required when the Telegram bridge is enabled.";
+  if (!/^\d+:[A-Za-z0-9_-]+$/.test(config.token)) return "Bot token format is invalid.";
+  if (config.allowedChatIds.length === 0) return "Add at least one allowed Telegram chat ID.";
+  if (!config.cwd) return "Working directory is required when the Telegram bridge is enabled.";
+  if (!existsSync(config.cwd)) return `Working directory does not exist: ${config.cwd}`;
+  return null;
+}
+
+export function writeTelegramConfig(config: TelegramBridgeConfig): void {
+  const path = telegramConfigPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(tempPath, path);
+}


### PR DESCRIPTION
Hi, and thank you for maintaining Pi Web.

This PR proposes an optional bot bridge for users who would like to follow and control a Pi session from Telegram. The feature is disabled by default and can be configured from a new **Bridge** button in the top action bar.

### What it adds

- Server-side bot-token storage with only a masked hint exposed to the browser
- Allow-listed chat IDs and a configurable working directory
- One persistent Pi session per chat
- Live message updates for the model name, Thinking output, tool calls and arguments, tool duration, token/cache usage, cost, and streamed response text
- Throttled message editing to avoid Telegram API rate limits
- An optional guard that rejects new messages while the model is responding
- `/new`, `/status`, `/model`, `/stats`, `/stop`, and `/help` commands
- Responsive Bridge settings UI integrated with the existing Pi Web styling
- English and Chinese README documentation

The implementation keeps the integration opt-in and local: enabling it requires an explicit token, at least one allowed chat ID, and a working directory.

I would be grateful if you would consider including this feature. I am happy to adjust the UI, naming, behavior, or implementation details to better match the project's direction. Thank you for your time and review.

### Testing

Not run in this iteration.