### PR TITLE
feat(explorer): quick changes viewer in explorer toolbar

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -372,13 +372,35 @@ export function AppShell() {
     }
   }, [selectedSession, router]);
 
-  const handleOpenFile = useCallback((filePath: string, fileName: string, sourceSessionId?: string | null) => {
+  const handleOpenFile = useCallback((
+    filePath: string,
+    fileName: string,
+    options?: { sourceSessionId?: string | null; modeHint?: "diff" },
+  ) => {
+    const sourceSessionId = options?.sourceSessionId;
+    const modeHint = options?.modeHint;
     const tabId = `file:${filePath}`;
     setFileTabs((prev) => {
       const existing = prev.find((t) => t.id === tabId);
-      if (!existing) return [...prev, { id: tabId, label: fileName, filePath, sourceSessionId }];
-      if (!sourceSessionId || existing.sourceSessionId === sourceSessionId) return prev;
-      return prev.map((t) => t.id === tabId ? { ...t, sourceSessionId } : t);
+      if (!existing) {
+        return [...prev, {
+          id: tabId,
+          label: fileName,
+          filePath,
+          sourceSessionId,
+          initialDisplayMode: modeHint,
+        }];
+      }
+      const sourceUnchanged = !sourceSessionId || existing.sourceSessionId === sourceSessionId;
+      const modeUnchanged = !modeHint || existing.initialDisplayMode === modeHint;
+      if (sourceUnchanged && modeUnchanged) return prev;
+      return prev.map((t) => {
+        if (t.id !== tabId) return t;
+        const next: Tab = { ...t };
+        if (sourceSessionId) next.sourceSessionId = sourceSessionId;
+        if (modeHint) next.initialDisplayMode = modeHint;
+        return next;
+      });
     });
     setActiveFileTabId(tabId);
     setRightPanelOpen(true);
@@ -387,7 +409,7 @@ export function AppShell() {
   }, [isMobile]);
 
   const handleOpenLinkedFile = useCallback((filePath: string) => {
-    handleOpenFile(filePath, getFileName(filePath), selectedSession?.id ?? null);
+    handleOpenFile(filePath, getFileName(filePath), { sourceSessionId: selectedSession?.id ?? null });
   }, [handleOpenFile, selectedSession?.id]);
 
   const handleCloseFileTab = useCallback((tabId: string) => {
@@ -1239,10 +1261,11 @@ export function AppShell() {
               cwd={activeCwd ?? undefined}
               sourceSessionId={activeFileTab.sourceSessionId}
               gitRefreshKey={explorerRefreshKey}
+              initialDisplayMode={activeFileTab.initialDisplayMode}
               onOpenFile={(filePath) => handleOpenFile(
                 filePath,
                 getFileName(filePath),
-                activeFileTab.sourceSessionId,
+                { sourceSessionId: activeFileTab.sourceSessionId },
               )}
             />
           ) : (

--- a/components/FileExplorer.tsx
+++ b/components/FileExplorer.tsx
@@ -5,6 +5,7 @@ import { getFileIcon, FolderIcon } from "./FileIcons";
 import {
   encodeFilePathForApi,
   getFileDirectory,
+  getFileName,
   getRelativeFilePath,
   joinFilePath,
   normalizeFilePathSlashes,
@@ -29,11 +30,13 @@ interface FileNode {
 
 interface Props {
   cwd: string;
-  onOpenFile: (filePath: string, fileName: string) => void;
+  onOpenFile: (filePath: string, fileName: string, options?: OpenFileOptions) => void;
   refreshKey?: number;
   onAtMention?: (relativePath: string, isDir: boolean) => void;
   onAtMentions?: (relativePaths: string[]) => void;
   onUploadBusyChange?: (busy: boolean) => void;
+  changesCollapsed: boolean;
+  onChangesCountChange?: (count: number) => void;
 }
 
 export interface FileExplorerHandle {
@@ -118,6 +121,26 @@ const GIT_STATUS_COLORS: Record<GitFileStatusKind, string> = {
   conflict: "#f87171",
 };
 
+function GitStatusBadge({ status }: { status: GitFileStatus }) {
+  return (
+    <span
+      title={GIT_STATUS_LABELS[status.status]}
+      aria-label={GIT_STATUS_LABELS[status.status]}
+      style={{
+        width: 14,
+        flexShrink: 0,
+        color: GIT_STATUS_COLORS[status.status],
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        fontWeight: 600,
+        textAlign: "center",
+      }}
+    >
+      {status.code}
+    </span>
+  );
+}
+
 function uploadFiles(
   targetDirectory: string,
   files: File[],
@@ -197,7 +220,7 @@ function TreeNode({
   node: FileNode;
   depth: number;
   cwd: string;
-  onOpenFile: (filePath: string, fileName: string) => void;
+  onOpenFile: (filePath: string, fileName: string, options?: OpenFileOptions) => void;
   onAtMention?: (relativePath: string, isDir: boolean) => void;
   expandedPaths: Set<string>;
   onToggleExpanded: (fullPath: string, open: boolean) => void;
@@ -304,21 +327,7 @@ function TreeNode({
           />
         )}
         {!hovered && !node.isDir && gitStatus && (
-          <span
-            title={GIT_STATUS_LABELS[gitStatus.status]}
-            aria-label={GIT_STATUS_LABELS[gitStatus.status]}
-            style={{
-              width: 14,
-              flexShrink: 0,
-              color: GIT_STATUS_COLORS[gitStatus.status],
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-              fontWeight: 600,
-              textAlign: "center",
-            }}
-          >
-            {gitStatus.code}
-          </span>
+          <GitStatusBadge status={gitStatus} />
         )}
         {!hovered && containsGitChanges && (
           <span
@@ -435,6 +444,61 @@ function TreeNode({
   );
 }
 
+type OpenFileOptions = { sourceSessionId?: string | null; modeHint?: "diff" };
+
+type OpenFileHandler = (filePath: string, fileName: string, options?: OpenFileOptions) => void;
+
+function ChangeRow({
+  status,
+  cwd,
+  onOpenFile,
+}: {
+  status: GitFileStatus;
+  cwd: string;
+  onOpenFile: OpenFileHandler;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const name = getFileName(status.filePath);
+  const rel = getRelativeFilePath(status.filePath, cwd);
+  return (
+    <div
+      onClick={() => onOpenFile(status.filePath, name, { modeHint: "diff" })}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      title={status.filePath}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        paddingLeft: 10,
+        paddingRight: 8,
+        height: 22,
+        cursor: "pointer",
+        background: hovered ? "var(--bg-hover)" : "transparent",
+        borderRadius: 4,
+        userSelect: "none",
+      }}
+    >
+      <GitStatusBadge status={status} />
+      <span style={{ flexShrink: 0, display: "flex", alignItems: "center", opacity: 0.85 }}>
+        {getFileIcon(name, 13)}
+      </span>
+      <span
+        style={{
+          fontSize: 12,
+          color: "var(--text)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          flex: 1,
+        }}
+      >
+        {rel}
+      </span>
+    </div>
+  );
+}
+
 export const FileExplorer = forwardRef<FileExplorerHandle, Props>(function FileExplorer({
   cwd,
   onOpenFile,
@@ -442,6 +506,8 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(function FileE
   onAtMention,
   onAtMentions,
   onUploadBusyChange,
+  changesCollapsed,
+  onChangesCountChange,
 }, ref) {
   const [roots, setRoots] = useState<FileNode[]>([]);
   const [loading, setLoading] = useState(true);
@@ -622,6 +688,10 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(function FileE
     return () => { cancelled = true; };
   }, [cwd, refreshKey, treeRefreshKey]);
 
+  useEffect(() => {
+    onChangesCountChange?.(gitFiles.length);
+  }, [gitFiles, onChangesCountChange]);
+
   const showUploadFeedback = uploadBusy || pendingConflict !== null || uploadError !== null || uploadSummary !== null;
 
   const addUploadedFilesToChat = useCallback(() => {
@@ -752,35 +822,47 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(function FileE
         </div>
       )}
 
-      <div style={{ padding: "2px 4px" }}>
-        {loading ? (
-          <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-dim)" }}>Loading files...</div>
-        ) : error ? (
-          <div style={{ padding: "8px 12px", fontSize: 11, color: "#f87171" }}>{error}</div>
-        ) : (
-          roots.map((node) => (
-            <TreeNode
-              key={node.fullPath}
-              node={node}
-              depth={0}
-              cwd={cwd}
-              onOpenFile={onOpenFile}
-              onAtMention={onAtMention}
-              expandedPaths={expandedPaths}
-              onToggleExpanded={handleToggleExpanded}
-              refreshToken={refreshToken}
-              highlightedPaths={highlightedPaths}
-              gitStatusByPath={gitStatusByPath}
-              changedDirectoryPaths={changedDirectoryPaths}
-            />
-          ))
-        )}
-        {!loading && !error && roots.length === 0 && (
-          <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-dim)" }}>
-            No files found
+      {!changesCollapsed && gitFiles.length > 0 && (
+        <div style={{ borderTop: "1px solid var(--border)" }}>
+          <div style={{ padding: "2px 0" }}>
+            {gitFiles.map((status) => (
+              <ChangeRow key={status.filePath} status={status} cwd={cwd} onOpenFile={onOpenFile} />
+            ))}
           </div>
-        )}
-      </div>
+        </div>
+      )}
+
+      {(changesCollapsed || gitFiles.length === 0) && (
+        <div style={{ padding: "2px 4px" }}>
+          {loading ? (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-dim)" }}>Loading files...</div>
+          ) : error ? (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "#f87171" }}>{error}</div>
+          ) : (
+            roots.map((node) => (
+              <TreeNode
+                key={node.fullPath}
+                node={node}
+                depth={0}
+                cwd={cwd}
+                onOpenFile={onOpenFile}
+                onAtMention={onAtMention}
+                expandedPaths={expandedPaths}
+                onToggleExpanded={handleToggleExpanded}
+                refreshToken={refreshToken}
+                highlightedPaths={highlightedPaths}
+                gitStatusByPath={gitStatusByPath}
+                changedDirectoryPaths={changedDirectoryPaths}
+              />
+            ))
+          )}
+          {!loading && !error && roots.length === 0 && (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-dim)" }}>
+              No files found
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 });

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -29,6 +29,7 @@ interface Props {
   sourceSessionId?: string | null;
   onOpenFile?: (filePath: string) => void;
   gitRefreshKey?: number;
+  initialDisplayMode?: DisplayMode;
 }
 
 interface FileData {
@@ -701,7 +702,7 @@ function DocumentViewer({ filePath, cwd, sourceSessionId }: Props) {
   );
 }
 
-export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey }: Props) {
+export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey, initialDisplayMode }: Props) {
   if (isImagePath(filePath)) {
     return <ImageViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
@@ -711,10 +712,10 @@ export function FileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefr
   if (isDocumentPreviewPath(filePath)) {
     return <DocumentViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} />;
   }
-  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} gitRefreshKey={gitRefreshKey} />;
+  return <TextFileViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} onOpenFile={onOpenFile} gitRefreshKey={gitRefreshKey} initialDisplayMode={initialDisplayMode} />;
 }
 
-function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey }: Props) {
+function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefreshKey, initialDisplayMode }: Props) {
   const { isDark } = useTheme();
   const [data, setData] = useState<FileData | null>(null);
   const [gitDiff, setGitDiff] = useState<GitFileDiffResponse | null>(null);
@@ -778,7 +779,7 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
     }
 
     fetchContent(filePath).then((d) => {
-      if (d?.language === "markdown") setDisplayMode("preview");
+      if (d?.language === "markdown" && initialDisplayMode !== "diff") setDisplayMode("preview");
     }).finally(() => setLoading(false));
 
     // Set up SSE watch
@@ -817,6 +818,20 @@ function TextFileViewer({ filePath, cwd, sourceSessionId, onOpenFile, gitRefresh
   useEffect(() => {
     if (!hasGitDiff && displayMode === "diff") setDisplayMode("source");
   }, [displayMode, hasGitDiff]);
+
+  // Opened from the Changes list (initialDisplayMode === "diff"): switch to the
+  // diff view once the git diff has resolved. We do this after the diff loads
+  // rather than at mount so files without a diff never flash an empty diff view.
+  const autoDiffAppliedRef = useRef(false);
+  useEffect(() => {
+    autoDiffAppliedRef.current = false;
+  }, [filePath]);
+  useEffect(() => {
+    if (initialDisplayMode === "diff" && hasGitDiff && !autoDiffAppliedRef.current) {
+      autoDiffAppliedRef.current = true;
+      setDisplayMode("diff");
+    }
+  }, [initialDisplayMode, hasGitDiff]);
 
   if (loading) {
     return (

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -12,6 +12,65 @@ declare global {
   }
 }
 
+function ToolbarIconButton({
+  onClick,
+  title,
+  disabled,
+  skipHover,
+  color,
+  background = "none",
+  marginRight,
+  ariaPressed,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  disabled?: boolean;
+  skipHover?: boolean;
+  color: string;
+  background?: string;
+  marginRight?: number;
+  ariaPressed?: boolean;
+  children: ReactNode;
+}) {
+  const enter = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (disabled || skipHover) return;
+    e.currentTarget.style.color = "var(--text-muted)";
+    e.currentTarget.style.background = "var(--bg-hover)";
+  };
+  const leave = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (disabled || skipHover) return;
+    e.currentTarget.style.color = color;
+    e.currentTarget.style.background = background;
+  };
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      aria-pressed={ariaPressed}
+      style={{
+        position: "relative",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        width: 26, height: 26, padding: 0, marginRight,
+        background,
+        border: "none",
+        color,
+        cursor: disabled ? "default" : "pointer",
+        borderRadius: 5,
+        flexShrink: 0,
+        opacity: disabled ? 0.6 : 1,
+        transition: "color 0.3s, background 0.3s",
+      }}
+      onMouseEnter={enter}
+      onMouseLeave={leave}
+    >
+      {children}
+    </button>
+  );
+}
+
 interface Props {
   selectedSessionId: string | null;
   onSelectSession: (session: SessionInfo, isRestore?: boolean) => void;
@@ -23,7 +82,7 @@ interface Props {
   onSessionDeleted?: (sessionId: string) => void;
   selectedCwd?: string | null;
   onCwdChange?: (cwd: string | null, projectRoot?: string | null) => void;
-  onOpenFile?: (filePath: string, fileName: string) => void;
+  onOpenFile?: (filePath: string, fileName: string, options?: { sourceSessionId?: string | null; modeHint?: "diff" }) => void;
   explorerRefreshKey?: number;
   onExplorerRefresh?: () => void;
   onAtMention?: (relativePath: string, isDir: boolean) => void;
@@ -349,6 +408,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [explorerOpen, setExplorerOpen] = useState(true);
   const [explorerKey, setExplorerKey] = useState(0);
   const [explorerUploadBusy, setExplorerUploadBusy] = useState(false);
+  const [changesCount, setChangesCount] = useState(0);
+  const [changesCollapsed, setChangesCollapsed] = useState(true);
   const [sessionRefreshDone, setSessionRefreshDone] = useState(false);
   const [explorerRefreshDone, setExplorerRefreshDone] = useState(false);
   const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
@@ -1503,7 +1564,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             flexDirection: "column",
             flex: explorerOpen ? "1 1 0" : "0 0 auto",
             minHeight: 0,
-            overflow: "hidden",
+            overflow: "visible",
           }}
         >
           <div style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
@@ -1535,35 +1596,39 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
               </svg>
               Explorer
             </button>
+            {explorerOpen && changesCount > 0 && (
+              <ToolbarIconButton
+                onClick={() => setChangesCollapsed((v) => !v)}
+                title={`${changesCount} changed file${changesCount === 1 ? "" : "s"}`}
+                ariaPressed={!changesCollapsed}
+                color={changesCollapsed ? "var(--text-dim)" : "var(--accent)"}
+                background={changesCollapsed ? "none" : "var(--bg-hover)"}
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M3 12h6" />
+                  <path d="M15 12h6" />
+                </svg>
+                <span style={{ position: "absolute", top: -3, right: -3, minWidth: 13, height: 13, padding: "0 3px", display: "flex", alignItems: "center", justifyContent: "center", borderRadius: 7, background: "var(--accent)", color: "var(--bg)", fontSize: 9, fontWeight: 700, lineHeight: 1 }}>
+                  {changesCount}
+                </span>
+              </ToolbarIconButton>
+            )}
             {explorerOpen && (
-              <button
+              <ToolbarIconButton
                 onClick={() => fileExplorerRef.current?.openUploadPicker()}
                 disabled={explorerUploadBusy}
                 title="Upload files to project root"
-                aria-label="Upload files"
-                style={{
-                  display: "flex", alignItems: "center", justifyContent: "center",
-                  width: 26, height: 26, padding: 0,
-                  background: "none",
-                  border: "none",
-                  color: "var(--text-dim)",
-                  cursor: explorerUploadBusy ? "default" : "pointer",
-                  borderRadius: 5,
-                  flexShrink: 0,
-                  opacity: explorerUploadBusy ? 0.6 : 1,
-                  transition: "color 0.3s, background 0.3s",
-                }}
-                onMouseEnter={(e) => { if (explorerUploadBusy) return; e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "var(--bg-hover)"; }}
-                onMouseLeave={(e) => { if (explorerUploadBusy) return; e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.background = "none"; }}
+                color="var(--text-dim)"
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                   <path d="m17 8-5-5-5 5" />
                   <path d="M12 3v12" />
                 </svg>
-              </button>
+              </ToolbarIconButton>
             )}
-            <button
+            <ToolbarIconButton
               onClick={() => {
                 if (onExplorerRefresh) onExplorerRefresh();
                 else setExplorerKey((k) => k + 1);
@@ -1572,19 +1637,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 explorerRefreshTimerRef.current = setTimeout(() => setExplorerRefreshDone(false), 2000);
               }}
               title="Refresh explorer"
-              style={{
-                display: "flex", alignItems: "center", justifyContent: "center",
-                width: 26, height: 26, padding: 0, marginRight: 6,
-                background: explorerRefreshDone ? "rgba(74,222,128,0.18)" : "none",
-                border: "none",
-                color: explorerRefreshDone ? "#4ade80" : "var(--text-dim)",
-                cursor: "pointer",
-                borderRadius: 5,
-                flexShrink: 0,
-                transition: "color 0.3s, background 0.3s",
-              }}
-              onMouseEnter={(e) => { if (explorerRefreshDone) return; e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "var(--bg-hover)"; }}
-              onMouseLeave={(e) => { if (explorerRefreshDone) return; e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.background = "none"; }}
+              skipHover={explorerRefreshDone}
+              color={explorerRefreshDone ? "#4ade80" : "var(--text-dim)"}
+              background={explorerRefreshDone ? "rgba(74,222,128,0.18)" : "none"}
+              marginRight={6}
             >
               {explorerRefreshDone ? (
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#4ade80" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1596,7 +1652,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                   <path d="M3 3v5h5" />
                 </svg>
               )}
-            </button>
+            </ToolbarIconButton>
           </div>
           {explorerOpen && (
             <div style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}>
@@ -1608,6 +1664,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 onAtMention={onAtMention}
                 onAtMentions={onAtMentions}
                 onUploadBusyChange={setExplorerUploadBusy}
+                changesCollapsed={changesCollapsed}
+                onChangesCountChange={setChangesCount}
               />
             </div>
           )}

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -8,6 +8,7 @@ export interface Tab {
   label: string;
   filePath: string;
   sourceSessionId?: string | null;
+  initialDisplayMode?: "source" | "preview" | "diff";
 }
 
 interface Props {


### PR DESCRIPTION
## Summary

Adds a small **changes icon** (with a count badge) to the left of the upload button in the Explorer toolbar. Clicking it toggles an inline list of git-changed files in place of the file tree; selecting a file opens it directly in **diff view**.

This is the feature requested in #163, done with the smallest possible surface: it reuses data and views that already exist in the app and adds **no new API route, no new component file, and no new parser**.

<img width="1724" height="998" alt="dxb_screen_2026-07-25_11-12-23" src="https://github.com/user-attachments/assets/bf038e8c-4358-4b96-bedf-42ef2e487ba8" />


## Changes

- `components/FileExplorer.tsx` — lift `changesCollapsed` state up, report the change count via an `onChangesCountChange` callback, render the changed-file list inline, and hide the file tree while the list is open. Extract a `GitStatusBadge` component reused by both the tree rows and the changes rows.
- `components/SessionSidebar.tsx` — add the toolbar icon with a count badge; extract a `ToolbarIconButton` shared by the changes, upload, and refresh buttons.
- `components/TabBar.tsx` — add `initialDisplayMode?: "source" | "preview" | "diff"` to the `Tab` type.
- `components/AppShell.tsx` — thread `handleOpenFile` through an options object carrying `modeHint`, persist it on the tab.
- `components/FileViewer.tsx` — accept `initialDisplayMode`; skip the markdown-preview default when `modeHint === "diff"`, and switch to the diff view once the git diff has resolved (waits for the diff to load so files without a diff never flash an empty diff view).

## How this differs from #170

#170 proposed the same feature with a much heavier surface: a separate `app/api/git-diff/route.ts`, a new `components/FilesChangedSidebar.tsx`, and a new `lib/git-diff-parse.ts` parser, plus frozen Source/Diff tabs and staged/unstaged split. None of those files landed in the tree. This PR takes the opposite approach:

- **No new API route** — `FileExplorer` already collected git status (`gitFiles`) for the tree badges; we just render it as a list too.
- **No new component file** — the changes list lives inside `FileExplorer`; only the existing five files are touched.
- **No new parser** — git status comes from the existing `lib/git-types` flow; per-file diff still uses the existing `/api/files` + diff path that `FileViewer` already had.
- **No frozen tabs** — opening a changed file reuses the normal file tab, just with `initialDisplayMode="diff"`.

Net diff: ~+268 / -89 across 5 files, zero new files.

Closes #163


