### PR TITLE
fix: allow toggling globally installed skills in PATCH /api/skills (#274)

### DIFF
--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { existsSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import path from "path";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { loadSkillsWithInstallInfo } from "@/lib/skills-service";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
@@ -34,6 +36,12 @@ export async function PATCH(req: Request) {
     if (!existsSync(filePath)) return NextResponse.json({ error: "file not found" }, { status: 404 });
     const allowedRoots = new Set(await getAllowedFileRoots());
     allowedRoots.add(getAgentDir());
+    // Globally installed skills live in ~/.agents/skills and are symlinked into
+    // the agent's skills dir; isExistingFilePathAllowed resolves the symlink, so
+    // the real target sits outside getAgentDir(). Allow the global skills root
+    // too (the SDK always treats ~/.agents/skills as trusted).
+    const globalSkillsDir = path.join(homedir(), ".agents", "skills");
+    if (existsSync(globalSkillsDir)) allowedRoots.add(globalSkillsDir);
     if (!isExistingFilePathAllowed(filePath, allowedRoots)) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }


### PR DESCRIPTION
## Summary

Fixes #274.

Toggling the enable/disable switch for a **globally installed** skill in the Skills panel fails with `403 Access denied`.

### Root cause

`skills add -g <pkg>@<skill>` installs the skill under `~/.agents/skills/<skill>` and symlinks it into the agent's skills dir (`~/.pi/agent/skills/<skill>`). `PATCH /api/skills` validates the `SKILL.md` path with `isExistingFilePathAllowed`, which resolves symlinks via `realpathSync`. The real target is therefore `~/.agents/skills/<skill>/SKILL.md` — outside `getAgentDir()` (`~/.pi/agent`) and every other allowed root — so the check returns 403.

### Fix

Add `~/.agents/skills` to the allow-list for this check (guarded by `existsSync`). This is the SDK's canonical global skills location — `package-manager.js` resolves `join(getHomeDir(), ".agents", "skills")`, and the SDK's own trust manager comment notes the global `~/.agents/skills` directory is *always treated as trusted*. So allowing it here matches existing trust semantics rather than widening them.

Only `PATCH` validates a skill **file** path, so only it needs this. `GET /api/skills` and the project-scoped install/update routes validate the project `cwd` instead and are unaffected. The extra root is added to a local copy of the set inside the handler, so it does not affect the global allowed-roots cache used by other endpoints.

### Reproduction (before)

1. `skills add -g mattpocock/skills@ask-matt`
2. In the pi-web Skills panel, toggle that skill.
3. `PATCH /api/skills { filePath: "~/.pi/agent/skills/ask-matt/SKILL.md", ... }` → `403 { "error": "Access denied" }`

After this change the toggle succeeds and the `disable-model-invocation` frontmatter is written.

### Testing

- `tsc --noEmit` passes
- `eslint` passes
- Traced the matcher: `isExistingPathWithinRoots` realpaths both target and roots, so the resolved `~/.agents/skills/<skill>/SKILL.md` now matches the added `~/.agents/skills` root.