### PR TITLE
fix: gate untrusted project extensions behind project trust (#236)

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -4,6 +4,7 @@ import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { loadModelsWithCache, withModelRuntimeError, type ModelsData } from "@/lib/models-cache";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
+import { projectTrustReloadOptions } from "@/lib/project-trust";
 
 export const dynamic = "force-dynamic";
 
@@ -47,7 +48,15 @@ async function loadModels(cwd: string): Promise<ModelsData> {
   const thinkingLevelMaps: Record<string, Record<string, string | null>> = {};
 
   const agentDir = getAgentDir();
-  const services = await createAgentSessionServices({ cwd, agentDir });
+  // Gate untrusted project extensions: enumerating models still imports and
+  // runs a repository's .pi/extensions factories, so honor project trust here
+  // too (see lib/project-trust.ts, #236).
+  const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
+  const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
+  });
   const available = await services.modelRuntime.getAvailable();
   const modelError = services.modelRuntime.getError();
   const settings: SettingsManager = services.settingsManager;

--- a/lib/project-trust.test.mjs
+++ b/lib/project-trust.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// This module gates repository-controlled code execution, so the wiring is
+// asserted by source inspection (like rpc-manager.test.mjs) rather than by
+// loading the full SDK runtime.
+
+test("projectTrustReloadOptions denies untrusted projects and skips clean ones", async () => {
+  const source = await readFile(new URL("./project-trust.ts", import.meta.url), "utf8");
+
+  // Detects trust-requiring project resources via the SDK helper.
+  assert.match(source, /hasTrustRequiringProjectResources\(cwd\)/);
+  // No such resources -> undefined, so ordinary projects keep the normal path.
+  assert.match(source, /return undefined/);
+  // Otherwise the decision comes from the shared CLI trust store, default deny.
+  assert.match(source, /new ProjectTrustStore\(agentDir\)/);
+  assert.match(source, /resolveProjectTrust:\s*async \(\) => trustStore\.get\(cwd\) === true/);
+});
+
+test("both session-creation sites pass the project-trust gate to the SDK", async () => {
+  for (const rel of ["./rpc-manager.ts", "../app/api/models/route.ts"]) {
+    const source = await readFile(new URL(rel, import.meta.url), "utf8");
+    assert.match(source, /projectTrustReloadOptions\(cwd, agentDir\)/, `${rel} should compute trust reload options`);
+    assert.match(
+      source,
+      /resourceLoaderReloadOptions: trustReloadOptions/,
+      `${rel} should forward the gate to createAgentSessionServices`,
+    );
+  }
+});

--- a/lib/project-trust.ts
+++ b/lib/project-trust.ts
@@ -1,0 +1,27 @@
+import { hasTrustRequiringProjectResources, ProjectTrustStore } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Reload options that gate project-local, trust-requiring resources — a
+ * repository's `.pi/extensions`, project `.pi/settings.json` extension
+ * entries, and `.agents/skills` — behind the SDK's project-trust store.
+ *
+ * Pi Web *executes* project extensions when it builds session services: their
+ * factory runs on import and their `session_start` handlers run on startup.
+ * Without a trust gate, merely opening an untrusted repository in Pi Web runs
+ * repository-controlled code locally (issue #236). The SDK's resource loader
+ * only imports project extensions once `resolveProjectTrust` resolves true, so
+ * denying trust keeps them dormant.
+ *
+ * Pi Web has no in-app trust prompt yet, so this honors decisions already
+ * persisted by the `pi` CLI (the trust store is shared) and otherwise defaults
+ * to untrusted. Returns `undefined` when the project has no trust-requiring
+ * resources, leaving ordinary projects on their existing load path.
+ */
+export function projectTrustReloadOptions(
+  cwd: string,
+  agentDir: string,
+): { resolveProjectTrust: () => Promise<boolean> } | undefined {
+  if (!cwd || !hasTrustRequiringProjectResources(cwd)) return undefined;
+  const trustStore = new ProjectTrustStore(agentDir);
+  return { resolveProjectTrust: async () => trustStore.get(cwd) === true };
+}

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -5,6 +5,7 @@ import { existsSync, writeFileSync } from "fs";
 import { validateAgentImages } from "./image-attachments";
 import { invalidateModelsCache } from "./models-cache";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
+import { projectTrustReloadOptions } from "./project-trust";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
 import type { ExtensionUiRequest, ExtensionUiResponse, ExtensionWidgetItem } from "./types";
@@ -1076,7 +1077,14 @@ export async function startRpcSession(
 
     // Build services first so extension-registered providers are available
     // before the SDK restores the saved model from the session file.
-    const services = await createAgentSessionServices({ cwd, agentDir });
+    // Gate untrusted project extensions so opening a repository does not run
+    // its .pi/extensions code automatically (see lib/project-trust.ts, #236).
+    const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
+    const services = await createAgentSessionServices({
+      cwd,
+      agentDir,
+      ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
+    });
     const { session: inner } = await createAgentSessionFromServices({
       services,
       sessionManager,


### PR DESCRIPTION
## Summary

Fixes #236.

Opening a repository in Pi Web executes that repository's project-local extensions. Building session services imports every enabled `.pi/extensions` module (running its factory), and the session then dispatches `session_start` handlers. Because Pi Web called `createAgentSessionServices({ cwd, agentDir })` **without** the SDK's project-trust resolver, merely creating a session — or even enumerating models — for an untrusted repo ran repository-controlled code locally, with no trust prompt.

This is not prompt-injection: it needs no model output and no tool approval. Per the reproduction in #236, a `.pi/extensions/*.js` `session_start` handler runs on `POST /api/agent/new`.

## Fix

New helper `lib/project-trust.ts` returns the SDK's `resourceLoaderReloadOptions` **only** when the project actually has trust-requiring resources (`hasTrustRequiringProjectResources`), and resolves the decision from the `ProjectTrustStore` that is shared with the `pi` CLI, defaulting to **untrusted**:

```ts
export function projectTrustReloadOptions(cwd, agentDir) {
  if (!cwd || !hasTrustRequiringProjectResources(cwd)) return undefined;
  const trustStore = new ProjectTrustStore(agentDir);
  return { resolveProjectTrust: async () => trustStore.get(cwd) === true };
}
```

The SDK's resource loader runs a pre-trust pass that loads only user/global extensions, calls `resolveProjectTrust`, and includes project-local extensions **only if it resolves `true`** (`core/resource-loader.js`). So denying trust keeps the repo's extensions from ever being imported or bound.

Wired into both code paths that create services from a project `cwd`:
- `lib/rpc-manager.ts` `startRpcSession` (session create/restore — the `session_start` path)
- `app/api/models/route.ts` (model enumeration still imports project extension factories)

### Behavior

- Project with no `.pi` trust-requiring resources → `undefined`, unchanged (fast) load path.
- Project already trusted in the `pi` CLI → `trustStore.get(cwd) === true` → extensions load as before (the store is shared).
- Untrusted project → extensions stay dormant; **no auto-execution.**

### Scope / follow-up

Pi Web has no in-app trust prompt yet, so a project is currently trusted by trusting it once in the `pi` CLI. A web trust-prompt UI (the SDK exposes `getProjectTrustOptions` / `ProjectTrustStore.set`) is a good follow-up; this PR is the minimal change that closes the code-execution hole while honoring existing trust decisions.

## Testing

- `tsc --noEmit` passes
- `eslint` passes
- `node --test lib/project-trust.test.mjs` passes — asserts the helper defaults to deny for untrusted projects, returns `undefined` for clean ones, and that both session-creation sites forward the gate (source-inspection style, matching `rpc-manager.test.mjs`, to avoid loading the full SDK runtime in unit tests).

Verification of the SDK trust mechanics was done by reading `@earendil-works/pi-coding-agent` (`core/resource-loader.js` pre-trust pass, `core/trust-manager.js`) and mirroring the resolver pattern the `pi` CLI itself uses in `main.js`.