### PR TITLE
fix: share running-sessions SSE across tabs via BroadcastChannel

### DIFF
--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useState, useCallback, useRef, type CSSProp
 import type { SessionInfo } from "@/lib/types";
 import { DirectoryPicker } from "./DirectoryPicker";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
+import { useSharedRunningSessions } from "@/hooks/useSharedRunningSessions";
 
 declare global {
   interface Window {
@@ -351,12 +352,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [explorerUploadBusy, setExplorerUploadBusy] = useState(false);
   const [sessionRefreshDone, setSessionRefreshDone] = useState(false);
   const [explorerRefreshDone, setExplorerRefreshDone] = useState(false);
-  const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
+  const { runningSessionIds, applyFallback } = useSharedRunningSessions();
   const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(() => loadUnreadSessionIds());
   const previousRunningSessionIdsRef = useRef<Set<string>>(new Set());
-  // Once the SSE stream has delivered a frame it is the source of truth for
-  // running state; late /api/sessions responses must not overwrite it.
-  const sseAuthoritativeRef = useRef(false);
   const sessionRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const explorerRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileExplorerRef = useRef<FileExplorerHandle>(null);
@@ -368,11 +366,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json() as { sessions: SessionInfo[]; runningSessionIds?: string[] };
       setAllSessions(data.sessions);
-      // Treat the fetched running set as an initial fallback only. Once SSE is
-      // live it owns this state, so a slow fetch can't revive a stale snapshot.
-      if (!sseAuthoritativeRef.current) {
-        setRunningSessionIds(new Set(data.runningSessionIds ?? []));
-      }
+      // Treat the fetched running set as an initial fallback only. Once the
+      // shared SSE stream has delivered a frame it owns this state, so a slow
+      // fetch can't revive a stale snapshot.
+      applyFallback(data.runningSessionIds ?? []);
       // Drop unread markers for sessions that no longer exist (e.g. deleted).
       const existingIds = new Set(data.sessions.map((s) => s.id));
       setUnreadSessionIds((prev) => {
@@ -391,7 +388,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, []);
+  }, [applyFallback]);
 
   const initialLoadDone = useRef(false);
   useEffect(() => {
@@ -405,27 +402,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   useEffect(() => {
     saveUnreadSessionIds(unreadSessionIds);
   }, [unreadSessionIds]);
-
-  useEffect(() => {
-    // Live running status via SSE — no polling. The server pushes the current
-    // set of running session ids whenever any session starts/stops working.
-    const source = new EventSource("/api/agent/running/events");
-
-    source.onmessage = (e) => {
-      try {
-        const data = JSON.parse(e.data) as { type?: string; runningSessionIds?: string[] };
-        if (data.type === "running") {
-          sseAuthoritativeRef.current = true;
-          setRunningSessionIds(new Set(data.runningSessionIds ?? []));
-        }
-      } catch {
-        // ignore malformed frames
-      }
-    };
-
-    // On error EventSource auto-reconnects; keep the last known state meanwhile.
-    return () => source.close();
-  }, []);
 
   useEffect(() => {
     const previous = previousRunningSessionIdsRef.current;

--- a/hooks/useSharedRunningSessions.ts
+++ b/hooks/useSharedRunningSessions.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Shared `/api/agent/running/events` SSE across same-origin tabs.
+//
+// Why: each open pi-web tab used to open its own SSE for the running-sessions
+// list. Browsers cap HTTP/1.1 same-origin connections at 6, and SSE holds them
+// open, so ~3 tabs starved the pool and new SSE (agent events, file watch)
+// could no longer connect. Only ONE tab needs to hold this stream — the data
+// is a global set, identical for every tab — so the leader relays frames over
+// a BroadcastChannel and followers reuse them. Per-tab agent events SSE is
+// unaffected (it is per-session, not shared).
+//
+// Lease-based leader election: the leader writes {id,ts} to localStorage every
+// HEARTBEAT_MS. A follower that sees the lease stale past STALE_MS takes over.
+// Worst case (race) two tabs briefly hold the stream — one extra SSE, not
+// fatal; next tick one concedes. ponytail: O(1) localStorage lease; fine while
+// tab count stays in the dozens — switch to a SharedWorker if we ever need
+// hard mutual exclusion or cross-tab backpressure.
+
+const CHANNEL = "pi-running-sessions";
+const LS_LEASE = "pi-running-leader";
+const HEARTBEAT_MS = 1500;
+const STALE_MS = 4000;
+
+type RunningMsg = { type: "running"; runningSessionIds: string[] };
+
+export function useSharedRunningSessions() {
+  const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
+  const authoritativeRef = useRef(false);
+
+  // Initial fallback only: once any frame (SSE or broadcast) has arrived, the
+  // stream is authoritative and late /api/sessions snapshots must not overwrite
+  // it. Mirrors the old sseAuthoritativeRef behavior.
+  const applyFallback = useCallback((ids: string[]) => {
+    if (!authoritativeRef.current) setRunningSessionIds(new Set(ids));
+  }, []);
+
+  useEffect(() => {
+    const tabId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `t${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const markAuth = () => { if (!authoritativeRef.current) authoritativeRef.current = true; };
+    const apply = (ids: string[]) => { markAuth(); setRunningSessionIds(new Set(ids)); };
+
+    // Fallback: no BroadcastChannel (old browsers) → degrade to per-tab SSE,
+    // which is the original behavior. Still correct, just not shared.
+    if (typeof BroadcastChannel === "undefined") {
+      const es = new EventSource("/api/agent/running/events");
+      es.onmessage = (e) => {
+        try {
+          const d = JSON.parse(e.data) as RunningMsg;
+          if (d.type === "running") apply(d.runningSessionIds ?? []);
+        } catch { /* ignore malformed */ }
+      };
+      return () => es.close();
+    }
+
+    const channel = new BroadcastChannel(CHANNEL);
+    let es: EventSource | null = null;
+    let isLeader = false;
+
+    channel.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg?.type === "running") apply(msg.runningSessionIds ?? []);
+    };
+
+    const connectSse = () => {
+      if (es) return;
+      const stream = new EventSource("/api/agent/running/events");
+      stream.onmessage = (e) => {
+        try {
+          const d = JSON.parse(e.data) as RunningMsg;
+          if (d.type === "running") {
+            const ids = d.runningSessionIds ?? [];
+            apply(ids);
+            channel.postMessage({ type: "running", runningSessionIds: ids });
+          }
+        } catch { /* ignore malformed */ }
+      };
+      es = stream;
+    };
+    const disconnectSse = () => { es?.close(); es = null; };
+
+    const readLease = (): { id: string; ts: number } | null => {
+      try {
+        const raw = localStorage.getItem(LS_LEASE);
+        if (!raw) return null;
+        const p = JSON.parse(raw);
+        return typeof p?.id === "string" && typeof p?.ts === "number" ? p : null;
+      } catch { return null; }
+    };
+    const writeLease = () => {
+      try { localStorage.setItem(LS_LEASE, JSON.stringify({ id: tabId, ts: Date.now() })); } catch { /* ignore */ }
+    };
+    const clearLease = () => {
+      try { if (readLease()?.id === tabId) localStorage.removeItem(LS_LEASE); } catch { /* ignore */ }
+    };
+
+    const tick = () => {
+      const lease = readLease();
+      const now = Date.now();
+      if (lease && lease.id !== tabId && now - lease.ts < STALE_MS) {
+        // Another live tab is leader — stand down.
+        if (isLeader) { isLeader = false; disconnectSse(); }
+        return;
+      }
+      if (!isLeader) { isLeader = true; connectSse(); }
+      writeLease();
+    };
+
+    tick();
+    const timer = setInterval(tick, HEARTBEAT_MS);
+    window.addEventListener("beforeunload", clearLease);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("beforeunload", clearLease);
+      disconnectSse();
+      clearLease();
+      channel.close();
+    };
+  }, []);
+
+  return { runningSessionIds, applyFallback };
+}


### PR DESCRIPTION
Each open tab opened its own /api/agent/running/events SSE. Browsers cap HTTP/1.1 same-origin connections at 6 and SSE holds them open, so ~3 tabs starved the pool and new agent/file-watch SSE could no longer connect.

The running list is a global set identical for every tab, so only one tab needs to hold the stream. Leader election via a localStorage lease (1.5s heartbeat, 4s stale) picks the leader; the leader relays frames over a BroadcastChannel and followers reuse them. Per-tab agent events SSE is per-session and untouched. BroadcastChannel-less browsers fall back to the original per-tab behavior.

Side effect: SessionSidebar drops the sseAuthoritativeRef in favor of an applyFallback callback that mirrors the same "stream is authoritative once it delivered a frame" guard.

Effect: N tabs hold 1 running SSE instead of N; tab budget under the 6-connection limit roughly doubles.