### PR TITLE
fix: clear open file tabs when switching to a different project (#268)

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -191,6 +191,7 @@ export function AppShell() {
 
   const initialSessionId = initialNavigation.sessionId;
   const [activeCwd, setActiveCwd] = useState<string | null>(null);
+  const activeProjectRootRef = useRef<string | null>(null);
   // True once the initial ?session= URL param has been resolved (or confirmed absent)
   const [initialSessionRestored, setInitialSessionRestored] = useState<boolean>(() => !initialSessionId);
   // Suppresses sessionKey bump in handleCwdChange during the initial URL restore
@@ -233,8 +234,15 @@ export function AppShell() {
 
   const handleCwdChange = useCallback((cwd: string | null, projectRoot?: string | null) => {
     setActiveCwd(cwd);
-    // Skip if cwd is null (initial mount) or during the initial URL restore.
+    // Skip if cwd is null (initial mount).
     if (!cwd) return;
+    const newProject = projectRoot ?? cwd;
+    const currentProject = activeProjectRootRef.current
+      ?? (selectedSession ? (selectedSession.projectRoot ?? selectedSession.cwd) : null);
+    activeProjectRootRef.current = newProject;
+
+    // Keep the project identity in sync during the initial URL restore without
+    // remounting the just-created or restored chat.
     if (suppressCwdBumpRef.current) {
       suppressCwdBumpRef.current = false;
       return;
@@ -242,8 +250,7 @@ export function AppShell() {
     // Worktrees of one repo share a project root. Moving the effective cwd
     // within the same project (e.g. switching worktree, or clicking a session
     // that lives in another worktree) must not close the open session.
-    const newProject = projectRoot ?? cwd;
-    if (selectedSession && (selectedSession.projectRoot ?? selectedSession.cwd) === newProject) {
+    if (currentProject === newProject) {
       return;
     }
     // Close any session that belongs to a different project — it no longer

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -258,6 +258,14 @@ export function AppShell() {
     setBranchActiveLeafId(null);
     setSystemPrompt(null);
     setActiveTopPanel(null);
+    // File tabs are keyed by absolute path, so tabs opened in the previous
+    // project would otherwise linger after switching to a different project.
+    // Reached only past the same-project early return above, so worktrees of
+    // one repo keep their open tabs. Mirror handleCloseFileTab and close the
+    // now-empty right panel.
+    setFileTabs([]);
+    setActiveFileTabId(null);
+    setRightPanelOpen(false);
     router.replace("/", { scroll: false });
   }, [router, selectedSession]);
 


### PR DESCRIPTION
## Summary

Fixes #268.

When switching workspace in the UI, the left session list and the file explorer correctly follow to the new project, but the **right-hand file viewer keeps the tabs opened in the previous project**. Because those tabs are keyed by absolute path (`file:${absolutePath}`), they stay attached after moving to a different project — so the old project's files appear to belong to the new one.

## Fix

`handleCwdChange` already clears the per-project state (selected session, branch tree, system prompt, top panel) after the same-project early return. Clear the file tabs there too:

```ts
setFileTabs([]);
setActiveFileTabId(null);
setRightPanelOpen(false);
```

- Placed **after** the same-project early return, so switching between **worktrees of the same repo** (which share a `projectRoot`) still keeps open tabs — consistent with the existing session-preservation behavior.
- Closes the now-empty right panel, mirroring `handleCloseFileTab`, which already calls `setRightPanelOpen(false)` when the last tab is closed.

## Testing

- `tsc --noEmit` passes
- `eslint` passes
- Manual: open files in project A (right panel shows tabs) → switch to project B → the file tabs clear and the panel closes; switching between worktrees of the same repo keeps the tabs.

Distinct from #262/#264 (manual batch-close of tabs); this is the automatic scope cleanup on project switch.