### PR TITLE
Add retry and model settings actions for prompt errors

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1400,6 +1400,7 @@ export function AppShell() {
               onSessionStatsPanelOpen={openSessionStatsPanel}
               onContextUsageChange={handleContextUsageChange}
               onOpenFile={handleOpenLinkedFile}
+              onOpenModelsConfig={() => setModelsConfigOpen(true)}
             />
           ) : initialCwdStatus === "validating" ? (
             <div

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -37,6 +37,7 @@ interface Props {
   onSessionStatsPanelOpen?: () => void;
   onContextUsageChange?: (usage: { percent: number | null; contextWindow: number; tokens: number | null } | null) => void;
   onOpenFile?: (filePath: string) => void;
+  onOpenModelsConfig?: () => void;
 }
 
 function phaseLabel(phase: AgentPhase, t: (key: string, params?: Record<string, string | number>) => string): string {
@@ -170,7 +171,7 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, children, t }: { mes
   );
 }
 
-export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile }: Props) {
+export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile, onOpenModelsConfig }: Props) {
   const { t } = useI18n();
   const { soundEnabled, onSoundToggle, playDoneSound, unlockAudio } = useAudio();
   const isMobile = useIsMobile();
@@ -201,7 +202,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
-    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
+    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, dismissNotice,
     isAutoModelSelection,
     agentPhase,
     isNew,
@@ -473,7 +474,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 </span>
               </div>
             </div>
-            <NoticeShelf notices={notices} align="right" />
+            <NoticeShelf notices={notices} align="right" t={t} onDismiss={dismissNotice} onRetry={(message) => void handleSend(message)} onOpenModelsConfig={onOpenModelsConfig} />
             {chatInputElement}
           </div>
         </div>
@@ -492,7 +493,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
           }}
         >
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
-            <NoticeShelf notices={notices} floating align="right" />
+            <NoticeShelf notices={notices} floating align="right" t={t} onDismiss={dismissNotice} onRetry={(message) => void handleSend(message)} onOpenModelsConfig={onOpenModelsConfig} />
           </div>
         </div>
         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 [scrollbar-width:none]">
@@ -771,7 +772,15 @@ function ExtensionWidgets({ widgets }: { widgets: Array<{ key: string; lines: st
   );
 }
 
-function NoticeShelf({ notices, floating = false, align = "left" }: { notices: NoticeItem[]; floating?: boolean; align?: "left" | "right" }) {
+function NoticeShelf({ notices, floating = false, align = "left", t, onDismiss, onRetry, onOpenModelsConfig }: {
+  notices: NoticeItem[];
+  floating?: boolean;
+  align?: "left" | "right";
+  t: (key: string) => string;
+  onDismiss: (id: string) => void;
+  onRetry: (message: string) => void;
+  onOpenModelsConfig?: () => void;
+}) {
   if (notices.length === 0) return null;
   return (
     <div
@@ -819,6 +828,7 @@ function NoticeShelf({ notices, floating = false, align = "left" }: { notices: N
                 ? "notice-shelf-out 0.18s ease-in forwards"
                 : "notice-shelf-in 0.18s ease-out both",
               padding: "0 12px",
+              pointerEvents: "auto",
             }}
           >
             <span
@@ -833,6 +843,21 @@ function NoticeShelf({ notices, floating = false, align = "left" }: { notices: N
             <span style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
               {notice.message}
             </span>
+            {notice.retryMessage && (
+              <button type="button" onClick={() => onRetry(notice.retryMessage!)} style={{ border: "none", background: "transparent", color, cursor: "pointer", font: "inherit", fontSize: 13, fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("notice.retry")}
+              </button>
+            )}
+            {notice.showModelsAction && onOpenModelsConfig && (
+              <button type="button" onClick={onOpenModelsConfig} style={{ border: "none", background: "transparent", color, cursor: "pointer", font: "inherit", fontSize: 13, fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("notice.checkModels")}
+              </button>
+            )}
+            {notice.persistent && (
+              <button type="button" aria-label={t("notice.dismiss")} title={t("notice.dismiss")} onClick={() => onDismiss(notice.id)} style={{ border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer", fontSize: 18, lineHeight: 1, padding: 2 }}>
+                ×
+              </button>
+            )}
           </div>
         );
       })}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -96,6 +96,9 @@ export type NoticeItem = {
   id: string;
   message: string;
   type: NoticeType;
+  retryMessage?: string;
+  showModelsAction?: boolean;
+  persistent?: boolean;
   exiting?: boolean;
 };
 
@@ -195,7 +198,7 @@ function delay(ms: number): Promise<void> {
 }
 
 function markOldestNoticeExiting(notices: NoticeItem[]): NoticeItem[] {
-  const index = notices.findIndex((notice) => !notice.exiting);
+  const index = notices.findIndex((notice) => !notice.exiting && !notice.persistent);
   if (index === -1) return notices;
   return notices.map((notice, i) => (
     i === index ? { ...notice, exiting: true } : notice
@@ -387,6 +390,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const newSessionPromotedRef = useRef(false);
   const promptRunIdRef = useRef(0);
   const optimisticUserMessageKeyRef = useRef<string | null>(null);
+  const lastPromptTextRef = useRef<string | null>(null);
 
   const setToolPresetState = opts.setToolPreset ?? setToolPreset;
 
@@ -680,7 +684,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, []);
 
-  const addNotice = useCallback((notice: { id?: string; message: string; type?: NoticeType }) => {
+  const addNotice = useCallback((notice: Omit<NoticeItem, "id" | "exiting"> & { id?: string }) => {
     const message = notice.message.trim();
     if (!message) return;
     dispatchNotice({
@@ -689,6 +693,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         id: notice.id ?? createNoticeId(),
         message,
         type: notice.type ?? "info",
+        retryMessage: notice.retryMessage,
+        showModelsAction: notice.showModelsAction,
+        persistent: notice.persistent,
       },
     });
   }, []);
@@ -918,7 +925,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         void finishPromptWithoutStream(sessionIdRef.current);
         break;
       case "prompt_error":
-        addNotice({ type: "error", message: (event.errorMessage as string | undefined) ?? "Command failed" });
+        addNotice({
+          type: "error",
+          message: (event.errorMessage as string | undefined) ?? "Command failed",
+          retryMessage: lastPromptTextRef.current ?? undefined,
+          showModelsAction: true,
+          persistent: true,
+        });
         break;
       case "extension_error":
         addNotice({
@@ -1045,6 +1058,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
 
     const promptRunId = promptRunIdRef.current + 1;
+    lastPromptTextRef.current = message;
 
     const imageBlocks = images?.map((img) => ({ type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } }));
     const userMsg: AgentMessage = {
@@ -1613,7 +1627,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       }, NOTICE_EXIT_ANIMATION_MS);
       return () => clearTimeout(t);
     }
-    const oldest = noticeState.visible[0];
+    const oldest = noticeState.visible.find((notice) => !notice.persistent);
     if (!oldest) return;
     const t = setTimeout(() => {
       dispatchNotice({ type: "mark_oldest_exiting" });
@@ -1646,6 +1660,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     handleBuiltinSlashCommand,
     handleToolPresetChange, handleThinkingLevelChange, loadTools, loadSlashCommands, setActiveLeafId, setData, setMessages,
     dispatch, setAgentRunning, setForkingEntryId,
+    dismissNotice: (id: string) => dispatchNotice({ type: "remove", id }),
     bashRunning, pendingBash,
     // Subscriptions
     handleAgentEventRef,

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -426,5 +426,8 @@ export const enLocale: LocalePlugin = {
     "i18n.thinkingUnavailable": "Thinking content unavailable",
     "i18n.before": "Before",
     "i18n.after": "After",
+    "notice.retry": "Retry",
+    "notice.checkModels": "Check models",
+    "notice.dismiss": "Dismiss",
   },
 };

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -426,5 +426,8 @@ export const zhCNLocale: LocalePlugin = {
     "i18n.thinkingUnavailable": "思考内容不可用",
     "i18n.before": "之前",
     "i18n.after": "之后",
+    "notice.retry": "重试",
+    "notice.checkModels": "检查模型设置",
+    "notice.dismiss": "关闭",
   },
 };


### PR DESCRIPTION
## Summary

Improve the recovery flow when a prompt fails.

- Keep prompt error notices visible until dismissed.
- Add a **Retry** action for the failed text prompt.
- Add a **Check models** action that opens the model configuration dialog.
- Add English and Simplified Chinese labels for the new actions.

## Why

A failed model request currently shows a temporary notice that disappears after a few seconds. Users can be left with a message that appears unanswered and no direct way to retry or inspect model configuration.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`