### PR TITLE
Write model configuration atomically

### DIFF
--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
-import { randomUUID } from "crypto";
-import { join, dirname } from "path";
+import { existsSync, mkdirSync, readFileSync } from "fs";
+import { dirname, join } from "path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { writePrivateFileAtomicSync } from "@/lib/atomic-file";
 import { invalidateModelsCache } from "@/lib/models-cache";
 
 export const dynamic = "force-dynamic";
@@ -25,13 +25,7 @@ function writeModelsJson(data: Record<string, unknown>): void {
   const path = getModelsPath();
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const tempPath = join(dir, `.models-${randomUUID()}.json.tmp`);
-  try {
-    writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf8");
-    renameSync(tempPath, path);
-  } finally {
-    if (existsSync(tempPath)) unlinkSync(tempPath);
-  }
+  writePrivateFileAtomicSync(path, JSON.stringify(data, null, 2));
 }
 
 export async function GET() {

--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
+import { randomUUID } from "crypto";
 import { join, dirname } from "path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { invalidateModelsCache } from "@/lib/models-cache";
@@ -24,7 +25,13 @@ function writeModelsJson(data: Record<string, unknown>): void {
   const path = getModelsPath();
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(data, null, 2), "utf8");
+  const tempPath = join(dir, `.models-${randomUUID()}.json.tmp`);
+  try {
+    writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf8");
+    renameSync(tempPath, path);
+  } finally {
+    if (existsSync(tempPath)) unlinkSync(tempPath);
+  }
 }
 
 export async function GET() {

--- a/lib/atomic-file.test.mjs
+++ b/lib/atomic-file.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const { writePrivateFileAtomicSync } = await import("./atomic-file.ts");
+
+function createTempRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-atomic-file-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+test("atomically replaces a file with restrictive permissions", (t) => {
+  const root = createTempRoot(t);
+  const destination = path.join(root, "models.json");
+  fs.writeFileSync(destination, "old", { mode: 0o644 });
+
+  writePrivateFileAtomicSync(destination, "new");
+
+  assert.equal(fs.readFileSync(destination, "utf8"), "new");
+  assert.deepEqual(fs.readdirSync(root), ["models.json"]);
+  if (process.platform !== "win32") {
+    assert.equal(fs.statSync(destination).mode & 0o777, 0o600);
+  }
+});
+
+test("keeps the destination and removes the temporary file when replacement fails", (t) => {
+  const root = createTempRoot(t);
+  const destination = path.join(root, "models.json");
+  fs.mkdirSync(destination);
+
+  assert.throws(() => writePrivateFileAtomicSync(destination, "new"));
+  assert.equal(fs.statSync(destination).isDirectory(), true);
+  assert.deepEqual(fs.readdirSync(root), ["models.json"]);
+});

--- a/lib/atomic-file.ts
+++ b/lib/atomic-file.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "crypto";
+import { renameSync, unlinkSync, writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
+
+/**
+ * Replace a file atomically without exposing credentials through default
+ * process permissions. The caller must create the parent directory first.
+ */
+export function writePrivateFileAtomicSync(path: string, contents: string): void {
+  const dir = dirname(path);
+  const tempPath = join(dir, `.${basename(path)}-${randomUUID()}.tmp`);
+  let operationFailed = false;
+
+  try {
+    writeFileSync(tempPath, contents, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+      flush: true,
+    });
+    renameSync(tempPath, path);
+  } catch (error) {
+    operationFailed = true;
+    throw error;
+  } finally {
+    try {
+      unlinkSync(tempPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !operationFailed) {
+        throw error;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Write `models.json` through a temporary file in the same directory, then atomically rename it into place.

This prevents a partially written configuration file if the process is interrupted during a direct overwrite.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`