### PR TITLE
fix: surface assistant error messages in the chat UI

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -99,6 +99,7 @@ function countToolCalls(messages: AgentMessage[], indices: number[]): number {
 
 function hasDisplayableProcessMessage(message: AgentMessage): boolean {
   if (message.role === "assistant") {
+    if ((message as AssistantMessage).stopReason === "error") return true;
     return getDisplayableAssistantBlocks(message as AssistantMessage).length > 0;
   }
   return message.role === "custom";
@@ -629,7 +630,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 const finalProcessMessage = finalSplit.processBlocks.length > 0
                   ? withAssistantBlocks(finalAssistant, finalSplit.processBlocks, { omitUsage: true })
                   : null;
-                const finalAnswerMessage = finalSplit.answerBlocks.length > 0
+                const finalAnswerMessage = finalSplit.answerBlocks.length > 0 || finalAssistant.stopReason === "error"
                   ? withAssistantBlocks(finalAssistant, finalSplit.answerBlocks)
                   : null;
 

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -470,7 +470,7 @@ function AssistantMessageView({
     return () => clearInterval(id);
   }, [isStreaming]);
 
-  if (blocks.length === 0 && !isStreaming) return null;
+  if (blocks.length === 0 && !isStreaming && message.stopReason !== "error") return null;
 
   return (
     <div
@@ -531,6 +531,25 @@ function AssistantMessageView({
           <BlockView key={`${entryId ?? "stream"}-${originalIndex}`} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(originalIndex) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} sessionId={sessionId} entryId={entryId} blockIndex={originalIndex} />
         ))}
       </div>
+
+      {message.stopReason === "error" && (
+        <div
+          style={{
+            marginTop: 4,
+            padding: "8px 12px",
+            background: "color-mix(in srgb, #e01a4f 8%, transparent)",
+            border: "1px solid color-mix(in srgb, #e01a4f 35%, transparent)",
+            borderRadius: 6,
+            color: "#e01a4f",
+            fontSize: 12,
+            fontFamily: "var(--font-mono)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {message.errorMessage || "The model request failed."}
+        </div>
+      )}
 
       <div style={{
         display: "flex", alignItems: "center", gap: 8, marginTop: 4,

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "react";
 import type {
   AgentMessage,
+  AssistantMessage,
   ExtensionStatusItem,
   ExtensionUiRequest,
   ExtensionWidgetItem,
@@ -968,6 +969,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           });
         } else if (completed) {
           setMessages((prev) => [...prev, normalizeToolCalls(completed)]);
+          if (completed.role === "assistant" && (completed as AssistantMessage).stopReason === "error") {
+            const err = (completed as AssistantMessage).errorMessage;
+            addNotice({ type: "error", message: err || "The model request failed." });
+          }
         }
         dispatch({ type: "reset" });
         setAgentPhase({ kind: "waiting_model" });


### PR DESCRIPTION
## Problem

When the model request fails, pi stores an assistant message with `stopReason: "error"` and an `errorMessage`, but with empty `content`. The web UI rendered nothing for these messages:

- `AssistantMessageView` has an early return for empty-content messages (`MessageView.tsx`), so the whole message was dropped;
- the turn-grouping logic in `ChatWindow` only renders a final answer bubble when there are answer blocks, so an errored final message produced no bubble either;
- `useAgentSession` raised no notice on `message_end` for errored messages.

The result: on provider failures (e.g. `"All backends failed"`, context overflow, queue errors) the agent appears to silently stop / "disconnect", and the only way to find out what happened is to read the session `.jsonl` by hand. The TUI shows these errors; the web UI should too.

## Changes

- **MessageView**: render a red error banner when `message.stopReason === "error"`, and let empty-content error messages past the empty-blocks early return.
- **ChatWindow**: keep the final assistant message renderable when it errored; treat mid-turn errored messages as displayable inside the process group.
- **useAgentSession**: raise an error notice on `message_end` when the completed assistant message has `stopReason: "error"`.

## Screenshot

Before: empty space where the assistant reply should be. After:

user bubble → assistant model label → red banner with the full `errorMessage` (monospace, pre-wrap).

<img width="2100" height="700" alt="image" src="https://github.com/user-attachments/assets/85d58aba-bc86-4f9c-b85b-61d22ae07328" />


## Test plan

- [x] `tsc --noEmit` passes
- [x] Session whose leaf is an errored assistant message shows the banner (verified in browser against a real session file)
- [x] Normal sessions (text, tool calls, process groups) render unchanged