### PR TITLE
docs: add Russian README translation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Pi Web
 
-[English](./README.md) | [简体中文](./README.zh-CN.md)
+[English](./README.md) | [简体中文](./README.zh-CN.md) | [Русский](./README.ru.md)
 
 [pi コーディングエージェント](https://github.com/badlogic/pi-mono) のローカル Web UI です。Pi Web はローカルの pi セッションファイルを読み込み、セッションの閲覧、リアルタイムチャット、モデル設定、スキル管理、プロジェクトファイルのプレビューを行えるブラウザワークスペースを提供します。
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,33 +1,33 @@
 # Pi Web
 
-[中文文档](./README.zh-CN.md) | [日本語](./README.ja.md) | [Русский](./README.ru.md)
+[English](./README.md) | [中文文档](./README.zh-CN.md) | [日本語](./README.ja.md) | [Русский](./README.ru.md)
 
-Local web UI for the [pi coding agent](https://github.com/badlogic/pi-mono). Pi Web reads your local pi session files and gives you a browser workspace for session browsing, real-time chat, model configuration, skill management, and project file preview.
+Локальный web UI для [pi coding agent](https://github.com/badlogic/pi-mono). Pi Web читает локальные session-файлы pi и даёт браузерный workspace: просмотр сессий, real-time chat, настройка моделей, skills и preview файлов проекта.
 
 ![Pi Web shows the same pi session with structured Markdown, tool calls, and project navigation beside the CLI](https://raw.githubusercontent.com/agegr/pi-web/main/docs/screenshot2.png)
 
-The same pi session in CLI and Pi Web: structured tool calls, readable Markdown, session browsing, and cleaner results.
+Та же pi-сессия в CLI и Pi Web: structured tool calls, читаемый Markdown, session browsing и более удобные результаты.
 
-## Quick Start
+## Быстрый старт
 
-Pi Web requires Node.js 22.19.0 or newer. Check your version with `node --version`.
+Нужен Node.js **22.19.0** или новее. Проверка: `node --version`.
 
-**Run without installing:**
+**Без установки:**
 
 ```bash
 npx @agegr/pi-web@latest
 ```
 
-**Or install globally:**
+**Глобально:**
 
 ```bash
 npm install -g @agegr/pi-web
 pi-web
 ```
 
-Then open [http://127.0.0.1:30141](http://127.0.0.1:30141). The CLI will try to open the browser automatically after the server is ready. Pi Web listens on `127.0.0.1` by default.
+Откройте [http://127.0.0.1:30141](http://127.0.0.1:30141). CLI попытается открыть браузер после старта сервера. По умолчанию слушаем `127.0.0.1`.
 
-**Options:**
+**Опции:**
 
 ```bash
 pi-web --port 8080              # custom port
@@ -41,14 +41,14 @@ PI_WEB_ALLOWED_HOSTS=pi-web.internal pi-web  # allow an exact proxy/custom hostn
 PI_WEB_NO_OPEN=1 pi-web         # useful when running as a background service
 ```
 
-Pi Web has no application-level authentication and can invoke a high-privilege agent. Do not expose it to the internet; only use non-loopback bindings on a trusted network.
-API requests accept loopback names, IP literals, the selected bind hostname, and exact comma-separated names in `PI_WEB_ALLOWED_HOSTS`. Configure that variable when a trusted reverse proxy uses a different external hostname.
+У Pi Web **нет** application-level auth, при этом он может вызывать high-privilege agent. **Не** выставляйте в интернет; non-loopback bindings — только в trusted network.  
+API принимает loopback names, IP literals, bind hostname и exact names из `PI_WEB_ALLOWED_HOSTS` (через запятую). Нужно, если reverse proxy с другим external hostname.
 
 ## HTTP Proxy
 
-Pi Web reads the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables for server-side model and API requests.
+Серверные model/API-запросы уважают `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`.
 
-On macOS or Linux:
+macOS / Linux:
 
 ```bash
 HTTP_PROXY=http://127.0.0.1:7890 \
@@ -57,7 +57,7 @@ NO_PROXY=localhost,127.0.0.1 \
 npx @agegr/pi-web@latest
 ```
 
-On Windows PowerShell:
+Windows PowerShell:
 
 ```powershell
 $env:HTTP_PROXY = "http://127.0.0.1:7890"
@@ -66,25 +66,25 @@ $env:NO_PROXY = "localhost,127.0.0.1"
 npx @agegr/pi-web@latest
 ```
 
-## Features
+## Возможности
 
-- **Pick work back up**: browse previous pi conversations by project without digging through terminal history or session paths.
-- **Try different directions safely**: continue from an earlier message or fork a session into a separate route.
-- **Work across branches**: switch Git worktrees from the sidebar so new sessions and the Explorer follow the checkout you choose.
-- **Chat beside the project**: browse files on the left and preview source, docs, images, audio, and PDFs on the right while the agent works.
-- **See session state clearly**: context usage, cost, compaction state, and system prompt details are visible from the top bar.
-- **Configure less from the terminal**: manage models, login/API keys, model tests, and skill switches from the web UI.
-- **Use the interface in your language**: switch between the supported UI languages from the top bar.
+- **Продолжить работу**: предыдущие pi-разговоры по проектам без поиска в terminal history
+- **Безопасные ветки**: continue с сообщения или fork сессии в отдельный route
+- **Git worktrees**: переключение worktrees в sidebar — новые sessions и Explorer следуют checkout
+- **Chat рядом с проектом**: файлы слева; preview source/docs/images/audio/PDF справа, пока агент работает
+- **Состояние сессии**: context usage, cost, compaction, system prompt — в top bar
+- **Меньше терминала**: models, login/API keys, model tests, skills — из web UI
+- **Язык UI**: переключение supported languages в top bar
 
 ## Notes
 
-- **Data directory**: Pi Web reads `~/.pi/agent/sessions` by default. Set `PI_CODING_AGENT_DIR` to point at another pi agent directory.
-- **Session files**: files are stored as `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`.
-- **Model config**: the Models panel reads and writes `models.json` in the pi agent directory. Model lists and defaults come from pi's config.
-- **File access**: file browsing and preview are scoped to the selected project directory and working directories that appear in sessions.
-- **Git worktrees**: see [Worktrees in Pi Web](./docs/worktrees.md) for when the switcher appears, how new worktrees are created, and what removal does.
-- **Forks vs in-session branches**: Fork creates a new `.jsonl` file. "Edit from here" creates another branch inside the same session file.
-- **Internationalization**: see [Internationalization](./docs/i18n.md) for using translations and adding languages or UI text.
+- **Data directory**: по умолчанию `~/.pi/agent/sessions`. Другой каталог: `PI_CODING_AGENT_DIR`
+- **Session files**: `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`
+- **Model config**: панель Models читает/пишет `models.json` в pi agent directory
+- **File access**: browsing/preview ограничены selected project и working dirs из sessions
+- **Git worktrees**: [Worktrees in Pi Web](./docs/worktrees.md)
+- **Forks vs in-session branches**: Fork = новый `.jsonl`; «Edit from here» = ветка внутри того же session file
+- **i18n**: [Internationalization](./docs/i18n.md)
 
 ## Development
 
@@ -93,18 +93,16 @@ npm install
 npm run dev
 ```
 
-The local dev server runs at [http://127.0.0.1:30141](http://127.0.0.1:30141).
-
-Common checks:
+Dev server: [http://127.0.0.1:30141](http://127.0.0.1:30141).
 
 ```bash
 node_modules/.bin/tsc --noEmit
 npm run lint
 ```
 
-Avoid running `next build` / `npm run build` during local development. It writes to `.next/` and can interfere with the dev server; leave builds for release work.
+Не гоняйте `next build` / `npm run build` во время local dev — пишет в `.next/` и мешает dev server; builds — для release.
 
-## Project Structure
+## Структура проекта
 
 ```text
 app/

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,54 +1,57 @@
 # Pi Web
 
-[English](./README.md) | [中文文档](./README.zh-CN.md) | [日本語](./README.ja.md) | [Русский](./README.ru.md)
+[English](./README.md) | [中文文档](./README.zh-CN.md) | [日本語](./README.ja.md)
 
-Локальный web UI для [pi coding agent](https://github.com/badlogic/pi-mono). Pi Web читает локальные session-файлы pi и даёт браузерный workspace: просмотр сессий, real-time chat, настройка моделей, skills и preview файлов проекта.
+Локальный веб-интерфейс для [pi coding agent](https://github.com/badlogic/pi-mono). Pi Web читает локальные файлы сессий pi и предоставляет рабочее пространство в браузере для просмотра сессий, общения с агентом в реальном времени, настройки моделей, управления навыками и предварительного просмотра файлов проекта.
 
-![Pi Web shows the same pi session with structured Markdown, tool calls, and project navigation beside the CLI](https://raw.githubusercontent.com/agegr/pi-web/main/docs/screenshot2.png)
+![Pi Web показывает одну и ту же сессию pi рядом с CLI: структурированный Markdown, вызовы инструментов и навигация по проекту](https://raw.githubusercontent.com/agegr/pi-web/main/docs/screenshot2.png)
 
-Та же pi-сессия в CLI и Pi Web: structured tool calls, читаемый Markdown, session browsing и более удобные результаты.
+Одна и та же сессия pi в CLI и Pi Web: структурированные вызовы инструментов, удобочитаемый Markdown, просмотр сессий и наглядные результаты.
 
 ## Быстрый старт
 
-Нужен Node.js **22.19.0** или новее. Проверка: `node --version`.
+Для работы Pi Web требуется Node.js **22.19.0** или новее. Проверьте версию командой `node --version`.
 
-**Без установки:**
+**Запуск без установки:**
 
 ```bash
 npx @agegr/pi-web@latest
 ```
 
-**Глобально:**
+**Или глобальная установка:**
 
 ```bash
 npm install -g @agegr/pi-web
 pi-web
 ```
 
-Откройте [http://127.0.0.1:30141](http://127.0.0.1:30141). CLI попытается открыть браузер после старта сервера. По умолчанию слушаем `127.0.0.1`.
+Затем откройте [http://127.0.0.1:30141](http://127.0.0.1:30141). После запуска сервера CLI попытается автоматически открыть браузер. По умолчанию Pi Web прослушивает только `127.0.0.1`.
 
-**Опции:**
+**Параметры:**
 
 ```bash
-pi-web --port 8080              # custom port
-pi-web --hostname 0.0.0.0       # expose on a trusted network
-pi-web -p 8080 -H 0.0.0.0       # combine options
-pi-web --no-open                # do not open the browser automatically
+pi-web --port 8080              # другой порт
+pi-web --hostname 0.0.0.0       # доступ в доверенной сети
+pi-web -p 8080 -H 0.0.0.0       # сочетание параметров
+pi-web --no-open                # не открывать браузер автоматически
 
-PORT=8080 pi-web                # environment variable is also supported
-PI_WEB_HOSTNAME=0.0.0.0 pi-web  # explicit network exposure
-PI_WEB_ALLOWED_HOSTS=pi-web.internal pi-web  # allow an exact proxy/custom hostname
-PI_WEB_NO_OPEN=1 pi-web         # useful when running as a background service
+PORT=8080 pi-web                # порт также можно задать переменной окружения
+PI_WEB_HOSTNAME=0.0.0.0 pi-web  # явное разрешение сетевого доступа
+PI_WEB_ALLOWED_HOSTS=pi-web.internal pi-web  # точное имя прокси или другого хоста
+PI_WEB_PASSWORD='длинный-случайный-пароль' pi-web  # Basic Auth (имя пользователя: pi)
+PI_WEB_NO_OPEN=1 pi-web         # удобно для фоновой службы
 ```
 
-У Pi Web **нет** application-level auth, при этом он может вызывать high-privilege agent. **Не** выставляйте в интернет; non-loopback bindings — только в trusted network.  
-API принимает loopback names, IP literals, bind hostname и exact names из `PI_WEB_ALLOWED_HOSTS` (через запятую). Нужно, если reverse proxy с другим external hostname.
+Задайте `PI_WEB_PASSWORD`, чтобы защитить веб-интерфейс и все конечные точки API с помощью HTTP Basic Auth. Имя пользователя всегда `pi`. Если переменная не задана или пуста, аутентификация отключена.
 
-## HTTP Proxy
+Pi Web может вызывать агента с широкими полномочиями. Basic Auth не шифрует пароль при передаче, поэтому не публикуйте обычный HTTP-сервер в интернете. Для удалённого доступа используйте HTTPS через доверенный обратный прокси или надёжное VPN-подключение.
+API-запросы принимаются для loopback-имён, IP-адресов, выбранного имени хоста и точных имён из `PI_WEB_ALLOWED_HOSTS`, разделённых запятыми. Задайте эту переменную, если доверенный обратный прокси использует другое внешнее имя хоста.
 
-Серверные model/API-запросы уважают `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`.
+## HTTP-прокси
 
-macOS / Linux:
+Для серверных запросов к моделям и API Pi Web использует стандартные переменные окружения `HTTP_PROXY`, `HTTPS_PROXY` и `NO_PROXY`.
+
+В macOS и Linux:
 
 ```bash
 HTTP_PROXY=http://127.0.0.1:7890 \
@@ -57,7 +60,7 @@ NO_PROXY=localhost,127.0.0.1 \
 npx @agegr/pi-web@latest
 ```
 
-Windows PowerShell:
+В Windows PowerShell:
 
 ```powershell
 $env:HTTP_PROXY = "http://127.0.0.1:7890"
@@ -68,83 +71,85 @@ npx @agegr/pi-web@latest
 
 ## Возможности
 
-- **Продолжить работу**: предыдущие pi-разговоры по проектам без поиска в terminal history
-- **Безопасные ветки**: continue с сообщения или fork сессии в отдельный route
-- **Git worktrees**: переключение worktrees в sidebar — новые sessions и Explorer следуют checkout
-- **Chat рядом с проектом**: файлы слева; preview source/docs/images/audio/PDF справа, пока агент работает
-- **Состояние сессии**: context usage, cost, compaction, system prompt — в top bar
-- **Меньше терминала**: models, login/API keys, model tests, skills — из web UI
-- **Язык UI**: переключение supported languages в top bar
+- **Продолжайте работу с прежнего места**: просматривайте предыдущие разговоры с pi по проектам, не разыскивая их в истории терминала или путях к сессиям.
+- **Безопасно пробуйте разные подходы**: продолжайте диалог с более раннего сообщения или создавайте отдельный форк сессии.
+- **Работайте с разными ветками**: переключайте Git worktree в боковой панели, чтобы новые сессии и Explorer следовали за выбранным рабочим деревом.
+- **Общайтесь с агентом рядом с проектом**: просматривайте файлы слева, а исходный код, документы, изображения, аудио и PDF — справа, пока агент работает.
+- **Следите за состоянием сессии**: в верхней панели видны использование контекста, стоимость, состояние сжатия и сведения о системном промпте.
+- **Реже обращайтесь к терминалу**: управляйте моделями, учётными данными для входа и API, тестированием моделей и переключателями навыков в веб-интерфейсе.
+- **Используйте удобный язык интерфейса**: переключайтесь между поддерживаемыми языками в верхней панели.
 
-## Notes
+## Примечания
 
-- **Data directory**: по умолчанию `~/.pi/agent/sessions`. Другой каталог: `PI_CODING_AGENT_DIR`
-- **Session files**: `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`
-- **Model config**: панель Models читает/пишет `models.json` в pi agent directory
-- **File access**: browsing/preview ограничены selected project и working dirs из sessions
-- **Git worktrees**: [Worktrees in Pi Web](./docs/worktrees.md)
-- **Forks vs in-session branches**: Fork = новый `.jsonl`; «Edit from here» = ветка внутри того же session file
-- **i18n**: [Internationalization](./docs/i18n.md)
+- **Каталог данных**: по умолчанию Pi Web читает `~/.pi/agent/sessions`. Чтобы указать другой каталог агента pi, задайте `PI_CODING_AGENT_DIR`.
+- **Файлы сессий**: файлы хранятся по пути `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`.
+- **Настройка моделей**: панель Models читает и записывает `models.json` в каталоге агента pi. Список моделей и модель по умолчанию берутся из конфигурации pi.
+- **Доступ к файлам**: просмотр файлов ограничен выбранным каталогом проекта и рабочими каталогами, которые встречаются в сессиях.
+- **Git worktree**: условия отображения переключателя, создание новых рабочих деревьев и их удаление описаны в документе [Worktrees in Pi Web](./docs/worktrees.md).
+- **Форк и ветка внутри сессии**: Fork создаёт новый файл `.jsonl`, а «Edit from here» — другую ветку внутри того же файла сессии.
+- **Интернационализация**: использование переводов и добавление языков или текстов интерфейса описаны в документе [Internationalization](./docs/i18n.md).
 
-## Development
+## Разработка
 
 ```bash
 npm install
 npm run dev
 ```
 
-Dev server: [http://127.0.0.1:30141](http://127.0.0.1:30141).
+Локальный сервер разработки доступен по адресу [http://127.0.0.1:30141](http://127.0.0.1:30141).
+
+Основные проверки:
 
 ```bash
 node_modules/.bin/tsc --noEmit
 npm run lint
 ```
 
-Не гоняйте `next build` / `npm run build` во время local dev — пишет в `.next/` и мешает dev server; builds — для release.
+Не запускайте `next build` / `npm run build` во время локальной разработки. Эта команда записывает данные в `.next/` и может помешать работе сервера разработки; выполняйте сборку только при подготовке релиза.
 
 ## Структура проекта
 
 ```text
 app/
   api/
-    agent/          # creates/drives AgentSession and exposes SSE events
-    auth/           # OAuth and API key management
-    cwd/browse/     # browsable server directory listing
-    cwd/validate/   # custom working directory validation
-    default-cwd/    # pi default working directory lookup
-    files/          # file listing, reading, preview, and watching
-    home/           # current user home directory
-    models/         # available models, default model, thinking levels
-    models-config/  # read/write models.json and test models
-    sessions/       # session reads, rename, delete, context, HTML export
-    skills/         # skill listing, search, install, enable/disable
+    agent/          # создание и управление AgentSession, события SSE
+    auth/           # управление OAuth и ключами API
+    cwd/browse/     # просмотр каталогов на сервере
+    cwd/validate/   # проверка пользовательского рабочего каталога
+    default-cwd/    # рабочий каталог pi по умолчанию
+    files/          # список, чтение, просмотр и отслеживание файлов
+    home/           # домашний каталог текущего пользователя
+    models/         # доступные модели, модель по умолчанию, уровни рассуждения
+    models-config/  # чтение и запись models.json, проверка моделей
+    sessions/       # чтение, переименование, удаление, контекст и экспорт сессий в HTML
+    skills/         # список, поиск, установка, включение и отключение навыков
 components/
-  AppShell.tsx        # main layout, URL state, top panels, file tabs
-  SessionSidebar.tsx  # project selector, session tree, Explorer
-  DirectoryPicker.tsx # browsable and editable working-directory picker
-  ChatWindow.tsx      # messages, SSE, image drag/drop, minimap
-  ChatInput.tsx       # input bar, model/tools/thinking/compact/slash controls
-  MessageView.tsx     # message, thinking, tool call/result rendering
-  ModelsConfig.tsx    # model and auth configuration panel
-  SkillsConfig.tsx    # skill management panel
-  FileExplorer.tsx    # file tree
-  FileViewer.tsx      # source, diff, image, audio, PDF, DOCX preview
+  AppShell.tsx        # основной макет, состояние URL, верхние панели, вкладки файлов
+  SessionSidebar.tsx  # выбор проекта, дерево сессий, Explorer
+  DirectoryPicker.tsx # просмотр и изменение рабочего каталога
+  ChatWindow.tsx      # сообщения, SSE, перетаскивание изображений, мини-карта
+  ChatInput.tsx       # модели, инструменты, рассуждение, сжатие и слеш-команды
+  MessageView.tsx     # сообщения, рассуждения, вызовы инструментов и результаты
+  ModelsConfig.tsx    # настройка моделей и аутентификации
+  SkillsConfig.tsx    # управление навыками
+  FileExplorer.tsx    # дерево файлов
+  FileViewer.tsx      # просмотр кода, diff, изображений, аудио, PDF и DOCX
 lib/
-  directory-browser.ts # directory normalization and safe listing helpers
-  http-dispatcher.ts  # HTTP(S) proxy setup for server-side fetch
-  rpc-manager.ts      # AgentSessionWrapper lifecycle and global registry
-  session-reader.ts   # parses .jsonl session files and branch contexts
-  normalize.ts        # normalizes toolCall field names
-  file-access.ts      # file read safety boundary
-  file-paths.ts       # path encoding and relative path helpers
-  markdown.ts         # Markdown/Mermaid/KaTeX plugin configuration
-  pi-types.ts         # pi-related types
+  directory-browser.ts # нормализация каталогов и безопасный просмотр
+  http-dispatcher.ts  # настройка HTTP(S)-прокси для серверных запросов
+  rpc-manager.ts      # жизненный цикл AgentSessionWrapper и глобальный реестр
+  session-reader.ts   # разбор файлов сессий .jsonl и контекста веток
+  normalize.ts        # нормализация имён полей toolCall
+  file-access.ts      # границы безопасного чтения файлов
+  file-paths.ts       # кодирование путей и работа с относительными путями
+  markdown.ts         # настройка плагинов Markdown, Mermaid и KaTeX
+  pi-types.ts         # типы, связанные с pi
 hooks/
-  useAgentSession.ts  # session loading, command sending, SSE state machine
-  useAudio.ts         # completion sound
-  useDragDrop.ts      # image drag/drop
-  useTheme.ts         # theme switching
+  useAgentSession.ts  # загрузка сессии, команды и автомат состояний SSE
+  useAudio.ts         # звук завершения
+  useDragDrop.ts      # перетаскивание изображений
+  useTheme.ts         # переключение темы
 bin/
-  pi-web.js           # npm CLI entrypoint
-instrumentation.ts    # initializes the server HTTP dispatcher
+  pi-web.js           # точка входа npm CLI
+instrumentation.ts    # инициализация HTTP-диспетчера сервера
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Pi Web
 
-[English](./README.md) | [日本語](./README.ja.md)
+[English](./README.md) | [日本語](./README.ja.md) | [Русский](./README.ru.md)
 
 [pi 编程智能体](https://github.com/badlogic/pi-mono) 的本地网页界面。它会读取本机的 pi 会话文件，在浏览器里提供会话管理、实时对话、模型配置、技能管理和项目文件预览。
 


### PR DESCRIPTION
## Summary
Adds a full native **Russian** README (`README.ru.md`) and links **Русский** from existing locale bars (EN / zh-CN / ja).

## Why
Pi Web already ships Chinese and Japanese README siblings. Russian documentation matches the established i18n pattern for the local pi coding agent web UI.

## Changes
- New `README.ru.md` (aligned with current English README)
- Language bar updates on `README.md`, `README.zh-CN.md`, `README.ja.md`

## Notes
Docs-only. CLI flags and env vars left unchanged.