### PR TITLE
fix: support wildcard enabled model refs

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -2,6 +2,7 @@ import { stat } from "fs/promises";
 import { resolve } from "path";
 import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { filterByEnabledModels } from "@/lib/enabled-models";
 import { loadModelsWithCache, withModelRuntimeError, type ModelsData } from "@/lib/models-cache";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 import { projectTrustReloadOptions } from "@/lib/project-trust";
@@ -17,27 +18,6 @@ function compareModelEntries(
   return modelNameCollator.compare(a.name || a.id, b.name || b.id)
     || modelNameCollator.compare(a.provider, b.provider)
     || modelNameCollator.compare(a.id, b.id);
-}
-
-const THINKING_SUFFIXES = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
-
-function stripThinkingSuffix(modelRef: string): string {
-  const trimmed = modelRef.trim();
-  const colonIndex = trimmed.lastIndexOf(":");
-  if (colonIndex === -1) return trimmed;
-  const suffix = trimmed.substring(colonIndex + 1);
-  return THINKING_SUFFIXES.has(suffix) ? trimmed.substring(0, colonIndex) : trimmed;
-}
-
-function filterByExactEnabledModels<T extends { id: string; provider: string }>(
-  available: readonly T[],
-  enabledModels: string[] | undefined,
-): readonly T[] {
-  if (!enabledModels || enabledModels.length === 0) return available;
-
-  const refs = new Set(enabledModels.map(stripThinkingSuffix).filter(Boolean));
-  const visible = available.filter((m) => refs.has(`${m.provider}/${m.id}`) || refs.has(m.id));
-  return visible.length > 0 ? visible : available;
 }
 
 async function loadModels(cwd: string): Promise<ModelsData> {
@@ -61,7 +41,7 @@ async function loadModels(cwd: string): Promise<ModelsData> {
   const modelError = services.modelRuntime.getError();
   const settings: SettingsManager = services.settingsManager;
   const enabledModels = settings.getEnabledModels();
-  const visible = filterByExactEnabledModels(available, enabledModels);
+  const visible = filterByEnabledModels(available, enabledModels);
   modelList = visible.map((m: { id: string; name: string; provider: string }) => ({
     id: m.id,
     name: m.name,

--- a/lib/enabled-models.test.mjs
+++ b/lib/enabled-models.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function loadSubject() {
+  try {
+    const { createJiti } = await import("jiti");
+    return createJiti(import.meta.url).import("./enabled-models.ts");
+  } catch {
+    return import("./enabled-models.ts");
+  }
+}
+
+const { filterByEnabledModels, stripThinkingSuffix } = await loadSubject();
+
+const available = [
+  { provider: "opencode", id: "big-pickle" },
+  { provider: "opencode", id: "deepseek-v3-free" },
+  { provider: "openai-codex", id: "gpt-5.5" },
+  { provider: "DeepSeek", id: "deepseek-chat" },
+  { provider: "ollama", id: "qwen3:latest" },
+];
+
+test("filters enabled models by exact provider/model and model id", () => {
+  assert.deepEqual(
+    filterByEnabledModels(available, ["opencode/big-pickle", "qwen3:latest"]),
+    [available[0], available[4]],
+  );
+});
+
+test("supports wildcard enabled model refs", () => {
+  assert.deepEqual(
+    filterByEnabledModels(available, ["opencode/big-pickle", "opencode/*-free", "openai-codex/*", "DeepSeek/*"]),
+    [available[0], available[1], available[2], available[3]],
+  );
+});
+
+test("strips known thinking suffixes without stripping model ids that contain colons", () => {
+  assert.equal(stripThinkingSuffix("openai-codex/gpt-5.5:high"), "openai-codex/gpt-5.5");
+  assert.equal(stripThinkingSuffix("qwen3:latest"), "qwen3:latest");
+});
+
+test("falls back to all available models when enabled model refs match nothing", () => {
+  assert.deepEqual(filterByEnabledModels(available, ["missing/*"]), available);
+});

--- a/lib/enabled-models.ts
+++ b/lib/enabled-models.ts
@@ -1,0 +1,35 @@
+const THINKING_SUFFIXES = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+export function stripThinkingSuffix(modelRef: string): string {
+  const trimmed = modelRef.trim();
+  const colonIndex = trimmed.lastIndexOf(":");
+  if (colonIndex === -1) return trimmed;
+  const suffix = trimmed.substring(colonIndex + 1);
+  return THINKING_SUFFIXES.has(suffix) ? trimmed.substring(0, colonIndex) : trimmed;
+}
+
+function wildcardToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesAnyModelRef(modelRef: string, exactRefs: Set<string>, wildcardRefs: RegExp[]): boolean {
+  if (exactRefs.has(modelRef)) return true;
+  return wildcardRefs.some((pattern) => pattern.test(modelRef));
+}
+
+export function filterByEnabledModels<T extends { id: string; provider: string }>(
+  available: readonly T[],
+  enabledModels: string[] | undefined,
+): readonly T[] {
+  if (!enabledModels || enabledModels.length === 0) return available;
+
+  const refs = enabledModels.map(stripThinkingSuffix).filter(Boolean);
+  const exactRefs = new Set(refs.filter((ref) => !ref.includes("*")));
+  const wildcardRefs = refs.filter((ref) => ref.includes("*")).map(wildcardToRegExp);
+  const visible = available.filter((m) => (
+    matchesAnyModelRef(`${m.provider}/${m.id}`, exactRefs, wildcardRefs)
+    || matchesAnyModelRef(m.id, exactRefs, wildcardRefs)
+  ));
+  return visible.length > 0 ? visible : available;
+}


### PR DESCRIPTION
## Summary
- Support wildcard patterns in `enabledModels`, such as `provider/*` and `provider/*-free`
- Preserve existing exact model matching behavior
- Keep thinking-level suffix stripping behavior

## Verification
- `node --test lib/enabled-models.test.mjs`
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`