### PR TITLE
fix: improve iOS PWA viewport and keyboard layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,9 +72,13 @@ html.dark {
 }
 
 html, body {
-  height: 100%;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  height: var(--app-viewport-height, 100dvh);
   margin: 0;
   padding: 0;
+  overflow: hidden;
   background: var(--bg);
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -83,7 +87,8 @@ html, body {
 }
 
 body {
-  height: 100dvh;
+  display: flex;
+  flex-direction: column;
 }
 
 ::-webkit-scrollbar {
@@ -111,6 +116,9 @@ pre, code {
 
 /* react-markdown output styles */
 .markdown-body {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: hidden;
   font-size: 14px;
   line-height: 1.7;
   color: var(--text);
@@ -358,6 +366,9 @@ pre, code {
 
 .markdown-code-block {
   position: relative;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   margin: 6px 0;
   border: 1px solid var(--border);
   border-radius: 7px;
@@ -985,6 +996,7 @@ span.linenumber {
     bottom: 0;
     width: 280px;
     max-width: 85vw;
+    height: var(--app-viewport-height, 100dvh);
     transition: transform 0.25s ease, box-shadow 0.25s ease;
   }
   .sidebar-container.sidebar-open {
@@ -999,6 +1011,7 @@ span.linenumber {
   .right-panel-container {
     position: fixed;
     inset: 0;
+    height: var(--app-viewport-height, 100dvh);
     z-index: 250;
     overflow: hidden;
     transition: transform 0.2s ease;
@@ -1032,5 +1045,10 @@ span.linenumber {
   .directory-picker-footer {
     flex-wrap: wrap;
     padding-bottom: max(10px, env(safe-area-inset-bottom)) !important;
+  }
+  textarea,
+  input,
+  select {
+    font-size: 16px !important;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -962,7 +962,7 @@ span.linenumber {
   .right-panel-container {
     position: fixed;
     top: 0;
-    right: 0;
+    right: env(safe-area-inset-right);
     bottom: 0;
     z-index: 250;
     width: min(560px, calc(100vw - 48px));
@@ -992,7 +992,7 @@ span.linenumber {
   .sidebar-container {
     position: fixed !important;
     top: 0;
-    left: 0;
+    left: env(safe-area-inset-left);
     bottom: 0;
     width: 280px;
     max-width: 85vw;
@@ -1004,20 +1004,20 @@ span.linenumber {
     box-shadow: 4px 0 20px rgba(0,0,0,0.15);
   }
   .sidebar-container.sidebar-closed {
-    transform: translateX(-100%);
+    transform: translateX(calc(-100% - env(safe-area-inset-left)));
     box-shadow: none;
   }
 
   .right-panel-container {
     position: fixed;
-    inset: 0;
+    inset: 0 env(safe-area-inset-right) 0 env(safe-area-inset-left);
     height: var(--app-viewport-height, 100dvh);
     z-index: 250;
     overflow: hidden;
     transition: transform 0.2s ease;
   }
   .right-panel-container.right-panel-open {
-    width: 100%;
+    width: auto;
     min-width: 0;
   }
   .right-panel-container.right-panel-closed {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   appleWebApp: {
     capable: true,
-    statusBarStyle: "default",
+    statusBarStyle: "black-translucent",
     title: "Pi Web",
   },
   formatDetection: {
@@ -42,6 +42,10 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  interactiveWidget: "resizes-content",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
     { media: "(prefers-color-scheme: dark)", color: "#1a1a1a" },
@@ -63,7 +67,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body translate="no" className="notranslate" style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
+      <body translate="no" className="notranslate">
         {children}
         <PwaRegistration />
       </body>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -767,12 +767,20 @@ export function AppShell() {
           pointer-events: none !important;
         }
         .sidebar-container.sidebar-mobile-pending.sidebar-open {
-          transform: translateX(-100%);
+          transform: translateX(calc(-100% - env(safe-area-inset-left)));
           box-shadow: none;
         }
       }
     `}</style>
-    <div style={{ display: "flex", width: "100%", height: "var(--app-viewport-height, 100dvh)", overflow: "hidden", background: "var(--bg)" }}>
+    <div style={{
+      display: "flex",
+      width: "100%",
+      height: "var(--app-viewport-height, 100dvh)",
+      paddingLeft: "env(safe-area-inset-left)",
+      paddingRight: "env(safe-area-inset-right)",
+      overflow: "hidden",
+      background: "var(--bg)",
+    }}>
       {/* Mobile overlay backdrop */}
       <div
         className={`sidebar-overlay-backdrop${mobileSidebarReady ? "" : " sidebar-mobile-pending"}`}
@@ -1560,7 +1568,15 @@ export function AppShell() {
         } as React.CSSProperties}
       >
         {/* Right panel tab bar */}
-        <div style={{ display: "flex", alignItems: "center", flexShrink: 0, background: "var(--bg-panel)", borderBottom: "1px solid var(--border)", height: 36 }}>
+        <div style={{
+          display: "flex",
+          alignItems: "center",
+          flexShrink: 0,
+          height: "calc(36px + env(safe-area-inset-top))",
+          paddingTop: "env(safe-area-inset-top)",
+          background: "var(--bg-panel)",
+          borderBottom: "1px solid var(--border)",
+        }}>
           <div style={{ flex: 1, overflow: "hidden" }}>
             <TabBar
               tabs={fileTabs}
@@ -1573,7 +1589,7 @@ export function AppShell() {
         </div>
 
         {/* File content */}
-        <div style={{ flex: 1, overflow: "hidden" }}>
+        <div style={{ flex: 1, overflow: "hidden", paddingBottom: "env(safe-area-inset-bottom)" }}>
           {activeFileTab?.filePath ? (
             <FileViewer
               filePath={activeFileTab.filePath}
@@ -1604,7 +1620,7 @@ export function AppShell() {
        title={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
        aria-label={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
       style={{
-        position: "fixed", top: "env(safe-area-inset-top)", right: 0, zIndex: 300,
+        position: "fixed", top: "env(safe-area-inset-top)", right: "env(safe-area-inset-right)", zIndex: 300,
         display: "flex", alignItems: "center", justifyContent: "center",
         width: 36, height: 36, padding: 0,
         background: "var(--bg-panel)", border: "none", borderLeft: "1px solid var(--border)", borderBottom: "1px solid var(--border)",

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -15,6 +15,7 @@ import { BranchNavigator } from "./BranchNavigator";
 import { useTheme } from "@/hooks/useTheme";
 import { useI18n } from "@/hooks/useI18n";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useViewportHeight } from "@/hooks/useViewportHeight";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { copyText } from "@/lib/clipboard";
 import { getFileName } from "@/lib/file-paths";
@@ -53,6 +54,7 @@ export function AppShell() {
   const { isDark, toggleTheme } = useTheme();
   const { locale, setLocale, t: translate, supportedLocales } = useI18n();
   const isMobile = useIsMobile();
+  useViewportHeight();
   const [selectedSession, setSelectedSession] = useState<SessionInfo | null>(null);
   // When user clicks +, we only store the cwd — no fake session id
   const [newSessionCwd, setNewSessionCwd] = useState<string | null>(null);
@@ -770,7 +772,7 @@ export function AppShell() {
         }
       }
     `}</style>
-    <div style={{ display: "flex", height: "100dvh", overflow: "hidden", background: "var(--bg)" }}>
+    <div style={{ display: "flex", width: "100%", height: "var(--app-viewport-height, 100dvh)", overflow: "hidden", background: "var(--bg)" }}>
       {/* Mobile overlay backdrop */}
       <div
         className={`sidebar-overlay-backdrop${mobileSidebarReady ? "" : " sidebar-mobile-pending"}`}
@@ -798,6 +800,8 @@ export function AppShell() {
           display: "flex",
           flexDirection: "column",
           flexShrink: 0,
+          paddingTop: "env(safe-area-inset-top)",
+          paddingBottom: "env(safe-area-inset-bottom)",
           zIndex: 200,
         } as React.CSSProperties}
       >
@@ -816,7 +820,7 @@ export function AppShell() {
       {/* Center: chat */}
       <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", minWidth: 0 }}>
         {/* Top bar with sidebar toggle */}
-        <div ref={topBarRef} style={{ display: "flex", alignItems: "center", flexShrink: 0, borderBottom: "1px solid var(--border)", height: 36, background: "var(--bg-panel)" }}>
+        <div ref={topBarRef} style={{ display: "flex", alignItems: "center", flexShrink: 0, borderBottom: "1px solid var(--border)", height: "calc(36px + env(safe-area-inset-top))", paddingTop: "env(safe-area-inset-top)", background: "var(--bg-panel)" }}>
           <button
             onClick={handleSidebarToggle}
              title={sidebarOpen ? translate("sidebar.hide") : translate("sidebar.show")}
@@ -1600,7 +1604,7 @@ export function AppShell() {
        title={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
        aria-label={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
       style={{
-        position: "fixed", top: 0, right: 0, zIndex: 300,
+        position: "fixed", top: "env(safe-area-inset-top)", right: 0, zIndex: 300,
         display: "flex", alignItems: "center", justifyContent: "center",
         width: 36, height: 36, padding: 0,
         background: "var(--bg-panel)", border: "none", borderLeft: "1px solid var(--border)", borderBottom: "1px solid var(--border)",

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1223,7 +1223,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         )}
 
         {/* Main input */}
-        <div style={{ position: "relative" }}>
+        <div style={{ position: "relative", minWidth: 0 }}>
           {historyMenuOpen && inputHistory.length > 0 && (
             <div
               ref={historyMenuRef}
@@ -1539,6 +1539,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           })()}
           <div
             style={{
+              minWidth: 0,
               display: "flex",
               gap: 8,
               alignItems: "center",
@@ -1585,6 +1586,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
             rows={1}
             style={{
               flex: 1,
+              minWidth: 0,
+              width: "100%",
               background: "none",
               border: "none",
               outline: "none",

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -397,7 +397,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
 
   return (
     <div
-      className="relative flex h-full flex-col overflow-hidden"
+      className="relative flex h-full min-w-0 flex-col overflow-hidden"
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -483,7 +483,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
         </div>
       ) : (
       <>
-      <div className="relative flex flex-1 overflow-hidden">
+      <div className="relative flex min-w-0 flex-1 overflow-hidden">
         <div
           style={{
             position: "absolute",
@@ -499,9 +499,9 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
             <NoticeShelf notices={notices} floating align="right" />
           </div>
         </div>
-        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 [scrollbar-width:none]">
-          <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
-            <div style={{ maxWidth: 820, margin: "0 auto" }}>
+        <div ref={scrollContainerRef} className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto pt-4 [scrollbar-width:none]">
+          <div style={{ minWidth: 0, padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
+            <div style={{ width: "100%", minWidth: 0, maxWidth: 820, margin: "0 auto" }}>
               <ExtensionWidgets widgets={aboveEditorWidgets} />
 
             {(() => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -398,6 +398,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   return (
     <div
       className="relative flex h-full min-w-0 flex-col overflow-hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const layoutSource = await readFile(new URL("../app/layout.tsx", import.meta.url), "utf8");
+const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const appShellSource = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
+const chatWindowSource = await readFile(new URL("./ChatWindow.tsx", import.meta.url), "utf8");
+const chatInputSource = await readFile(new URL("./ChatInput.tsx", import.meta.url), "utf8");
+const viewportHookSource = await readFile(new URL("../hooks/useViewportHeight.ts", import.meta.url), "utf8");
+
+test("configures iOS standalone mode to use the full screen", () => {
+  assert.match(layoutSource, /statusBarStyle: "black-translucent"/);
+  assert.match(layoutSource, /viewportFit: "cover"/);
+  assert.match(layoutSource, /interactiveWidget: "resizes-content"/);
+});
+
+test("tracks the visual viewport while the software keyboard is open", () => {
+  assert.match(appShellSource, /useViewportHeight\(\)/);
+  assert.match(appShellSource, /paddingTop: "env\(safe-area-inset-top\)"/);
+  assert.match(appShellSource, /paddingBottom: "env\(safe-area-inset-bottom\)"/);
+  assert.match(appShellSource, /height: "calc\(36px \+ env\(safe-area-inset-top\)\)"/);
+  assert.match(appShellSource, /height: "var\(--app-viewport-height, 100dvh\)"/);
+  assert.match(viewportHookSource, /window\.visualViewport/);
+  assert.match(viewportHookSource, /--app-viewport-height/);
+  assert.match(viewportHookSource, /window\.scrollTo\(0, 0\)/);
+  assert.match(cssSource, /height: var\(--app-viewport-height, 100dvh\)/);
+});
+
+test("contains chat content and inputs within the mobile viewport", () => {
+  assert.match(cssSource, /\.markdown-body \{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;[\s\S]*?overflow-x: hidden;/);
+  assert.match(cssSource, /\.markdown-code-block \{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/);
+  assert.match(chatWindowSource, /overflow-x-hidden overflow-y-auto/);
+  assert.match(chatInputSource, /flex: 1,\s*minWidth: 0,\s*width: "100%",/);
+});
+
+test("prevents iOS focus zoom from widening the layout", () => {
+  assert.match(cssSource, /@media \(max-width: 640px\)[\s\S]*?textarea,[\s\S]*?input,[\s\S]*?select \{\s*font-size: 16px !important;/);
+});

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -19,12 +19,18 @@ test("tracks the visual viewport while the software keyboard is open", () => {
   assert.match(appShellSource, /useViewportHeight\(\)/);
   assert.match(appShellSource, /paddingTop: "env\(safe-area-inset-top\)"/);
   assert.match(appShellSource, /paddingBottom: "env\(safe-area-inset-bottom\)"/);
+  assert.match(appShellSource, /paddingLeft: "env\(safe-area-inset-left\)"/);
+  assert.match(appShellSource, /paddingRight: "env\(safe-area-inset-right\)"/);
   assert.match(appShellSource, /height: "calc\(36px \+ env\(safe-area-inset-top\)\)"/);
+  assert.match(appShellSource, /\/\* Right panel tab bar \*\/[\s\S]*?height: "calc\(36px \+ env\(safe-area-inset-top\)\)"/);
   assert.match(appShellSource, /height: "var\(--app-viewport-height, 100dvh\)"/);
+  assert.match(appShellSource, /right: "env\(safe-area-inset-right\)"/);
   assert.match(viewportHookSource, /window\.visualViewport/);
   assert.match(viewportHookSource, /--app-viewport-height/);
   assert.match(viewportHookSource, /window\.scrollTo\(0, 0\)/);
   assert.match(cssSource, /height: var\(--app-viewport-height, 100dvh\)/);
+  assert.match(cssSource, /left: env\(safe-area-inset-left\)/);
+  assert.match(chatWindowSource, /paddingBottom: "env\(safe-area-inset-bottom\)"/);
 });
 
 test("contains chat content and inputs within the mobile viewport", () => {

--- a/hooks/useViewportHeight.test.mjs
+++ b/hooks/useViewportHeight.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { shouldUseVisualViewportHeight } = await jiti.import("./useViewportHeight.ts");
+
+test("uses the visual viewport for a focused editor when the keyboard shrinks it", () => {
+  assert.equal(shouldUseVisualViewportHeight({
+    hasFocusedEditable: true,
+    innerHeight: 844,
+    viewportHeight: 510,
+    viewportScale: 1,
+  }), true);
+});
+
+test("keeps the dynamic viewport height when no editor is focused", () => {
+  assert.equal(shouldUseVisualViewportHeight({
+    hasFocusedEditable: false,
+    innerHeight: 844,
+    viewportHeight: 510,
+    viewportScale: 1,
+  }), false);
+});
+
+test("does not mistake pinch zoom for an open keyboard", () => {
+  assert.equal(shouldUseVisualViewportHeight({
+    hasFocusedEditable: true,
+    innerHeight: 844,
+    viewportHeight: 422,
+    viewportScale: 2,
+  }), false);
+});
+
+test("keeps the dynamic viewport height when the visual viewport is not reduced", () => {
+  assert.equal(shouldUseVisualViewportHeight({
+    hasFocusedEditable: true,
+    innerHeight: 844,
+    viewportHeight: 844,
+    viewportScale: 1,
+  }), false);
+});

--- a/hooks/useViewportHeight.ts
+++ b/hooks/useViewportHeight.ts
@@ -2,6 +2,33 @@
 
 import { useEffect } from "react";
 
+interface ViewportHeightState {
+  hasFocusedEditable: boolean;
+  innerHeight: number;
+  viewportHeight: number;
+  viewportScale: number;
+}
+
+export function shouldUseVisualViewportHeight({
+  hasFocusedEditable,
+  innerHeight,
+  viewportHeight,
+  viewportScale,
+}: ViewportHeightState): boolean {
+  const isUnscaled = Math.abs(viewportScale - 1) < 0.01;
+  return hasFocusedEditable && isUnscaled && innerHeight - viewportHeight > 1;
+}
+
+function hasFocusedEditableElement(): boolean {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement)) return false;
+
+  return activeElement.isContentEditable
+    || activeElement.tagName === "INPUT"
+    || activeElement.tagName === "SELECT"
+    || activeElement.tagName === "TEXTAREA";
+}
+
 /**
  * Keep the app height aligned with the visual viewport while a mobile keyboard
  * is open. iOS standalone PWAs can leave 100dvh at the layout viewport height,
@@ -15,7 +42,12 @@ export function useViewportHeight(): void {
     const root = document.documentElement;
 
     const update = () => {
-      const keyboardOpen = window.innerHeight - viewport.height > 1;
+      const keyboardOpen = shouldUseVisualViewportHeight({
+        hasFocusedEditable: hasFocusedEditableElement(),
+        innerHeight: window.innerHeight,
+        viewportHeight: viewport.height,
+        viewportScale: viewport.scale,
+      });
       if (keyboardOpen) {
         root.style.setProperty("--app-viewport-height", `${viewport.height}px`);
         if (window.scrollX !== 0 || window.scrollY !== 0) {

--- a/hooks/useViewportHeight.ts
+++ b/hooks/useViewportHeight.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Keep the app height aligned with the visual viewport while a mobile keyboard
+ * is open. iOS standalone PWAs can leave 100dvh at the layout viewport height,
+ * which puts the composer behind the keyboard and may scroll the page itself.
+ */
+export function useViewportHeight(): void {
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const root = document.documentElement;
+
+    const update = () => {
+      const keyboardOpen = window.innerHeight - viewport.height > 1;
+      if (keyboardOpen) {
+        root.style.setProperty("--app-viewport-height", `${viewport.height}px`);
+        if (window.scrollX !== 0 || window.scrollY !== 0) {
+          window.scrollTo(0, 0);
+        }
+      } else {
+        root.style.removeProperty("--app-viewport-height");
+      }
+    };
+
+    update();
+    viewport.addEventListener("resize", update);
+    viewport.addEventListener("scroll", update);
+
+    return () => {
+      viewport.removeEventListener("resize", update);
+      viewport.removeEventListener("scroll", update);
+      root.style.removeProperty("--app-viewport-height");
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

Improve the standalone PWA layout on iOS, based on the viewport/safe-area approach used by HAPI.

- opt into the full-screen iOS viewport with `viewport-fit=cover` and `black-translucent`
- account for top, bottom, and horizontal safe areas across the app bar, sidebar, composer, and file panel
- track `window.visualViewport` while the software keyboard is open so the composer remains inside the visible area
- distinguish keyboard resizing from pinch zoom by requiring an unscaled viewport and a focused editable control
- prevent mobile focus zoom and horizontal content expansion
- constrain chat/markdown/code content with `min-width: 0` and explicit horizontal overflow containment

## Problem

On an iPhone 16 Plus installed as a PWA:

1. the app started below a persistent unused status-bar strip
2. chat content and the composer could extend past the right edge, especially after focusing the input and opening the keyboard

The PWA previously used the default iOS status-bar mode without `viewport-fit=cover`, relied directly on `100dvh`, and rendered a 14px textarea (which lets iOS zoom the page on focus).

## HAPI comparison

HAPI uses the following relevant safeguards:

- `viewport-fit=cover`
- `apple-mobile-web-app-status-bar-style=black-translucent`
- `interactive-widget=resizes-content`
- safe-area padding on headers
- a `visualViewport` fallback for iOS keyboard resizing and page-scroll reset
- `min-w-0`, `max-w-full`, and horizontal overflow containment around chat/code surfaces

This PR adapts those patterns to pi-web's existing App Router and layout. Follow-up hardening also keeps the composer and file panel out of the bottom/top safe areas, respects landscape side insets, and avoids treating pinch zoom as a software keyboard.

## Validation

- `NODE_ENV=test node --test components/*.test.mjs hooks/*.test.mjs lib/*.test.mjs` — 221 passed
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `git diff --check`
- desktop and 390x844 mobile browser regression checks, including sidebar and file-panel transitions with no page-level horizontal overflow or console errors
- verified generated metadata:
  - `width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content`
  - `apple-mobile-web-app-status-bar-style=black-translucent`

## Testing note

The layout has been validated in the browser/build output, but the final visual check should still be performed on a physical iPhone in installed standalone mode because Safari's keyboard, status-bar, and safe-area behavior cannot be reproduced fully in desktop emulation.
