### PR TITLE
feat: collapse slash command expansion in user messages

### DIFF
--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
   jsx: { runtime: "automatic" },
   tsconfigPaths: true,
 });
-const { MessageView } = await jiti.import("./MessageView.tsx");
+const { MessageView, replaceUserMessageText } = await jiti.import("./MessageView.tsx");
 const { I18nProvider } = await jiti.import("../hooks/useI18n.tsx");
 
 function renderMessage(message) {
@@ -20,6 +20,14 @@ function renderMessage(message) {
     ),
   );
 }
+
+const COMPLETE_SKILL_EXPANSION = `<skill name="review" location="/skills/review/SKILL.md">
+References are relative to /skills/review.
+
+Review the supplied files.
+</skill>
+
+src/main.ts`;
 
 test("renders a provider error when the assistant message has no content", () => {
   const html = renderMessage({
@@ -48,4 +56,42 @@ test("renders partial assistant content before the provider error", () => {
 
   assert.match(html, /Partial response/);
   assert.match(html, /Error: Connection closed/);
+});
+
+test("renders a complete SDK skill expansion as a compact command", () => {
+  const html = renderMessage({
+    role: "user",
+    content: COMPLETE_SKILL_EXPANSION,
+  });
+
+  assert.match(html, /\/skill:review/);
+  assert.match(html, /src\/main\.ts/);
+  assert.match(html, /aria-expanded="false"/);
+  assert.doesNotMatch(html, /Review the supplied files/);
+});
+
+test("does not collapse incomplete skill-looking user text", () => {
+  const html = renderMessage({
+    role: "user",
+    content: '<skill name="review" location="/skills/review/SKILL.md">\nordinary user text',
+  });
+
+  assert.match(html, /ordinary user text/);
+  assert.doesNotMatch(html, /aria-expanded/);
+});
+
+test("keeps attached images when restoring a compact command for editing", () => {
+  const image = {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "QUJDRA==" },
+  };
+  const restored = replaceUserMessageText({
+    role: "user",
+    content: [{ type: "text", text: COMPLETE_SKILL_EXPANSION }, image],
+  }, "/skill:review src/main.ts");
+
+  assert.deepEqual(restored.content, [
+    { type: "text", text: "/skill:review src/main.ts" },
+    image,
+  ]);
 });

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -7,6 +7,7 @@ import { useI18n } from "@/hooks/useI18n";
 import { parseCompactionSummary } from "@/lib/compaction-summary";
 import { getAssistantErrorMessage, isEmptyThinkingBlock } from "@/lib/message-display";
 import { parseUnifiedPatch, type SplitDiffCell } from "@/lib/patch";
+import { skillExpansionToCommand } from "@/lib/slash-display";
 import type {
   AgentMessage,
   UserMessage,
@@ -84,6 +85,25 @@ function formatTime(ts?: number): string | null {
   return `${date} ${time}`;
 }
 
+export function replaceUserMessageText(message: UserMessage, text: string): UserMessage {
+  if (typeof message.content === "string") return { ...message, content: text };
+
+  const content: Array<TextContent | ImageContent> = [];
+  let replaced = false;
+  for (const block of message.content) {
+    if (block.type !== "text") {
+      content.push(block);
+      continue;
+    }
+    if (!replaced) {
+      content.push({ ...block, text });
+      replaced = true;
+    }
+  }
+  if (!replaced) content.unshift({ type: "text", text });
+  return { ...message, content };
+}
+
 function haveSameRelevantToolResults(
   message: AgentMessage,
   previous: Map<string, ToolResultMessage> | undefined,
@@ -151,6 +171,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
   const { t } = useI18n();
   const [hovered, setHovered] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   const content =
     typeof message.content === "string"
@@ -165,12 +186,49 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
       ? []
       : message.content.filter((b): b is ImageContent => b.type === "image");
 
+  const commandText = skillExpansionToCommand(content);
+  const commandSeparator = commandText?.search(/\s/) ?? -1;
+  const commandName = commandText
+    ? commandSeparator === -1 ? commandText : commandText.slice(0, commandSeparator)
+    : "";
+  const commandArgs = commandText && commandSeparator !== -1
+    ? commandText.slice(commandSeparator + 1)
+    : "";
+
   const time = formatTime(message.timestamp);
   const canFork = !!entryId && !!onFork;
+  const copyTarget = commandText ?? content;
+  const editTarget = commandText ? replaceUserMessageText(message, commandText) : message;
+
+  const imageBlocksNode = imageBlocks.length > 0 && (
+    <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: content ? 8 : 0 }}>
+      {imageBlocks.map((img, i) => {
+        // lib/types.ts ImageContent uses {source:{type,data,media_type,url}}
+        // pi-ai on-disk format uses flat {data, mimeType} — handle both
+        const flat = img as unknown as { data?: string; mimeType?: string };
+        const src = img.source
+          ? img.source.type === "base64"
+            ? `data:${img.source.media_type};base64,${img.source.data}`
+            : img.source.url ?? ""
+          : flat.data
+            ? `data:${flat.mimeType};base64,${flat.data}`
+            : "";
+        return (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            key={i}
+            src={src}
+            alt=""
+            style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid rgba(59,130,246,0.15)" }}
+          />
+        );
+      })}
+    </div>
+  );
   const canNavigate = !!prevAssistantEntryId && !!onNavigate;
 
   const copyContent = () => {
-    copyText(content).then(() => {
+    copyText(copyTarget).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -197,32 +255,71 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
             wordBreak: "break-word",
           }}
         >
-          {imageBlocks.length > 0 && (
-            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: content ? 8 : 0 }}>
-              {imageBlocks.map((img, i) => {
-                // lib/types.ts ImageContent uses {source:{type,data,media_type,url}}
-                // pi-ai on-disk format uses flat {data, mimeType} — handle both
-                const flat = img as unknown as { data?: string; mimeType?: string };
-                const src = img.source
-                  ? img.source.type === "base64"
-                    ? `data:${img.source.media_type};base64,${img.source.data}`
-                    : img.source.url ?? ""
-                  : flat.data
-                    ? `data:${flat.mimeType};base64,${flat.data}`
-                    : "";
-                return (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    key={i}
-                    src={src}
-                    alt=""
-                    style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid rgba(59,130,246,0.15)" }}
-                  />
-                );
-              })}
+          {commandText ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+              {imageBlocksNode}
+              <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  onClick={() => setExpanded((prev) => !prev)}
+                  title={expanded ? t("i18n.collapse") : t("i18n.expand")}
+                  aria-expanded={expanded}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    flexShrink: 0,
+                    padding: 0,
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "var(--accent)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 13,
+                    textAlign: "left",
+                  }}
+                >
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {commandName}
+                  </span>
+                  <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    style={{ flexShrink: 0, opacity: 0.75, transform: expanded ? "rotate(180deg)" : "none", transition: "transform 0.15s" }}
+                    aria-hidden="true"
+                  >
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </button>
+                {commandArgs && (
+                  <span style={{
+                    color: "var(--text)",
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    minWidth: 0,
+                    flex: 1,
+                  }}>
+                    {commandArgs}
+                  </span>
+                )}
+              </div>
+              {expanded && (
+                <MarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</MarkdownBody>
+              )}
             </div>
-          )}
+          ) : (
+          <>
+          {imageBlocksNode}
           {content && <MarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</MarkdownBody>}
+          </>
+          )}
         </div>
 
       </div>
@@ -278,7 +375,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
             }}>
               {canNavigate && (
                 <button
-                  onClick={() => { onNavigate!(prevAssistantEntryId!); onEditContent?.(message); }}
+                  onClick={() => { onNavigate!(prevAssistantEntryId!); onEditContent?.(editTarget); }}
                    title={t("i18n.editFromHereTitle")}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,

--- a/lib/slash-display.test.mjs
+++ b/lib/slash-display.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { skillExpansionToCommand } = await import("./slash-display.ts");
+
+function skillExpansion({
+  name = "review",
+  location = "/path/to/review/SKILL.md",
+  baseDir = "/path/to/review",
+  body = "Review the supplied files.",
+  args,
+} = {}) {
+  return `<skill name="${name}" location="${location}">\nReferences are relative to ${baseDir}.\n\n${body}\n</skill>${args === undefined ? "" : `\n\n${args}`}`;
+}
+
+test("restores a complete SDK skill expansion with arguments", () => {
+  assert.equal(
+    skillExpansionToCommand(skillExpansion({ args: "src/main.ts" })),
+    "/skill:review src/main.ts",
+  );
+});
+
+test("restores a complete SDK skill expansion without arguments", () => {
+  assert.equal(skillExpansionToCommand(skillExpansion()), "/skill:review");
+});
+
+test("restores multiline arguments", () => {
+  assert.equal(
+    skillExpansionToCommand(skillExpansion({ args: "first line\nsecond line" })),
+    "/skill:review first line\nsecond line",
+  );
+});
+
+test("uses the final closing tag when the skill body contains an example", () => {
+  assert.equal(
+    skillExpansionToCommand(skillExpansion({ body: "Example:\n</skill>\nContinue.", args: "src" })),
+    "/skill:review src",
+  );
+});
+
+test("does not collapse incomplete or lookalike user text", () => {
+  assert.equal(
+    skillExpansionToCommand('<skill name="review" location="/path/to/review/SKILL.md">\nordinary user text'),
+    null,
+  );
+  assert.equal(
+    skillExpansionToCommand('<skill name="review" location="/path/to/review/SKILL.md">\nReferences are elsewhere.\n\nbody\n</skill>'),
+    null,
+  );
+  assert.equal(skillExpansionToCommand("ordinary user text"), null);
+});

--- a/lib/slash-display.ts
+++ b/lib/slash-display.ts
@@ -1,0 +1,22 @@
+/**
+ * Display-only restoration for the exact envelope emitted by pi's
+ * `_expandSkillCommand`. The expanded text remains the stored session input.
+ */
+const SKILL_EXPANSION_RE = /^<skill name="([^"\n]+)" location="([^"\n]+)">\nReferences are relative to [^\n]+\.\n\n([\s\S]*)\n<\/skill>(?:\n\n([\s\S]+))?$/;
+
+/**
+ * Restore a complete SDK skill expansion to its compact command form.
+ *
+ * The expression intentionally requires the opening envelope, matching
+ * base-directory reference, final closing tag, and an optional two-newline args
+ * suffix. This avoids collapsing ordinary text that merely starts with a
+ * skill-looking tag. The greedy body capture makes the final closing tag win
+ * when a skill body contains an example `</skill>` tag.
+ */
+export function skillExpansionToCommand(text: string): string | null {
+  const match = text.match(SKILL_EXPANSION_RE);
+  if (!match) return null;
+
+  const [, name, , , args] = match;
+  return args ? `/skill:${name} ${args}` : `/skill:${name}`;
+}


### PR DESCRIPTION
Show a compact clickable command reference for slash-command messages (/skill:name and prompt templates) instead of the full SDK-expanded text. The user-supplied arguments stay fully visible; clicking the command name toggles the expanded skill/template body.

- lib/slash-display.ts: pure helpers (command parsing, skill expansion reverse-matching, FIFO tracker) + 17 unit tests
- rpc-manager.ts: inject originalText on message_end for user messages via a new message object (never mutates SDK-shared state), always consume one FIFO entry per message, clear the tracker on prompt failures
- session-reader.ts: reverse-match skill expansions when loading session history
- MessageView.tsx: render command name as accent-colored toggle with args shown verbatim; keep image blocks in both branches; add aria-expanded

Storage and model input stay unchanged: session JSONL keeps the expanded text and originalText is a display-only field.