### PR TITLE
fix: render math formulas in chat minimap outline

### DIFF
--- a/components/ChatMinimap.module.css
+++ b/components/ChatMinimap.module.css
@@ -139,6 +139,15 @@
   gap: 0;
 }
 
+.outline :global(.katex) {
+  font-size: 1em;
+}
+
+.outline :global(.katex-display) {
+  display: inline;
+  margin: 0;
+}
+
 .heading,
 .paragraph {
   display: block;

--- a/components/ChatMinimap.test.mjs
+++ b/components/ChatMinimap.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createJiti } from "jiti";
+
+registerHooks({
+  load(url, context, nextLoad) {
+    if (!url.endsWith(".module.css")) return nextLoad(url, context);
+    return {
+      format: "module",
+      shortCircuit: true,
+      source: "export default new Proxy({}, { get: (_, key) => String(key) });",
+    };
+  },
+});
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { AssistantOutline } = await jiti.import("./ChatMinimap.tsx");
+
+test("renders math in headings without disabling heading navigation", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(AssistantOutline, {
+      markdown: String.raw`# Inline $f_{k,t+1}$
+
+## Parentheses \(x^2 + y^2\)`,
+      onHeadingClick() {},
+    }),
+  );
+
+  assert.match(html, /class="katex"/);
+  assert.match(html, /data-preview-heading-index="0"/);
+  assert.match(html, /data-preview-heading-index="1"/);
+  assert.doesNotMatch(html, /disabled=""/);
+});

--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -2,7 +2,11 @@
 
 import { memo, useEffect, useRef, useState, useCallback, useMemo, type RefObject } from "react";
 import ReactMarkdown from "react-markdown";
-import { markdownPreviewRemarkPlugins } from "@/lib/markdown";
+import {
+  markdownPreviewRehypePlugins,
+  markdownPreviewRemarkPlugins,
+  normalizeDisplayMath,
+} from "@/lib/markdown";
 import { splitFinalAssistantBlocks } from "@/lib/message-display";
 import type { AgentMessage, AssistantMessage, TextContent, UserMessage } from "@/lib/types";
 import styles from "./ChatMinimap.module.css";
@@ -144,6 +148,7 @@ const AssistantOutline = memo(function AssistantOutline({
     <div className={styles.outline}>
       <ReactMarkdown
         remarkPlugins={previewRemarkPlugins}
+        rehypePlugins={markdownPreviewRehypePlugins}
         components={{
           h1: ({ children, node }) => <PreviewHeading level={1} headingIndex={getPreviewHeadingIndex(node)} onClick={onHeadingClick}>{children}</PreviewHeading>,
           h2: ({ children, node }) => <PreviewHeading level={2} headingIndex={getPreviewHeadingIndex(node)} onClick={onHeadingClick}>{children}</PreviewHeading>,
@@ -170,7 +175,7 @@ const AssistantOutline = memo(function AssistantOutline({
           code: ({ children }) => <>{children}</>,
         }}
       >
-        {markdown}
+        {normalizeDisplayMath(markdown)}
       </ReactMarkdown>
     </div>
   );

--- a/components/ChatMinimap.tsx
+++ b/components/ChatMinimap.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { memo, useEffect, useRef, useState, useCallback, useMemo, type RefObject } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
+import rehypeKatex from "rehype-katex";
 import {
-  markdownPreviewRehypePlugins,
   markdownPreviewRemarkPlugins,
   normalizeDisplayMath,
 } from "@/lib/markdown";
@@ -125,6 +125,9 @@ const previewRemarkPlugins = [
   ...(markdownPreviewRemarkPlugins ?? []),
   remarkPreviewOutline,
 ];
+const previewRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [
+  [rehypeKatex, { throwOnError: false, strict: false }],
+];
 
 function getPreviewHeadingIndex(node: unknown): number | null {
   const properties = (node as { properties?: Record<string, unknown> } | undefined)?.properties;
@@ -134,7 +137,7 @@ function getPreviewHeadingIndex(node: unknown): number | null {
   return null;
 }
 
-const AssistantOutline = memo(function AssistantOutline({
+export const AssistantOutline = memo(function AssistantOutline({
   markdown,
   onHeadingClick,
   onAnswerClick,
@@ -143,12 +146,13 @@ const AssistantOutline = memo(function AssistantOutline({
   onHeadingClick?: (headingIndex: number) => void;
   onAnswerClick?: () => void;
 }) {
+  const normalizedMarkdown = useMemo(() => normalizeDisplayMath(markdown), [markdown]);
   if (!markdown) return null;
   return (
     <div className={styles.outline}>
       <ReactMarkdown
         remarkPlugins={previewRemarkPlugins}
-        rehypePlugins={markdownPreviewRehypePlugins}
+        rehypePlugins={previewRehypePlugins}
         components={{
           h1: ({ children, node }) => <PreviewHeading level={1} headingIndex={getPreviewHeadingIndex(node)} onClick={onHeadingClick}>{children}</PreviewHeading>,
           h2: ({ children, node }) => <PreviewHeading level={2} headingIndex={getPreviewHeadingIndex(node)} onClick={onHeadingClick}>{children}</PreviewHeading>,
@@ -175,7 +179,7 @@ const AssistantOutline = memo(function AssistantOutline({
           code: ({ children }) => <>{children}</>,
         }}
       >
-        {normalizeDisplayMath(markdown)}
+        {normalizedMarkdown}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
## Summary

- Render math in chat minimap H1-H3 outlines with a local `rehype-katex` pipeline.
- Normalize `\\(...\\)` delimiters while preserving the existing heading navigation metadata.
- Keep KaTeX compact in the narrow history panel.
- Add a regression test covering both formula rendering and enabled heading navigation.

## Root cause

`AssistantOutline` already used `remark-math`, but did not run `rehype-katex`, so math nodes were flattened to raw LaTeX by the outline's `code` renderer.

The minimap uses a local KaTeX-only rehype pipeline instead of the shared markdown preview pipeline because that pipeline also runs `rehype-sanitize`, which removes `data-preview-heading-index` and disables H1-H3 navigation.

## Test plan

- [x] `node --test components/ChatMinimap.test.mjs components/MarkdownBody.test.mjs lib/markdown.test.mjs`
- [x] `node_modules/.bin/tsc --noEmit`
- [x] `npm run lint`
- [ ] Open a session whose assistant answers include headings with `$...$` / `\\(...\\)` math
- [ ] Hover the right-side chat minimap and confirm formulas render as KaTeX
- [ ] Click a math-containing outline heading and confirm navigation works