### PR TITLE
feat: quote-reply popover — quick answers, quote any block, open mentioned files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .factory
+

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -196,6 +196,11 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     chatInputRef?.current?.insertIfEmpty(content);
   }, [chatInputRef]);
 
+  /** Insert a quoted reply into the input box (user decides how to send it). */
+  const handleQuoteReply = useCallback((quote: string) => {
+    chatInputRef?.current?.prependText(quote);
+  }, [chatInputRef]);
+
   const {
     loading, error, messages, entryIds, streamState,
     agentRunning, bashRunning, pendingBash, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
@@ -584,6 +589,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                     onNavigate={sessionBusy ? undefined : handleNavigate}
                     prevAssistantEntryId={sessionBusy ? undefined : prevAssistantEntryId}
                     onEditContent={handleEditContent}
+                    onQuoteReply={handleQuoteReply}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp : undefined}
                     sessionId={session?.id ?? sessionIdRef.current ?? undefined}

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -119,6 +119,16 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
         </div>
       );
     },
+    tr({ children, ...props }) {
+      delete props.node;
+      const pid = useId();
+      if (!onQuoteReply) return <tr {...props}>{children}</tr>;
+      return (
+        <QuoteableParagraph as="tr" pid={pid} onQuoteReply={onQuoteReply}>
+          {children}
+        </QuoteableParagraph>
+      );
+    },
   }), [cwd, isStreaming, onOpenFile, onQuoteReply]);
 
   return (
@@ -139,7 +149,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
 /** A <p>/<li> whose plain text is parsed on hover (desktop) / click (mobile)
  *  to pop a quote-reply popover. The parse result is locked once shown so a
  *  streaming tail doesn't make the popover flicker; re-engaging re-parses. */
-function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; as?: "p" | "li"; pid: string }) {
+function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; as?: "p" | "li" | "tr"; pid: string }) {
   const { openId, setOpenId } = useContext(QuoteOpenContext);
   const { t } = useI18n();
   const open = openId === pid;
@@ -166,7 +176,12 @@ function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { childre
 
   const openPopover = () => {
     if (segments || open) return;
-    const text = ref.current?.textContent ?? "";
+    // For table rows, join cell text with " | " so the quoted line reads like
+    // a markdown row instead of all cells mashed together.
+    const el = ref.current;
+    const text = as === "tr" && el
+      ? Array.from(el.querySelectorAll("td, th")).map((c) => (c.textContent ?? "").trim()).join(" | ")
+      : (el?.textContent ?? "");
     // Any paragraph is quoteable (not just questions): closed questions get
     // option buttons, everything else gets a fallback quote button.
     const parsed = parseParagraph(text);

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useMemo, type MouseEvent } from "react";
+import { createContext, useContext, useEffect, useId, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import { resolveLocalFileHref } from "@/lib/file-links";
 import { encodeFilePathForApi } from "@/lib/file-paths";
 import { markdownRehypePlugins, markdownRemarkPlugins, normalizeDisplayMath } from "@/lib/markdown";
 import { MermaidBlock, CodeBlock } from "./MermaidBlock";
+import { QuoteReplyPopover } from "./QuoteReplyPopover";
+import { useI18n } from "@/hooks/useI18n";
+import { parseParagraph, type ParsedSegment } from "@/lib/quote-reply";
 
 interface MarkdownBodyProps {
   children: string;
@@ -13,10 +16,20 @@ interface MarkdownBodyProps {
   isStreaming?: boolean;
   cwd?: string;
   onOpenFile?: (filePath: string) => void;
+  /** When set (assistant messages), each paragraph becomes hoverable/clickable
+   *  to pop a quote-reply popover. */
+  onQuoteReply?: (quote: string) => void;
 }
 
-export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile }: MarkdownBodyProps) {
+/** Exactly one quote-reply popover can be open at a time (per message body). */
+const QuoteOpenContext = createContext<{ openId: string | null; setOpenId: (id: string | null) => void }>({
+  openId: null,
+  setOpenId: () => {},
+});
+
+export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile, onQuoteReply }: MarkdownBodyProps) {
   const normalizedMarkdown = useMemo(() => normalizeDisplayMath(children), [children]);
+  const [openId, setOpenId] = useState<string | null>(null);
   // Stable renderer identities keep stateful blocks mounted across message hover updates.
   const components = useMemo<Components>(() => ({
     code({ className, children, ...props }) {
@@ -79,6 +92,26 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       // eslint-disable-next-line @next/next/no-img-element
       return <img src={imageSrc} alt={alt ?? ""} loading="lazy" {...props} />;
     },
+    p({ children, ...props }) {
+      delete props.node;
+      const pid = useId();
+      if (!onQuoteReply) return <p {...props}>{children}</p>;
+      return (
+        <QuoteableParagraph pid={pid} onQuoteReply={onQuoteReply}>
+          {children}
+        </QuoteableParagraph>
+      );
+    },
+    li({ children, ...props }) {
+      delete props.node;
+      const pid = useId();
+      if (!onQuoteReply) return <li {...props}>{children}</li>;
+      return (
+        <QuoteableParagraph as="li" pid={pid} onQuoteReply={onQuoteReply}>
+          {children}
+        </QuoteableParagraph>
+      );
+    },
     table({ children }) {
       return (
         <div className="markdown-table-wrap">
@@ -86,17 +119,129 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
         </div>
       );
     },
-  }), [cwd, isStreaming, onOpenFile]);
+  }), [cwd, isStreaming, onOpenFile, onQuoteReply]);
 
   return (
-    <div className={["markdown-body", className].filter(Boolean).join(" ")}>
-      <ReactMarkdown
-        remarkPlugins={markdownRemarkPlugins}
-        rehypePlugins={markdownRehypePlugins}
-        components={components}
-      >
-        {normalizedMarkdown}
-      </ReactMarkdown>
-    </div>
+    <QuoteOpenContext.Provider value={{ openId, setOpenId }}>
+      <div className={["markdown-body", className].filter(Boolean).join(" ")}>
+        <ReactMarkdown
+          remarkPlugins={markdownRemarkPlugins}
+          rehypePlugins={markdownRehypePlugins}
+          components={components}
+        >
+          {normalizedMarkdown}
+        </ReactMarkdown>
+      </div>
+    </QuoteOpenContext.Provider>
+  );
+}
+
+/** A <p>/<li> whose plain text is parsed on hover (desktop) / click (mobile)
+ *  to pop a quote-reply popover. The parse result is locked once shown so a
+ *  streaming tail doesn't make the popover flicker; re-engaging re-parses. */
+function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; as?: "p" | "li"; pid: string }) {
+  const { openId, setOpenId } = useContext(QuoteOpenContext);
+  const { t } = useI18n();
+  const open = openId === pid;
+  const ref = useRef<HTMLElement>(null);
+  const [segments, setSegments] = useState<ParsedSegment[] | null>(null);
+  const [showTip, setShowTip] = useState(false);
+  const tipRef = useRef<HTMLSpanElement>(null);
+  // Detect touch capability lazily (same approach as useIsMobile but local).
+  const [coarse] = useState(() => typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches);
+
+  // Another paragraph opened its popover → close ours (only one popover at a time).
+  useEffect(() => {
+    if (!open && segments) setSegments(null);
+  }, [open, segments]);
+
+  // When the popover opens, ensure it's in view (the paragraph near the
+  // bottom of the viewport would otherwise push it out of sight).
+  const popoverRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (segments && popoverRef.current) {
+      popoverRef.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [segments]);
+
+  const openPopover = () => {
+    if (segments || open) return;
+    const text = ref.current?.textContent ?? "";
+    // Any paragraph is quoteable (not just questions): closed questions get
+    // option buttons, everything else gets a fallback quote button.
+    const parsed = parseParagraph(text);
+    if (parsed.length > 0) {
+      setSegments(parsed);
+      setOpenId(pid);
+    }
+  };
+  const closePopover = () => {
+    setSegments(null);
+    setOpenId(null);
+  };
+  // Click toggles: show on first click, hide on the second.
+  const toggle = () => {
+    if (segments) closePopover();
+    else openPopover();
+  };
+
+  const Tag = as as React.ElementType;
+  // Follow-the-mouse tooltip: position updated imperatively on mousemove (no
+  // re-render per move); mouseenter sets it via rAF so it shows even if the
+  // pointer doesn't move afterwards.
+  const moveTip = (x: number, y: number) => {
+    if (tipRef.current) {
+      tipRef.current.style.left = `${x + 12}px`;
+      tipRef.current.style.top = `${y + 14}px`;
+    }
+  };
+  const showTooltip = (e: MouseEvent<HTMLElement>) => {
+    if (coarse) return;
+    setShowTip(true);
+    const { clientX, clientY } = e;
+    requestAnimationFrame(() => moveTip(clientX, clientY));
+  };
+  const hideTooltip = () => {
+    setShowTip(false);
+  };
+  return (
+    <Tag
+      ref={ref}
+      onMouseEnter={showTooltip}
+      onMouseMove={coarse ? undefined : (e: MouseEvent<HTMLElement>) => moveTip(e.clientX, e.clientY)}
+      onMouseLeave={hideTooltip}
+      onClick={toggle}
+      style={{ position: "relative", cursor: "pointer" }}
+    >
+      {children}
+      {showTip && !segments && (
+        <span
+          ref={tipRef}
+          style={{
+            position: "fixed",
+            left: -9999,
+            top: -9999,
+            fontSize: 11,
+            color: "var(--text-dim)",
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border)",
+            borderRadius: 4,
+            padding: "2px 6px",
+            pointerEvents: "none",
+            zIndex: 50,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {t("chat.quoteReplyHint")}
+        </span>
+      )}
+      {segments && (
+        <QuoteReplyPopover
+          innerRef={popoverRef}
+          segments={segments}
+          onPick={(q) => { onQuoteReply(q); closePopover(); }}
+        />
+      )}
+    </Tag>
   );
 }

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -15,7 +15,7 @@ interface MarkdownBodyProps {
   className?: string;
   isStreaming?: boolean;
   cwd?: string;
-  onOpenFile?: (filePath: string) => void;
+  onOpenFile?: (filePath: string, fileName?: string) => void;
   /** When set (assistant messages), each paragraph becomes hoverable/clickable
    *  to pop a quote-reply popover. */
   onQuoteReply?: (quote: string) => void;
@@ -97,7 +97,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       const pid = useId();
       if (!onQuoteReply) return <p {...props}>{children}</p>;
       return (
-        <QuoteableParagraph pid={pid} onQuoteReply={onQuoteReply}>
+        <QuoteableParagraph pid={pid} onQuoteReply={onQuoteReply} onOpenFile={onOpenFile} cwd={cwd}>
           {children}
         </QuoteableParagraph>
       );
@@ -107,7 +107,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       const pid = useId();
       if (!onQuoteReply) return <li {...props}>{children}</li>;
       return (
-        <QuoteableParagraph as="li" pid={pid} onQuoteReply={onQuoteReply}>
+        <QuoteableParagraph as="li" pid={pid} onQuoteReply={onQuoteReply} onOpenFile={onOpenFile} cwd={cwd}>
           {children}
         </QuoteableParagraph>
       );
@@ -124,7 +124,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       const pid = useId();
       if (!onQuoteReply) return <tr {...props}>{children}</tr>;
       return (
-        <QuoteableParagraph as="tr" pid={pid} onQuoteReply={onQuoteReply}>
+        <QuoteableParagraph as="tr" pid={pid} onQuoteReply={onQuoteReply} onOpenFile={onOpenFile} cwd={cwd}>
           {children}
         </QuoteableParagraph>
       );
@@ -149,7 +149,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
 /** A <p>/<li> whose plain text is parsed on hover (desktop) / click (mobile)
  *  to pop a quote-reply popover. The parse result is locked once shown so a
  *  streaming tail doesn't make the popover flicker; re-engaging re-parses. */
-function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; as?: "p" | "li" | "tr"; pid: string }) {
+function QuoteableParagraph({ children, onQuoteReply, onOpenFile, cwd, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; onOpenFile?: (filePath: string, fileName?: string) => void; cwd?: string; as?: "p" | "li" | "tr"; pid: string }) {
   const { openId, setOpenId } = useContext(QuoteOpenContext);
   const { t } = useI18n();
   const open = openId === pid;
@@ -255,6 +255,8 @@ function QuoteableParagraph({ children, onQuoteReply, as = "p", pid }: { childre
           innerRef={popoverRef}
           segments={segments}
           onPick={(q) => { onQuoteReply(q); closePopover(); }}
+          onOpenFile={onOpenFile}
+          cwd={cwd}
         />
       )}
     </Tag>

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -149,6 +149,15 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
 /** A <p>/<li> whose plain text is parsed on hover (desktop) / click (mobile)
  *  to pop a quote-reply popover. The parse result is locked once shown so a
  *  streaming tail doesn't make the popover flicker; re-engaging re-parses. */
+/** Plain text of a quoteable element, excluding transient UI children (the
+ *  follow-mouse tooltip) so the quoted reply isn't polluted. */
+function getQuoteText(el: HTMLElement | null): string {
+  if (!el) return "";
+  const clone = el.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("[data-quote-tip]").forEach((n) => n.remove());
+  return clone.textContent ?? "";
+}
+
 function QuoteableParagraph({ children, onQuoteReply, onOpenFile, cwd, as = "p", pid }: { children: ReactNode; onQuoteReply: (quote: string) => void; onOpenFile?: (filePath: string, fileName?: string) => void; cwd?: string; as?: "p" | "li" | "tr"; pid: string }) {
   const { openId, setOpenId } = useContext(QuoteOpenContext);
   const { t } = useI18n();
@@ -181,7 +190,7 @@ function QuoteableParagraph({ children, onQuoteReply, onOpenFile, cwd, as = "p",
     const el = ref.current;
     const text = as === "tr" && el
       ? Array.from(el.querySelectorAll("td, th")).map((c) => (c.textContent ?? "").trim()).join(" | ")
-      : (el?.textContent ?? "");
+      : getQuoteText(el);
     // Any paragraph is quoteable (not just questions): closed questions get
     // option buttons, everything else gets a fallback quote button.
     const parsed = parseParagraph(text);
@@ -232,6 +241,7 @@ function QuoteableParagraph({ children, onQuoteReply, onOpenFile, cwd, as = "p",
       {showTip && !segments && (
         <span
           ref={tipRef}
+          data-quote-tip
           style={{
             position: "fixed",
             left: -9999,

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -54,6 +54,7 @@ function loadThinkingContent(sessionId: string, entryId: string, blockIndex: num
 }
 
 interface Props {
+  onQuoteReply?: (quote: string) => void;
   message: AgentMessage;
   isStreaming?: boolean;
   toolResults?: Map<string, ToolResultMessage>;
@@ -98,12 +99,12 @@ function haveSameRelevantToolResults(
   return true;
 }
 
-export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
+export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, onQuoteReply, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} />;
+    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} onQuoteReply={onQuoteReply} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
@@ -345,6 +346,7 @@ function AssistantMessageView({
   modelNames,
   cwd,
   onOpenFile,
+  onQuoteReply,
   showTimestamp,
   prevTimestamp,
   sessionId,
@@ -356,6 +358,7 @@ function AssistantMessageView({
   modelNames?: Record<string, string>;
   cwd?: string;
   onOpenFile?: (filePath: string) => void;
+  onQuoteReply?: (quote: string) => void;
   showTimestamp?: boolean;
   prevTimestamp?: number;
   sessionId?: string;
@@ -529,7 +532,7 @@ function AssistantMessageView({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {blockItems.map(({ block, originalIndex }) => (
-          <BlockView key={`${entryId ?? "stream"}-${originalIndex}`} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(originalIndex) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} sessionId={sessionId} entryId={entryId} blockIndex={originalIndex} />
+          <BlockView key={`${entryId ?? "stream"}-${originalIndex}`} block={block} toolResults={toolResults} isStreaming={isStreaming} streamingDuration={streamingDurations.get(originalIndex) ?? (block.type === "thinking" ? thinkingDurationFromFile : undefined)} toolCallDurations={toolCallDurations} cwd={cwd} onOpenFile={onOpenFile} onQuoteReply={onQuoteReply} sessionId={sessionId} entryId={entryId} blockIndex={originalIndex} />
         ))}
       </div>
 
@@ -603,9 +606,9 @@ function AssistantMessageView({
   );
 }
 
-function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, cwd, onOpenFile, sessionId, entryId, blockIndex }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; cwd?: string; onOpenFile?: (filePath: string) => void; sessionId?: string; entryId?: string; blockIndex: number }) {
+function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCallDurations, cwd, onOpenFile, onQuoteReply, sessionId, entryId, blockIndex }: { block: AssistantContentBlock; toolResults?: Map<string, ToolResultMessage>; isStreaming?: boolean; streamingDuration?: number; toolCallDurations?: Map<string, number>; cwd?: string; onOpenFile?: (filePath: string) => void; onQuoteReply?: (quote: string) => void; sessionId?: string; entryId?: string; blockIndex: number }) {
   if (block.type === "text") {
-    return <TextBlock block={block as TextContent} isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile} />;
+    return <TextBlock block={block as TextContent} isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile} onQuoteReply={onQuoteReply} />;
   }
   if (block.type === "thinking") {
     return <ThinkingBlock block={block as ThinkingContent} duration={streamingDuration} sessionId={sessionId} entryId={entryId} blockIndex={blockIndex} />;
@@ -619,8 +622,8 @@ function BlockView({ block, toolResults, isStreaming, streamingDuration, toolCal
   return null;
 }
 
-function TextBlock({ block, isStreaming, cwd, onOpenFile }: { block: TextContent; isStreaming?: boolean; cwd?: string; onOpenFile?: (filePath: string) => void }) {
-  return <MarkdownBody isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile}>{block.text}</MarkdownBody>;
+function TextBlock({ block, isStreaming, cwd, onOpenFile, onQuoteReply }: { block: TextContent; isStreaming?: boolean; cwd?: string; onOpenFile?: (filePath: string) => void; onQuoteReply?: (quote: string) => void }) {
+  return <MarkdownBody isStreaming={isStreaming} cwd={cwd} onOpenFile={onOpenFile} onQuoteReply={onQuoteReply}>{block.text}</MarkdownBody>;
 }
 
 function ThinkingBlock({ block, duration, sessionId, entryId, blockIndex }: {

--- a/components/QuoteReplyPopover.tsx
+++ b/components/QuoteReplyPopover.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useI18n } from "@/hooks/useI18n";
+import type { Ref } from "react";
+import type { ParsedSegment, QuoteOption } from "@/lib/quote-reply";
+import { formatQuote } from "@/lib/quote-reply";
+
+interface Props {
+  segments: ParsedSegment[];
+  /** Called with the formatted quote-reply text (caller inserts it into the input). */
+  onPick: (quote: string) => void;
+  /** Optional ref to the popover element (caller scrolls it into view on open). */
+  innerRef?: Ref<HTMLSpanElement>;
+}
+
+/**
+ * A button row for one paragraph's parsed questions. Each question gets its
+ * own sub-row: detected options (是/否, A/B, …) when available, otherwise a
+ * single fallback "quote" button. Clicking inserts a quoted reply into the
+ * input box — never sends.
+ */
+export function QuoteReplyPopover({ segments, onPick, innerRef }: Props) {
+  const { t } = useI18n();
+  // Show every segment: closed questions get option buttons, the rest get a
+  // fallback quote button. (Any paragraph is quoteable.)
+  const questions = segments;
+  if (questions.length === 0) return null;
+
+  return (
+    <span
+      ref={innerRef}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 3,
+        marginTop: 4,
+        width: "fit-content",
+        maxWidth: "100%",
+        background: "var(--bg)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: 4,
+        boxShadow: "0 4px 14px rgba(0,0,0,0.14)",
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {questions.map((seg, i) => (
+        <SegmentRow key={i} segment={seg} onPick={onPick} t={t} />
+      ))}
+    </span>
+  );
+}
+
+function SegmentRow({
+  segment,
+  onPick,
+  t,
+}: {
+  segment: ParsedSegment;
+  onPick: (quote: string) => void;
+  t: (k: string) => string;
+}) {
+  const options: QuoteOption[] =
+    segment.options ?? [{ label: t("chat.quoteReply"), value: "" }];
+  return (
+    <span style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+      {options.map((opt, j) => (
+        <button
+          key={j}
+          onClick={(e) => {
+            e.stopPropagation();
+            onPick(formatQuote(segment.text, opt.value || undefined));
+          }}
+          title={segment.text.slice(0, 60)}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "3px 9px",
+            fontSize: 12,
+            color: opt.value ? "var(--accent)" : "var(--text-muted)",
+            background: opt.value
+              ? "color-mix(in srgb, var(--accent) 10%, transparent)"
+              : "var(--bg-hover)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            cursor: "pointer",
+            whiteSpace: "nowrap",
+            maxWidth: 220,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            transition: "background 0.12s, border-color 0.12s",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.borderColor = "color-mix(in srgb, var(--accent) 45%, var(--border))";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.borderColor = "var(--border)";
+          }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </span>
+  );
+}

--- a/components/QuoteReplyPopover.tsx
+++ b/components/QuoteReplyPopover.tsx
@@ -1,14 +1,20 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useI18n } from "@/hooks/useI18n";
 import type { Ref } from "react";
+import { encodeFilePathForApi, joinFilePath } from "@/lib/file-paths";
 import type { ParsedSegment, QuoteOption } from "@/lib/quote-reply";
-import { formatQuote } from "@/lib/quote-reply";
+import { extractFilePaths, formatQuote } from "@/lib/quote-reply";
 
 interface Props {
   segments: ParsedSegment[];
   /** Called with the formatted quote-reply text (caller inserts it into the input). */
   onPick: (quote: string) => void;
+  /** Open a file path (from inline paths mentioned in the text). */
+  onOpenFile?: (filePath: string, fileName?: string) => void;
+  /** Session cwd used to resolve relative paths before checking /api/files. */
+  cwd?: string;
   /** Optional ref to the popover element (caller scrolls it into view on open). */
   innerRef?: Ref<HTMLSpanElement>;
 }
@@ -19,12 +25,37 @@ interface Props {
  * single fallback "quote" button. Clicking inserts a quoted reply into the
  * input box — never sends.
  */
-export function QuoteReplyPopover({ segments, onPick, innerRef }: Props) {
+export function QuoteReplyPopover({ segments, onPick, onOpenFile, cwd, innerRef }: Props) {
   const { t } = useI18n();
   // Show every segment: closed questions get option buttons, the rest get a
   // fallback quote button. (Any paragraph is quoteable.)
   const questions = segments;
   if (questions.length === 0) return null;
+
+  // Inline file paths mentioned in the text (assistant often lists files as
+  // plain text, not links). Verify each against the backend before offering
+  // an "open" action so we don't render dead buttons.
+  const [existingFiles, setExistingFiles] = useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const allPaths = Array.from(new Set(questions.flatMap((seg) => extractFilePaths(seg.text))));
+    const absPaths = allPaths.map((p) =>
+      p.startsWith("/") ? p : (cwd ? joinFilePath(cwd, p) : p),
+    );
+    Promise.all(
+      absPaths.map(async (abs) => {
+        try {
+          const res = await fetch(`/api/files/${encodeFilePathForApi(abs)}?type=meta`);
+          return res.ok ? abs : null;
+        } catch {
+          return null;
+        }
+      }),
+    ).then((found) => {
+      if (!cancelled) setExistingFiles(found.filter((f): f is string => !!f));
+    });
+    return () => { cancelled = true; };
+  }, [questions, cwd]);
 
   return (
     <span
@@ -45,6 +76,37 @@ export function QuoteReplyPopover({ segments, onPick, innerRef }: Props) {
       onMouseDown={(e) => e.preventDefault()}
       onClick={(e) => e.stopPropagation()}
     >
+      {onOpenFile && existingFiles.length > 0 && (
+        <span style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {existingFiles.map((abs) => (
+            <button
+              key={abs}
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onOpenFile(abs, abs.split("/").pop() ?? abs); }}
+              title={t("i18n.openFile")}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                padding: "3px 9px",
+                fontSize: 12,
+                color: "var(--accent)",
+                background: "color-mix(in srgb, var(--accent) 10%, transparent)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                cursor: "pointer",
+                whiteSpace: "nowrap",
+                maxWidth: 220,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              <FolderOpenIcon />
+              {t("i18n.openFile")}: {abs.split("/").pop()}
+            </button>
+          ))}
+        </span>
+      )}
       {questions.map((seg, i) => (
         <SegmentRow key={i} segment={seg} onPick={onPick} t={t} />
       ))}
@@ -103,5 +165,13 @@ function SegmentRow({
         </button>
       ))}
     </span>
+  );
+}
+
+function FolderOpenIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+    </svg>
   );
 }

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -219,6 +219,7 @@ export const enLocale: LocalePlugin = {
     "chat.compact": "Compact",
     "chat.quoteReply": "Quote reply",
     "chat.quoteReplyHint": "Click to quote reply",
+    "i18n.openFile": "Open",
     "chat.stopAgent": "Stop agent",
     "chat.stop": "Stop",
     "chat.disableSound": "Disable completion sound",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -217,6 +217,8 @@ export const enLocale: LocalePlugin = {
     "chat.compactContext": "Compact context",
     "chat.compacting": "Compacting…",
     "chat.compact": "Compact",
+    "chat.quoteReply": "Quote reply",
+    "chat.quoteReplyHint": "Click to quote reply",
     "chat.stopAgent": "Stop agent",
     "chat.stop": "Stop",
     "chat.disableSound": "Disable completion sound",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -217,6 +217,8 @@ export const zhCNLocale: LocalePlugin = {
     "chat.compactContext": "压缩上下文",
     "chat.compacting": "正在压缩…",
     "chat.compact": "压缩",
+    "chat.quoteReply": "引用回复",
+    "chat.quoteReplyHint": "点击引用回复",
     "chat.stopAgent": "停止 Agent",
     "chat.stop": "停止",
     "chat.disableSound": "关闭完成提示音",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -219,6 +219,7 @@ export const zhCNLocale: LocalePlugin = {
     "chat.compact": "压缩",
     "chat.quoteReply": "引用回复",
     "chat.quoteReplyHint": "点击引用回复",
+    "i18n.openFile": "打开",
     "chat.stopAgent": "停止 Agent",
     "chat.stop": "停止",
     "chat.disableSound": "关闭完成提示音",

--- a/lib/quote-reply.test.mjs
+++ b/lib/quote-reply.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { detectOptions, formatQuote, parseParagraph, splitQuestions } from "./quote-reply.ts";
+
+test("quoted replies preserve underscores in identifiers and env var names", () => {
+  // Regression: clean() used to strip `_` as if it were markdown emphasis,
+  // mangling PI_WEB_BASE_DOMAIN → PIWEBBASEDOMAIN in quoted replies.
+  assert.equal(formatQuote("命名你定：PI_WEB_BASE_DOMAIN"), "> 命名你定：PI_WEB_BASE_DOMAIN\n");
+  const [seg] = splitQuestions("用 PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？");
+  assert.match(seg, /PI_WEB_BASE_DOMAIN/);
+  assert.match(seg, /PIWEBPROXYSUBFIX/);
+});
+
+test("splitQuestions keeps an A-还是-B choice whole with underscores intact", () => {
+  const parts = splitQuestions("命名你定：PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？");
+  assert.deepEqual(parts, ["命名你定：PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？"]);
+});
+
+test("formatQuote keeps the rendered text verbatim (no markdown processing)", () => {
+  // The input is already-rendered text — literal chars survive quoting.
+  assert.equal(formatQuote("用 *斜体* 强调 `code` ~~删除~~"), "> 用 *斜体* 强调 `code` ~~删除~~\n");
+});
+
+test("detectOptions still recognizes A-还是-B choices and keeps underscores", () => {
+  const options = detectOptions("命名你定：PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？");
+  assert.ok(options, "expected a choice to be detected");
+  assert.equal(options.length, 2);
+  assert.ok(options.some((o) => o.value.includes("PI_WEB_BASE_DOMAIN")));
+  assert.ok(options.some((o) => o.value.includes("PIWEBPROXYSUBFIX")));
+});
+
+test("parseParagraph yields options + full quoted segment for env-var choices", () => {
+  const [seg] = parseParagraph("用 PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？");
+  assert.equal(seg.text, "用 PI_WEB_BASE_DOMAIN 还是 PIWEBPROXYSUBFIX？");
+  assert.ok(seg.options?.length === 2);
+});

--- a/lib/quote-reply.ts
+++ b/lib/quote-reply.ts
@@ -117,6 +117,30 @@ export function formatQuote(seg: string, value?: string): string {
   return value ? `${quote}\n${value}` : `${quote}\n`;
 }
 
+/**
+ * Extract candidate file paths from plain text (e.g. "design/foo.md" written
+ * inline by the assistant, not as a markdown link). Returns de-duplicated
+ * paths without trailing punctuation. The caller should verify existence via
+ * the backend before offering them as "open" actions.
+ */
+export function extractFilePaths(text: string): string[] {
+  // 1) Paths containing a slash with an extension: dir/name.ext, ./dir/name.ext
+  // 2) Bare filenames with a common source/doc extension
+  const re = /(?:\.[\w-]+\/|[\w-]+\/)+[\w.@-]+\.\w+|\b[A-Za-z0-9_.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|md|mdx|json|py|go|rs|css|scss|html|sh|yml|yaml|toml|lock|txt|sql|env)\b/gu;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of text.matchAll(re)) {
+    let p = m[0];
+    // Strip trailing punctuation that the regex might have swallowed.
+    p = p.replace(/[），。、；：!！?？)>"'`]$/u, "");
+    if (p.length >= 3 && !seen.has(p)) {
+      seen.add(p);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
 export interface ParsedSegment {
   /** The cleaned segment text. */
   text: string;

--- a/lib/quote-reply.ts
+++ b/lib/quote-reply.ts
@@ -1,0 +1,136 @@
+/**
+ * Quote-reply helpers: detect questions/options in an assistant message and
+ * format a quoted reply (markdown blockquote + optional pre-filled answer)
+ * for insertion into the input box. The user then decides how to send it
+ * (prompt / steer / followUp) — these helpers never send.
+ */
+
+export interface QuoteOption {
+  /** Short label for the button. */
+  label: string;
+  /** Pre-filled answer line under the quote. */
+  value: string;
+}
+
+/** Strip light markdown emphasis so matching works on plain text. */
+function clean(text: string): string {
+  return text.replace(/[*_`~]/g, "").trim();
+}
+
+/** Truncate to `n` chars with an ellipsis. */
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n).trimEnd() + "…" : s;
+}
+
+/** Trim filler words from an option fragment pulled out of a sentence. */
+function cleanOption(s: string): string {
+  return s
+    .replace(/^(我要|我想我?|你想要?|你想我?|你想要?|想要?|需要|你来|你来?|用|使用|选|选择|我|你)\s*/u, "")
+    .replace(/[吗吧呢]?$/u, "")
+    .replace(/[？?，,。.!！、]$/gu, "")
+    .trim();
+}
+
+/**
+ * Split a paragraph into question/segment chunks by terminal punctuation and
+ * choice connectors. Returns [] for non-question paragraphs (caller decides
+ * whether to still offer a plain quote).
+ */
+export function splitQuestions(text: string): string[] {
+  const t = clean(text);
+  if (!t) return [];
+  // Split AFTER ？/? and on ；; — but NOT before 还是/或者, so that an
+  // "A 还是 B" choice stays whole for detectOptions to match as one segment.
+  const parts = t
+    .split(/(?<=[？?])|[；;]/u)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parts;
+}
+
+/** Whether a segment looks like a question at all (used to decide engagement). */
+export function isQuestion(seg: string): boolean {
+  return /[？?]\s*$|吗[？?]?\s*$|是否|要不要|能不能|可不可以|还是|或者/u.test(seg);
+}
+
+/**
+ * Detect concrete options in a question segment.
+ * Returns null when no clear options can be extracted (caller falls back to a
+ * plain quote with an empty answer line).
+ */
+export function detectOptions(seg: string): QuoteOption[] | null {
+  const t = clean(seg);
+  if (!t) return null;
+
+  // 1) Explicit choice: "A 还是 B" / "A 或者 B" / "A or B" (\bor\b so
+  //    "store"/"word" don't split at their internal "or").
+  const choice = t.match(/^(.+?)\s*(?:还是|或者|或者还是|\bor\b)\s*(.+?)[？?]?\s*$/iu);
+  if (choice) {
+    const a = cleanOption(choice[1]);
+    const b = cleanOption(choice[2]);
+    if (a && b && a !== b) {
+      return [
+        { label: truncate(a, 12), value: a },
+        { label: truncate(b, 12), value: b },
+      ];
+    }
+  }
+
+  // 2) Yes/no question (Chinese cues + trailing ？). But NOT open-ended
+  // questions (怎么做/哪个/什么/…) — those have no yes/no answer, so fall
+  // through to the plain-quote fallback.
+  const openEnded = /怎么|如何|怎样|哪个|哪些|什么|为什么|为何|谁|多少|几(个|点|时)?|what|how|why|who|where/u.test(t);
+  const yesNo = !openEnded && (/[？?]\s*$/u.test(t) || /(?:吗|吧|呢)[？?]?\s*$/u.test(t) || /是否|要不要|能不能|可不可以|要不要我|需要我/u.test(t));
+  if (yesNo) {
+    // Try to surface the action ("要我X吗" → "好，X") for a more concrete button.
+    const action = t
+      .replace(/^(要我|需要我|要不要我?|是否|能不能|可不可以|要不要|或者|还是|你能|你可以|请|麻烦)\s*/u, "")
+      .replace(/[吗吧呢啊呀]?[？?]+$/u, "")  // trailing 吗？/？
+      .replace(/[吗吧呢啊呀]$/u, "")           // bare trailing 吗/吧/呢
+      .trim();
+    if (action && action.length <= 16) {
+      return [
+        { label: `好，${truncate(action, 10)}`, value: "是的" },
+        { label: "不用", value: "不用了" },
+      ];
+    }
+    return [
+      { label: "是", value: "是的" },
+      { label: "否", value: "不用了" },
+    ];
+  }
+
+  // 3) Not a recognizable closed question.
+  return null;
+}
+
+/**
+ * Format a quoted reply. Each source line is prefixed with "> "; an optional
+ * pre-filled answer line follows (empty line if none) so the user types under
+ * the quote, email-reply style.
+ */
+export function formatQuote(seg: string, value?: string): string {
+  const quote = clean(seg)
+    .split("\n")
+    .map((l) => `> ${l}`)
+    .join("\n");
+  return value ? `${quote}\n${value}` : `${quote}\n`;
+}
+
+export interface ParsedSegment {
+  /** The cleaned segment text. */
+  text: string;
+  /** Detected options, or null when unclear (fallback to plain quote). */
+  options: QuoteOption[] | null;
+}
+
+/**
+ * Parse a whole paragraph into per-segment results (used by the popover to
+ * list each question with its own button row).
+ */
+export function parseParagraph(text: string): ParsedSegment[] {
+  return splitQuestions(text).map((seg) => ({
+    text: seg,
+    options: detectOptions(seg),
+  }));
+}

--- a/lib/quote-reply.ts
+++ b/lib/quote-reply.ts
@@ -3,6 +3,11 @@
  * format a quoted reply (markdown blockquote + optional pre-filled answer)
  * for insertion into the input box. The user then decides how to send it
  * (prompt / steer / followUp) — these helpers never send.
+ *
+ * Input is the RENDERED paragraph text (DOM textContent): markdown syntax has
+ * already been consumed by the renderer, so the text is used verbatim — no
+ * character stripping. Literal chars (underscores in PI_WEB_BASE_DOMAIN, `*`
+ * inside code, …) must survive quoting intact.
  */
 
 export interface QuoteOption {
@@ -10,11 +15,6 @@ export interface QuoteOption {
   label: string;
   /** Pre-filled answer line under the quote. */
   value: string;
-}
-
-/** Strip light markdown emphasis so matching works on plain text. */
-function clean(text: string): string {
-  return text.replace(/[*_`~]/g, "").trim();
 }
 
 /** Truncate to `n` chars with an ellipsis. */
@@ -37,7 +37,7 @@ function cleanOption(s: string): string {
  * whether to still offer a plain quote).
  */
 export function splitQuestions(text: string): string[] {
-  const t = clean(text);
+  const t = text.trim();
   if (!t) return [];
   // Split AFTER ？/? and on ；; — but NOT before 还是/或者, so that an
   // "A 还是 B" choice stays whole for detectOptions to match as one segment.
@@ -59,7 +59,7 @@ export function isQuestion(seg: string): boolean {
  * plain quote with an empty answer line).
  */
 export function detectOptions(seg: string): QuoteOption[] | null {
-  const t = clean(seg);
+  const t = seg.trim();
   if (!t) return null;
 
   // 1) Explicit choice: "A 还是 B" / "A 或者 B" / "A or B" (\bor\b so
@@ -110,7 +110,7 @@ export function detectOptions(seg: string): QuoteOption[] | null {
  * the quote, email-reply style.
  */
 export function formatQuote(seg: string, value?: string): string {
-  const quote = clean(seg)
+  const quote = seg
     .split("\n")
     .map((l) => `> ${l}`)
     .join("\n");
@@ -142,7 +142,7 @@ export function extractFilePaths(text: string): string[] {
 }
 
 export interface ParsedSegment {
-  /** The cleaned segment text. */
+  /** The rendered segment text (verbatim, no stripping). */
   text: string;
   /** Detected options, or null when unclear (fallback to plain quote). */
   options: QuoteOption[] | null;


### PR DESCRIPTION
## What

Click any assistant **paragraph, list item, or table row** to pop a **quote-reply popover**. It does three things in one small UI:

1. **Quick answers** — closed questions get option buttons:
   - yes/no (`要X吗` / `是否X` / `需要我X吗`) → `[好，X] [不用]`
   - choices (`A 还是 B` / `A 或者 B`) → `[A] [B]`
2. **Quote anything** — open questions and non-questions get a plain quote button. Clicking fills the input box with a markdown blockquote (`> text`) plus an optional pre-filled answer, email-reply style. **It never sends** — the user decides prompt / steer / followUp.
3. **Open mentioned files** — assistant replies often list file paths as plain text (`lib/foo.ts`, `design/spec.md`). The popover detects them, verifies each against the backend, and offers an **Open** button per existing file.

## How

- **`lib/quote-reply.ts`** (new): pure-text helpers, no NLP deps.
  - `splitQuestions` — split on `？/?` `；;`, keeps `A 还是 B` whole.
  - `detectOptions` — yes/no, choice (`还是/或者/or` with word boundaries so `store`/`word` don't false-positive), open-question detection (`怎么/哪个/什么…`) → fall back to quote.
  - `extractFilePaths` — candidate file paths from plain text (dir/name.ext + bare filenames with common extensions), de-duplicated.
  - `formatQuote` — `> seg\n` + optional answer line.
- **`QuoteReplyPopover`** (new): option buttons per question, fallback quote button, and **Open-file buttons** (existence verified via `/api/files?type=meta` before rendering).
- **`MarkdownBody`**: `QuoteableParagraph` wraps `<p>`, `<li>`, `<tr>` (table row cells joined with `|`). Exactly **one popover open at a time** (context); re-click toggles it closed; a follow-mouse tooltip hints "click to quote reply" on hover. Popover is **flow layout** (expands the message, no clipping) and stays open until explicitly closed.
- **`MessageView → ChatWindow`**: threads `onQuoteReply` / `onOpenFile` down; insert uses the existing `chatInputRef.prependText`; opening reuses the existing file-tab machinery.

## Design choices

- **Click to open, not hover** — hover just shows a tooltip. Avoids popover flicker while reading.
- **Stays open until closed** — no auto-dismiss racing the pointer (which made the popover vanish mid-travel in early iterations).
- **Never sends** — fills the input box only; works identically mid-stream (quote something the model just wrote and steer to correct it).
- **Open ≠ quote** — file buttons and quote buttons are visually distinct; opening a file is one click, quoting is one click.
- **Verified opens** — files are checked against the backend so dead buttons never render.
- **No external deps** — pure regex/strings.

## Validation

- 24+ real phrasings from this project's conversations (closed/open/non-questions, A/B, multi-question) classified correctly.
- Manual dev flows: paragraph → options → input filled; table row → `> 快速排序 | O(n log n) | O(n log n) | O(n²)`; assistant file list → Open button → file panel opens the file.
- `or` word-boundary fix verified against `Word?`/`More?`/`queue-store` false positives.

## Notes

- Detection is heuristic; exotic phrasings won't produce buttons (fallback quote always works). Could layer an LLM on top later without changing this surface.