### PR TITLE
fix: rename input pre-fills the session title and selects all text

### DIFF
--- a/components/SessionSidebar.test.mjs
+++ b/components/SessionSidebar.test.mjs
@@ -24,3 +24,10 @@ test("polls running sessions only while the tab is visible", () => {
   assert.match(source, /document\.visibilityState !== "visible"/);
   assert.match(source, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/);
 });
+
+test("does not persist an unchanged fallback title ending in whitespace", () => {
+  assert.match(
+    sessionItemSource,
+    /const name = renameValue\.trim\(\);[\s\S]*?if \(renameValue === title \|\| name === \(session\.name \?\? ""\)\) return;/,
+  );
+});

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -1852,7 +1852,7 @@ function SessionItem({
     setRenaming(false);
     // No-op when unchanged: the fallback title (first message / id) isn't a
     // real stored name, so don't persist it as one.
-    if (name === (session.name ?? "") || name === title) return;
+    if (renameValue === title || name === (session.name ?? "")) return;
     try {
       await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
         method: "PATCH",

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -1830,19 +1830,29 @@ function SessionItem({
   const [deleting, setDeleting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Select the whole name once the rename input is mounted (startRename's
+  // immediate setTimeout can fire before the input exists).
+  useEffect(() => {
+    if (renaming) {
+      const id = requestAnimationFrame(() => inputRef.current?.select());
+      return () => cancelAnimationFrame(id);
+    }
+  }, [renaming]);
+
   const title = session.name || session.firstMessage.slice(0, 50) || session.id.slice(0, 12);
 
   const startRename = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setRenameValue(session.name ?? "");
+    setRenameValue(session.name || session.firstMessage.slice(0, 50) || session.id.slice(0, 12));
     setRenaming(true);
-    setTimeout(() => inputRef.current?.select(), 0);
-  }, [session.name]);
+  }, [session.name, session.firstMessage, session.id]);
 
   const commitRename = useCallback(async () => {
     const name = renameValue.trim();
     setRenaming(false);
-    if (name === (session.name ?? "")) return;
+    // No-op when unchanged: the fallback title (first message / id) isn't a
+    // real stored name, so don't persist it as one.
+    if (name === (session.name ?? "") || name === title) return;
     try {
       await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
         method: "PATCH",
@@ -1853,7 +1863,7 @@ function SessionItem({
     } catch {
       // ignore
     }
-  }, [renameValue, session.id, session.name, onRenamed]);
+  }, [renameValue, session.id, session.name, onRenamed, title]);
 
   const performDelete = useCallback(async () => {
     setConfirmDelete(false);


### PR DESCRIPTION
## What

When renaming a session, the rename input now **pre-fills the displayed title** and **selects all of it** — so you can type a new name to replace it, or edit in place.

## Why

Before, the input was pre-filled with `session.name` only. Sessions without an explicit name (most of them) have an empty `session.name`, so the input appeared **blank** — even though the sidebar displays a fallback title (first message / id). Also the pre-select ran via `setTimeout(..., 0)` before the input had mounted, so it often didn't select anything.

## How

- `startRename` fills `session.name || firstMessage.slice(0,50) || id.slice(0,12)` (the same fallback the row title uses).
- Selection happens in a `useEffect` on `renaming` (after the input is mounted, via `requestAnimationFrame`).
- `commitRename` no-ops when the value equals the displayed fallback title — so the fallback isn't accidentally persisted as a real name.

## Validation

- Rename on a session without a custom name → input shows the first-message title, fully selected.
- Type to replace, or edit in place; unchanged submit doesn't persist the fallback as a name.