### PR TITLE
fix: persist file explorer collapsed state

### DIFF
--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useLayoutEffect, useState, useCallback, useRef, type CSSProperties, type ReactNode } from "react";
 import type { SessionInfo } from "@/lib/types";
+import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
 import { useI18n } from "@/hooks/useI18n";
 import { DirectoryPicker } from "./DirectoryPicker";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
@@ -464,6 +465,12 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     initialLoadDone.current = true;
     loadSessions(isFirst);
   }, [loadSessions, refreshKey]);
+
+  // Browser storage is unavailable during server rendering. Restore the panel
+  // preference after hydration so a collapsed explorer stays collapsed on reload.
+  useEffect(() => {
+    setExplorerOpen(loadExplorerOpen());
+  }, []);
 
   // Persist unread markers so they survive a browser refresh before the user
   // has actually opened the completed session.
@@ -1558,7 +1565,11 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         >
           <div style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
             <button
-              onClick={() => setExplorerOpen((v) => !v)}
+              onClick={() => setExplorerOpen((open) => {
+                const next = !open;
+                saveExplorerOpen(next);
+                return next;
+              })}
               style={{
                 display: "flex",
                 alignItems: "center",

--- a/lib/file-explorer-state.test.mjs
+++ b/lib/file-explorer-state.test.mjs
@@ -41,3 +41,23 @@ test("falls back to open when browser storage is unavailable", () => {
   assert.equal(loadExplorerOpen(unavailable), true);
   assert.doesNotThrow(() => saveExplorerOpen(false, unavailable));
 });
+
+test("falls back when accessing browser storage throws", () => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const blockedWindow = {};
+  Object.defineProperty(blockedWindow, "localStorage", {
+    get() { throw new DOMException("blocked", "SecurityError"); },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: blockedWindow,
+  });
+
+  try {
+    assert.equal(loadExplorerOpen(), true);
+    assert.doesNotThrow(() => saveExplorerOpen(false));
+  } finally {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else delete globalThis.window;
+  }
+});

--- a/lib/file-explorer-state.test.mjs
+++ b/lib/file-explorer-state.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { loadExplorerOpen, saveExplorerOpen } = await jiti.import("./file-explorer-state.ts");
+
+function createStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    values,
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
+}
+
+test("defaults to an open file explorer", () => {
+  assert.equal(loadExplorerOpen(createStorage()), true);
+});
+
+test("saves and restores the file explorer panel state", () => {
+  const storage = createStorage();
+
+  saveExplorerOpen(false, storage);
+  assert.equal(loadExplorerOpen(storage), false);
+
+  saveExplorerOpen(true, storage);
+  assert.equal(loadExplorerOpen(storage), true);
+});
+
+test("falls back to open when browser storage is unavailable", () => {
+  const unavailable = {
+    getItem() { throw new Error("blocked"); },
+    setItem() { throw new Error("blocked"); },
+  };
+
+  assert.equal(loadExplorerOpen(unavailable), true);
+  assert.doesNotThrow(() => saveExplorerOpen(false, unavailable));
+});

--- a/lib/file-explorer-state.ts
+++ b/lib/file-explorer-state.ts
@@ -7,7 +7,11 @@ interface StorageLike {
 
 function getBrowserStorage(): StorageLike | null {
   if (typeof window === "undefined") return null;
-  return window.localStorage;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 }
 
 export function loadExplorerOpen(storage: StorageLike | null = getBrowserStorage()): boolean {

--- a/lib/file-explorer-state.ts
+++ b/lib/file-explorer-state.ts
@@ -1,0 +1,32 @@
+const EXPLORER_OPEN_STORAGE_KEY = "pi-web:file-explorer:open";
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function getBrowserStorage(): StorageLike | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function loadExplorerOpen(storage: StorageLike | null = getBrowserStorage()): boolean {
+  if (!storage) return true;
+  try {
+    return storage.getItem(EXPLORER_OPEN_STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function saveExplorerOpen(
+  open: boolean,
+  storage: StorageLike | null = getBrowserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(EXPLORER_OPEN_STORAGE_KEY, String(open));
+  } catch {
+    // Persistence is best-effort; privacy mode and storage quotas must not break the explorer.
+  }
+}


### PR DESCRIPTION
## Summary

- persist whether the entire file explorer panel is expanded or collapsed
- restore the preference after client hydration so a collapsed explorer stays collapsed after a page refresh
- default to expanded when no preference exists or browser storage is unavailable
- add focused tests for saving, restoring, and storage failure fallback

## Verification

- `env -u PI_WEB_PASSWORD node --test lib/file-explorer-state.test.mjs`
- all repository `*.test.mjs` tests: 251 passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- manually verified in a browser: collapse panel, refresh, panel remains collapsed; expand panel, refresh, panel remains expanded

Closes #365
