### PR TITLE
fix: model switching reliability, lost composer input, stranded tasks after compaction, and intranet TLS

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -37,13 +37,14 @@ interface Props {
   onPromptWithStreamingBehavior?: (message: string, behavior: "steer" | "followUp", images?: AttachedImage[]) => void;
   isStreaming: boolean;
   model?: { provider: string; modelId: string } | null;
-  isAutoModelSelection?: boolean;
   modelNames?: Record<string, string>;
   modelList?: { id: string; name: string; provider: string }[];
   modelError?: string | null;
   /** Diagnostics from resolving `enabledModels`, e.g. a pattern that matched nothing. */
   modelScopeWarnings?: string[];
   onModelChange?: (provider: string, modelId: string) => void;
+  /** A switch is in flight — shown on the picker so the click never looks ignored. */
+  modelSwitching?: boolean;
   onCompact?: () => void;
   onAbortCompaction?: () => void;
   isCompacting?: boolean;
@@ -76,6 +77,7 @@ export interface ChatInputHandle {
   insertIfEmpty: (text: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
+  restoreSubmission: (text: string, images?: ChatDraftImage[]) => void;
 }
 
 const TOOL_PRESETS = ["off", "default", "full"] as const;
@@ -312,7 +314,7 @@ export function ModelScopeWarningBanner({ warnings }: { warnings?: string[] }) {
 }
 
 export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
-  onSend, onAbort, onSteer, onFollowUp, isStreaming, model, isAutoModelSelection, modelNames, modelList, modelError, modelScopeWarnings, onModelChange,
+  onSend, onAbort, onSteer, onFollowUp, isStreaming, model, modelNames, modelList, modelError, modelScopeWarnings, onModelChange, modelSwitching,
   onCompact, onAbortCompaction, isCompacting, compactError, compactResult, toolPreset, onToolPresetChange,
   thinkingLevel, onThinkingLevelChange, availableThinkingLevels, thinkingLevelMap,
   retryInfo, queuedMessages, inputHistory = [], onRecallQueue,
@@ -435,6 +437,32 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     },
     addImages(files: File[]) {
       processImageFiles(files);
+    },
+    // Recovery path for a message that was cleared on submit but never made it
+    // into the conversation. Never discards what the user typed since: the
+    // failed text goes in front of it, the same way queued messages are
+    // recalled.
+    restoreSubmission(text: string, images?: ChatDraftImage[]) {
+      const ta = textareaRef.current;
+      const current = ta ? ta.value : valueRef.current;
+      const combined = [text, current].filter((t) => t.trim()).join("\n\n");
+      if (combined !== current) {
+        setValue(combined);
+        setAtQuery(null);
+      }
+      if (images?.length) {
+        setAttachedImages((prev) => {
+          if (prev.length) return prev;
+          return draftImagesToAttachedImages(images);
+        });
+      }
+      requestAnimationFrame(() => {
+        if (!ta) return;
+        ta.focus();
+        ta.setSelectionRange(combined.length, combined.length);
+        ta.style.height = "auto";
+        ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+      });
     },
   }));
 
@@ -1856,8 +1884,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                       <line x1="20" y1="9" x2="23" y2="9" /><line x1="20" y1="14" x2="23" y2="14" />
                       <line x1="1" y1="9" x2="4" y2="9" /><line x1="1" y1="14" x2="4" y2="14" />
                     </svg>
-                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0, opacity: modelSwitching ? 0.6 : 1 }}>
                       {currentName ?? (modelOptions.length > 0 ? "Select model" : "No models")}
+                      {modelSwitching ? " …" : ""}
                     </span>
                   </button>
                   {modelDropdownOpen && modelDropdownRect && (() => {
@@ -1932,10 +1961,16 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                               return (
                                 <button
                                   key={`${opt.provider}:${opt.modelId}`}
+                                  // Always re-issue the switch, even for the
+                                  // entry that looks active: set_model is
+                                  // idempotent, and skipping it made a stale
+                                  // label impossible to recover from — the user
+                                  // clicked the model they wanted and nothing
+                                  // happened.
                                   onClick={() => {
                                     setModelDropdownOpen(false);
                                     setModelFilter("");
-                                    if (!isActive || isAutoModelSelection) onModelChange(opt.provider, opt.modelId);
+                                    onModelChange(opt.provider, opt.modelId);
                                   }}
                                   style={{
                                     display: "flex", alignItems: "center", gap: 8,

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -375,6 +375,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const fileIndexMetaRef = useRef<{ cwd: string; fetchedAt: number } | null>(null);
   const fileIndexFetchingRef = useRef<string | null>(null);
   const draftKeyRef = useRef(draftKey);
+  const pendingRestoreRef = useRef<{ key: string | undefined; text: string } | null>(null);
   const valueRef = useRef(value);
   const attachedImagesRef = useRef(attachedImages);
   const pendingImageCountRef = useRef(0);
@@ -443,23 +444,23 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     // failed text goes in front of it, the same way queued messages are
     // recalled.
     restoreSubmission(text: string, images?: ChatDraftImage[]) {
-      const ta = textareaRef.current;
-      const current = ta ? ta.value : valueRef.current;
-      const combined = [text, current].filter((t) => t.trim()).join("\n\n");
-      if (combined !== current) {
-        setValue(combined);
-        setAtQuery(null);
-      }
+      if (!text.trim() && !images?.length) return;
+      // Functional update on purpose. Submitting queues setValue("") and the
+      // failure can land before React has flushed it, so reading the textarea
+      // or `value` here sees the text that is about to be wiped — which is how
+      // insertIfEmpty used to bail out and lose the message. Composing against
+      // the queued state instead is correct in every ordering.
+      pendingRestoreRef.current = { key: draftKeyRef.current, text };
+      setValue((prev) => [text, prev].filter((t) => t.trim()).join("\n\n"));
+      setAtQuery(null);
       if (images?.length) {
-        setAttachedImages((prev) => {
-          if (prev.length) return prev;
-          return draftImagesToAttachedImages(images);
-        });
+        setAttachedImages((prev) => (prev.length ? prev : draftImagesToAttachedImages(images)));
       }
       requestAnimationFrame(() => {
+        const ta = textareaRef.current;
         if (!ta) return;
         ta.focus();
-        ta.setSelectionRange(combined.length, combined.length);
+        ta.setSelectionRange(ta.value.length, ta.value.length);
         ta.style.height = "auto";
         ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
       });
@@ -523,6 +524,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const clearInput = useCallback(() => {
     setValue("");
     setAtQuery(null);
+    pendingRestoreRef.current = null;
     setHistoryMenuOpen(false);
     if (draftKey) clearDraft(draftKey);
     if (draftKeyRef.current && draftKeyRef.current !== draftKey) clearDraft(draftKeyRef.current);
@@ -553,7 +555,16 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
     const draft = draftKey ? getDraft(draftKey) : null;
     draftKeyRef.current = draftKey;
-    setValue(draft?.value ?? "");
+    // A send that failed on a brand-new session restores its text under the
+    // "new:<cwd>" key, and promoting the session then swaps the key — carry the
+    // recovered text across instead of resetting the composer to the promoted
+    // session's (empty) draft.
+    const pendingRestore = pendingRestoreRef.current;
+    pendingRestoreRef.current = null;
+    const carried = pendingRestore && pendingRestore.key === previousDraftKey && previousDraftKey?.startsWith("new:")
+      ? pendingRestore.text
+      : null;
+    setValue(carried ? [carried, draft?.value ?? ""].filter((t) => t.trim()).join("\n\n") : (draft?.value ?? ""));
     setAtQuery(null);
     setHistoryMenuOpen(false);
     setAttachedImages((prev) => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -200,10 +200,9 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     loading, error, messages, entryIds, streamState,
     agentRunning, bashRunning, pendingBash, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
     retryInfo, contextUsage, forkingEntryId,
-    isCompacting, compactError, compactResult, displayModel: displayModelValue, sessionStats,
+    isCompacting, compactError, compactResult, displayModel: displayModelValue, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
     notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
-    isAutoModelSelection,
     agentPhase,
     isNew,
     sessionIdRef, messagesEndRef, scrollContainerRef,
@@ -350,12 +349,12 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       onPromptWithStreamingBehavior={agentRunning ? handlePromptWithStreamingBehavior : undefined}
       isStreaming={sessionBusy}
       model={displayModelValue}
-      isAutoModelSelection={isAutoModelSelection}
       modelNames={modelNames}
       modelList={modelList}
       modelError={modelError}
       modelScopeWarnings={modelScopeWarnings}
       onModelChange={handleModelChange}
+      modelSwitching={modelSwitching}
       onCompact={session || isNew ? handleCompact : undefined}
       onAbortCompaction={handleAbortCompaction}
       isCompacting={isCompacting}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -69,6 +69,8 @@ interface LastAssistantTextResponse {
 type AgentStateResponse = {
   contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null;
   systemPrompt?: string;
+  /** The live in-memory model of the agent — authoritative over the session file. */
+  model?: { id: string; provider: string };
   thinkingLevel?: string;
   isStreaming?: boolean;
   isPromptRunning?: boolean;
@@ -86,6 +88,12 @@ export interface QueuedMessages {
 
 function normalizeQueuedMessages(q?: { steering?: string[]; followUp?: string[] } | null): QueuedMessages {
   return { steering: q?.steering ?? [], followUp: q?.followUp ?? [] };
+}
+
+type SelectedModelRef = { provider: string; modelId: string };
+
+function sameModel(a: SelectedModelRef | null | undefined, b: SelectedModelRef | null | undefined): boolean {
+  return !!a && !!b && a.provider === b.provider && a.modelId === b.modelId;
 }
 
 type ExtensionUiDialogRequest = Extract<ExtensionUiRequest, { method: "select" | "confirm" | "input" | "editor" }>;
@@ -305,6 +313,8 @@ export interface ChatInputHandle {
   insertIfEmpty: (content: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
+  /** Put a submission that never reached the agent back into the composer. */
+  restoreSubmission: (text: string, images?: { data: string; mimeType: string }[]) => void;
 }
 
 export interface AttachedImage {
@@ -364,6 +374,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [forkingEntryId, setForkingEntryId] = useState<string | null>(null);
   const [currentModelOverride, setCurrentModelOverride] = useState<{ provider: string; modelId: string } | null>(null);
   const [pendingModel, setPendingModel] = useState<{ provider: string; modelId: string } | null>(null);
+  const [modelSwitching, setModelSwitching] = useState(false);
   const [isCompacting, setIsCompacting] = useState(false);
   const [compactError, setCompactError] = useState<string | null>(null);
   const [compactResult, setCompactResult] = useState<CompactResultInfo | null>(null);
@@ -407,6 +418,18 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const thinkingLevelOverrideRef = useRef<Exclude<ThinkingLevelOption, "auto"> | null>(null);
   const promptRunIdRef = useRef(0);
   const optimisticUserMessageKeyRef = useRef<string | null>(null);
+  // Monotonic id for model switches: a slow response from an earlier switch
+  // must never overwrite the model the user picked later.
+  const modelSwitchIdRef = useRef(0);
+  const modelSwitchInFlightRef = useRef(0);
+  // The prompt currently in flight, kept so a failed turn can hand the user's
+  // text back to the composer instead of dropping it on the floor.
+  const inFlightPromptRef = useRef<{ runId: number; message: string; images?: AttachedImage[] } | null>(null);
+  const promptProducedOutputRef = useRef(false);
+  // A prompt whose turn errored out. Whether the text is actually lost depends
+  // on whether pi persisted the user entry (it does not for a session with no
+  // assistant reply yet), so the decision is deferred to the next reload.
+  const failedPromptRef = useRef<{ message: string; images?: AttachedImage[]; key: string } | null>(null);
 
   const setToolPresetState = opts.setToolPreset ?? setToolPreset;
 
@@ -452,6 +475,38 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } satisfies SessionStatsInfo;
   }, [messages, sessionStatsOverride, contextUsage, data?.filePath, session?.id, session?.name]);
 
+  // The wrapper's in-memory model is the only authoritative source: the
+  // session file trails behind and settings can be changed elsewhere. Every
+  // place that reads agent state feeds it back here so the picker label always
+  // matches the model that will actually answer the next prompt.
+  const applyLiveAgentModel = useCallback((state?: AgentStateResponse | null) => {
+    const live = state?.model;
+    if (!live) return;
+    if (modelSwitchInFlightRef.current !== 0) return;
+    setCurrentModelOverride((prev) => {
+      const next = { provider: live.provider, modelId: live.id };
+      return sameModel(prev, next) ? prev : next;
+    });
+  }, []);
+
+  // Hand a prompt that never made it into the conversation back to the
+  // composer. Used for synchronous send failures and, via failedPromptRef, for
+  // prompt_error — which is how a dead or misconfigured model reports itself
+  // (the POST returns 200 because pi runs the turn fire-and-forget).
+  const restorePromptToComposer = useCallback((pending: { message: string; images?: AttachedImage[] }) => {
+    const images = pending.images?.map((img) => ({ data: img.data, mimeType: img.mimeType }));
+    if (!pending.message.trim() && !images?.length) return;
+    opts.chatInputRef?.current?.restoreSubmission(pending.message, images);
+  }, [opts.chatInputRef]);
+
+  const restoreFailedPrompt = useCallback((runId?: number) => {
+    const pending = inFlightPromptRef.current;
+    if (!pending) return;
+    if (runId !== undefined && pending.runId !== runId) return;
+    inFlightPromptRef.current = null;
+    restorePromptToComposer(pending);
+  }, [restorePromptToComposer]);
+
   const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
     let messagesLoaded = false;
     try {
@@ -473,8 +528,29 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setData(d);
       setActiveLeafId(d.leafId);
       setMessages(d.context.messages);
+      // A failed turn is only real data loss when the reloaded session no
+      // longer contains the message — pi drops it for sessions it has not
+      // flushed yet. Give it back to the composer in that case only, so a
+      // failure that kept the message in the transcript does not duplicate it.
+      const failedPrompt = failedPromptRef.current;
+      if (failedPrompt) {
+        failedPromptRef.current = null;
+        const survived = d.context.messages.some(
+          (m) => m.role === "user" && userMessageKey(m) === failedPrompt.key,
+        );
+        if (!survived) restorePromptToComposer(failedPrompt);
+      }
       setEntryIds(d.context.entryIds ?? []);
-      setCurrentModelOverride(null);
+      // Drop the optimistic model only once the reloaded session agrees with
+      // it. The session file lags a switch (pi flushes the model_change entry
+      // asynchronously, and a destroyed-then-restarted wrapper replays an older
+      // leaf), so clearing unconditionally used to snap the picker back to the
+      // previous model — which reads as "switching did nothing".
+      setCurrentModelOverride((prev) => {
+        if (!prev) return null;
+        if (modelSwitchInFlightRef.current !== 0) return prev;
+        return sameModel(d.context.model, prev) ? null : prev;
+      });
       setError(null);
       if (d.context.thinkingLevel && d.context.thinkingLevel !== "off") {
         setThinkingLevel(d.context.thinkingLevel as ThinkingLevelOption);
@@ -492,6 +568,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
         const liveState = agentState.state;
         if (liveState) {
+          applyLiveAgentModel(liveState);
           if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
           if (liveState.systemPrompt !== undefined) setSystemPrompt(liveState.systemPrompt ?? null);
           if (liveState.thinkingLevel !== undefined) setThinkingLevel((liveState.thinkingLevel as ThinkingLevelOption) ?? "auto");
@@ -512,7 +589,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } finally {
       if (showLoading && !messagesLoaded) setLoading(false);
     }
-  }, []);
+  }, [applyLiveAgentModel, restorePromptToComposer]);
 
   const loadContext = useCallback(async (sid: string, leafId: string | null) => {
     try {
@@ -998,6 +1075,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         && (state.isStreaming || state.isPromptRunning || state.isCompacting);
       if (busy || !agentRunningRef.current) return;
       if (state) {
+        applyLiveAgentModel(state);
         if (state.contextUsage !== undefined) setContextUsage(state.contextUsage ?? null);
         if (state.systemPrompt !== undefined) setSystemPrompt(state.systemPrompt ?? null);
         if (state.extensionStatuses !== undefined) setExtensionStatuses(state.extensionStatuses ?? []);
@@ -1007,7 +1085,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } catch {
       // Network still down — the next poll / visibility / online tick retries.
     }
-  }, [finishPromptWithoutStream]);
+  }, [applyLiveAgentModel, finishPromptWithoutStream]);
 
   // Recovery net for missed SSE events: while the agent is running, verify
   // against the server periodically and whenever the tab returns to the
@@ -1060,6 +1138,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           fetch(`/api/agent/${encodeURIComponent(sessionIdRef.current)}`)
             .then((r) => r.json())
             .then((d: { state?: AgentStateResponse }) => {
+              applyLiveAgentModel(d.state);
               if (d.state?.contextUsage !== undefined) setContextUsage(d.state.contextUsage ?? null);
               if (d.state?.systemPrompt !== undefined) setSystemPrompt(d.state.systemPrompt ?? null);
               if (d.state?.extensionStatuses !== undefined) setExtensionStatuses(d.state.extensionStatuses ?? []);
@@ -1106,9 +1185,22 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           }
         }
         break;
-      case "prompt_error":
+      case "prompt_error": {
         addNotice({ type: "error", message: (event.errorMessage as string | undefined) ?? "Command failed" });
+        // The turn died before the model said anything (unavailable provider,
+        // bad key, request rejected). Stage the text for recovery: the reload
+        // that follows prompt_done decides whether it actually vanished.
+        const pending = inFlightPromptRef.current;
+        if (!promptProducedOutputRef.current && pending) {
+          inFlightPromptRef.current = null;
+          failedPromptRef.current = {
+            message: pending.message,
+            ...(pending.images?.length ? { images: pending.images } : {}),
+            key: optimisticUserMessageKeyRef.current ?? "",
+          };
+        }
         break;
+      }
       case "extension_error":
         addNotice({
           type: "error",
@@ -1126,6 +1218,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           break;
         }
         if (msg) {
+          promptProducedOutputRef.current = true;
+          inFlightPromptRef.current = null;
           dispatch({ type: "update", message: normalizeToolCalls(msg as AgentMessage) });
         }
         setAgentPhase(null);
@@ -1156,6 +1250,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             return [...prev, delivered];
           });
         } else if (completed) {
+          promptProducedOutputRef.current = true;
+          inFlightPromptRef.current = null;
           setMessages((prev) => [...prev, normalizeToolCalls(completed)]);
         }
         dispatch({ type: "reset" });
@@ -1215,7 +1311,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         handleExtensionUiRequest(event as ExtensionUiRequest);
         break;
     }
-  }, [addNotice, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, settleUiStage]);
+  }, [addNotice, applyLiveAgentModel, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, settleUiStage]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
@@ -1247,6 +1343,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     };
     setMessages((prev) => [...prev, userMsg]);
     optimisticUserMessageKeyRef.current = userMessageKey(userMsg);
+    inFlightPromptRef.current = { runId: promptRunId, message, ...(images?.length ? { images } : {}) };
+    promptProducedOutputRef.current = false;
     promptRunIdRef.current = promptRunId;
     agentRunningRef.current = true;
     setAgentRunning(true);
@@ -1265,7 +1363,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         const existingSid = sessionIdRef.current ?? await ensuringNewSessionRef.current;
         const sid = existingSid ?? await ensureNewSession();
 
-        if (sid) {
+        if (!sid) throw new Error("Unable to create a session for this message");
+        {
           sentSessionId = sid;
           if (selectedModel) {
             setPendingModel(selectedModel);
@@ -1307,28 +1406,32 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       rpcPromptPendingRef.current = false;
       agentRunningRef.current = false;
       closeEvents();
-      if (e instanceof EventStreamConnectionError) {
-        const optimisticKey = optimisticUserMessageKeyRef.current;
-        if (optimisticKey) {
-          setMessages((prev) => {
-            const last = prev[prev.length - 1];
-            return last?.role === "user" && userMessageKey(last) === optimisticKey
-              ? prev.slice(0, -1)
-              : prev;
-          });
-        }
-        addNotice({ type: "error", message: e.message });
-        // The prompt never reached the agent, so restore the user's text into
-        // the input instead of losing it. Mirrors the shell-command recovery in
-        // executeBash; insertIfEmpty avoids clobbering anything typed since.
-        if (message) opts.chatInputRef?.current?.insertIfEmpty(message);
+      // Past that guard the prompt definitively never reached the agent —
+      // whatever the reason (dead event stream, unreachable model, no API key,
+      // session start failure). Drop the optimistic bubble, tell the user why,
+      // and hand the text back to the composer. Only EventStreamConnectionError
+      // used to be recovered, so every other failure silently ate what the user
+      // had just typed.
+      const optimisticKey = optimisticUserMessageKeyRef.current;
+      if (optimisticKey) {
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          return last?.role === "user" && userMessageKey(last) === optimisticKey
+            ? prev.slice(0, -1)
+            : prev;
+        });
       }
+      addNotice({
+        type: "error",
+        message: e instanceof EventStreamConnectionError ? e.message : `Failed to send: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      restoreFailedPrompt(promptRunId);
       optimisticUserMessageKeyRef.current = null;
       setAgentRunning(false);
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, opts.chatInputRef]);
+  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, restoreFailedPrompt]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;
@@ -1418,29 +1521,56 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [loadContext]);
 
   const handleModelChange = useCallback(async (provider: string, modelId: string) => {
+    const target = { provider, modelId };
     if (isNew) {
-      const selectedModel = { provider, modelId };
-      newSessionModelOverrideRef.current = selectedModel;
-      setNewSessionModel(selectedModel);
-      setPendingModel(selectedModel);
+      newSessionModelOverrideRef.current = target;
+      setNewSessionModel(target);
+      setPendingModel(target);
       const sid = sessionIdRef.current ?? await ensuringNewSessionRef.current;
       if (!sid) return;
       try {
-        await sendAgentCommand(sid, { type: "set_model", provider, modelId });
+        await sendAgentCommand(sid, { type: "set_model", ...target });
       } catch (e) {
         console.error("Failed to set model:", e);
+        addNotice({ type: "error", message: `Failed to switch model: ${e instanceof Error ? e.message : String(e)}` });
       }
       return;
     }
     const sid = sessionIdRef.current;
     if (!sid) return;
+
+    const switchId = modelSwitchIdRef.current + 1;
+    modelSwitchIdRef.current = switchId;
+    modelSwitchInFlightRef.current = switchId;
+    // Reflect the choice immediately. A cold wrapper has to be restarted from
+    // the session file before it can answer, which took long enough that the
+    // click looked like it was ignored.
+    const previous = currentModelOverride;
+    setCurrentModelOverride(target);
+    setModelSwitching(true);
     try {
-      await sendAgentCommand(sid, { type: "set_model", provider, modelId });
-      setCurrentModelOverride({ provider, modelId });
+      const applied = await sendAgentCommand<{ id?: string; provider?: string } | null>(
+        sid,
+        { type: "set_model", ...target },
+      );
+      // A newer click won while this one was in flight — its result wins.
+      if (modelSwitchIdRef.current !== switchId) return;
+      // Trust what the agent reports it switched to, not what we asked for.
+      if (applied?.id && applied.provider) {
+        setCurrentModelOverride({ provider: applied.provider, modelId: applied.id });
+      }
     } catch (e) {
       console.error("Failed to set model:", e);
+      if (modelSwitchIdRef.current !== switchId) return;
+      setCurrentModelOverride(previous);
+      addNotice({ type: "error", message: `Failed to switch model: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      if (modelSwitchIdRef.current === switchId) {
+        modelSwitchInFlightRef.current = 0;
+        setModelSwitching(false);
+      }
     }
-  }, [isNew, setNewSessionModel]);
+  }, [addNotice, currentModelOverride, isNew, setNewSessionModel]);
 
   const handleCompact = useCallback(async () => {
     const sid = sessionIdRef.current;
@@ -1575,55 +1705,52 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   // the real user message when pi delivers it (user message_end event). An
   // optimistic chat bubble here would duplicate the queue panel and turn into
   // a ghost message if the queue is recalled.
-  const handleSteer = useCallback(async (message: string, images?: AttachedImage[]) => {
+  // Steering and follow-ups are cleared from the composer the moment they are
+  // submitted, so a rejected command has to give the text back — otherwise a
+  // backend hiccup silently swallows what the user just wrote.
+  const sendQueuedMessage = useCallback(async (
+    command: Record<string, unknown>,
+    message: string,
+    images: AttachedImage[] | undefined,
+    label: string,
+  ) => {
     const sid = sessionIdRef.current;
-    if (!sid) return;
+    const fail = (reason: string) => {
+      addNotice({ type: "error", message: `${label}: ${reason}` });
+      restorePromptToComposer({ message, ...(images?.length ? { images } : {}) });
+    };
+    if (!sid) {
+      fail("no active session");
+      return;
+    }
     const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
     try {
       await sendAgentCommand(sid, {
-        type: "steer",
+        ...command,
         message,
         ...(piImages?.length ? { images: piImages } : {}),
       });
     } catch (e) {
-      console.error("Failed to steer:", e);
+      console.error(`${label}:`, e);
+      fail(e instanceof Error ? e.message : String(e));
     }
-  }, []);
+  }, [addNotice, restorePromptToComposer]);
+
+  const handleSteer = useCallback(async (message: string, images?: AttachedImage[]) => {
+    await sendQueuedMessage({ type: "steer" }, message, images, "Failed to steer");
+  }, [sendQueuedMessage]);
 
   const handlePromptWithStreamingBehavior = useCallback(async (
     message: string,
     behavior: "steer" | "followUp",
     images?: AttachedImage[],
   ) => {
-    const sid = sessionIdRef.current;
-    if (!sid) return;
-    const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
-    try {
-      await sendAgentCommand(sid, {
-        type: "prompt",
-        message,
-        streamingBehavior: behavior,
-        ...(piImages?.length ? { images: piImages } : {}),
-      });
-    } catch (e) {
-      console.error("Failed to queue prompt:", e);
-    }
-  }, []);
+    await sendQueuedMessage({ type: "prompt", streamingBehavior: behavior }, message, images, "Failed to queue prompt");
+  }, [sendQueuedMessage]);
 
   const handleFollowUp = useCallback(async (message: string, images?: AttachedImage[]) => {
-    const sid = sessionIdRef.current;
-    if (!sid) return;
-    const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
-    try {
-      await sendAgentCommand(sid, {
-        type: "follow_up",
-        message,
-        ...(piImages?.length ? { images: piImages } : {}),
-      });
-    } catch (e) {
-      console.error("Failed to follow up:", e);
-    }
-  }, []);
+    await sendQueuedMessage({ type: "follow_up" }, message, images, "Failed to follow up");
+  }, [sendQueuedMessage]);
 
   const handleAbortCompaction = useCallback(async () => {
     const sid = sessionIdRef.current;
@@ -1840,10 +1967,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     data, loading, error, activeLeafId, messages, entryIds, streamState,
     agentRunning, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, newSessionModel, toolPreset, thinkingLevel,
     retryInfo, contextUsage, systemPrompt, forkingEntryId,
-    isCompacting, compactError, compactResult, currentModel, displayModel, sessionStats,
+    isCompacting, compactError, compactResult, currentModel, displayModel, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
     notices: noticeState.visible, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
-    isAutoModelSelection: isNew && newSessionModel === null,
     agentPhase,
     isNew,
     // Refs

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -430,6 +430,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   // on whether pi persisted the user entry (it does not for a session with no
   // assistant reply yet), so the decision is deferred to the next reload.
   const failedPromptRef = useRef<{ message: string; images?: AttachedImage[]; key: string } | null>(null);
+  // Client-side mirror of what we handed to pi's steering / follow-up queue.
+  // That queue lives only in the wrapper's memory — it is never written to the
+  // session file — so if the wrapper dies before delivering, the text is gone
+  // and the composer was already cleared on submit.
+  const pendingQueuedRef = useRef<{ message: string; images?: AttachedImage[] }[]>([]);
+  // addNotice is declared further down; the recovery paths above it reach the
+  // current one through this ref.
+  const addNoticeRef = useRef<((notice: { id?: string; message: string; type?: NoticeType }) => void) | null>(null);
 
   const setToolPresetState = opts.setToolPreset ?? setToolPreset;
 
@@ -507,6 +515,31 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     restorePromptToComposer(pending);
   }, [restorePromptToComposer]);
 
+  // Reconcile the queue mirror against what the agent actually reports. A dead
+  // wrapper (no state) means pi's in-memory queue died with it, so anything we
+  // never saw delivered has to go back to the composer. Anything the live queue
+  // no longer lists was delivered and is already in the transcript.
+  const reconcilePendingQueue = useCallback((state?: AgentStateResponse | null) => {
+    const mirror = pendingQueuedRef.current;
+    if (mirror.length === 0) return;
+    if (!state) {
+      pendingQueuedRef.current = [];
+      restorePromptToComposer({ message: mirror.map((m) => m.message).join("\n\n") });
+      addNoticeRef.current?.({
+        type: "warning",
+        message: mirror.length > 1
+          ? `${mirror.length} queued messages were never delivered — restored to the input`
+          : "Your queued message was never delivered — restored to the input",
+      });
+      return;
+    }
+    const stillQueued = new Set([
+      ...(state.queuedMessages?.steering ?? []),
+      ...(state.queuedMessages?.followUp ?? []),
+    ]);
+    pendingQueuedRef.current = mirror.filter((m) => stillQueued.has(m.message));
+  }, [restorePromptToComposer]);
+
   const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
     let messagesLoaded = false;
     try {
@@ -567,6 +600,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         if (sessionIdRef.current !== sid) return null;
 
         const liveState = agentState.state;
+        reconcilePendingQueue(liveState);
         if (liveState) {
           applyLiveAgentModel(liveState);
           if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
@@ -589,7 +623,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } finally {
       if (showLoading && !messagesLoaded) setLoading(false);
     }
-  }, [applyLiveAgentModel, restorePromptToComposer]);
+  }, [applyLiveAgentModel, reconcilePendingQueue, restorePromptToComposer]);
 
   const loadContext = useCallback(async (sid: string, leafId: string | null) => {
     try {
@@ -848,6 +882,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       },
     });
   }, []);
+  addNoticeRef.current = addNotice;
 
   const handleExtensionUiRequest = useCallback((request: ExtensionUiRequest) => {
     switch (request.method) {
@@ -1070,6 +1105,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // would otherwise leave the "Stop compaction" UI stuck. No state
       // (wrapper destroyed) means nothing is compacting.
       setIsCompacting(state?.isCompacting ?? false);
+      reconcilePendingQueue(state);
       setQueuedMessages(normalizeQueuedMessages(state?.queuedMessages));
       const busy = data.running && state
         && (state.isStreaming || state.isPromptRunning || state.isCompacting);
@@ -1085,7 +1121,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } catch {
       // Network still down — the next poll / visibility / online tick retries.
     }
-  }, [applyLiveAgentModel, finishPromptWithoutStream]);
+  }, [applyLiveAgentModel, finishPromptWithoutStream, reconcilePendingQueue]);
 
   // Recovery net for missed SSE events: while the agent is running, verify
   // against the server periodically and whenever the tab returns to the
@@ -1144,7 +1180,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
               if (d.state?.extensionStatuses !== undefined) setExtensionStatuses(d.state.extensionStatuses ?? []);
               if (d.state?.extensionWidgets !== undefined) setExtensionWidgets(d.state.extensionWidgets ?? []);
               // Aborted turns can leave messages queued in pi (delivered with the
-              // next turn); dead wrapper (no state) means the queue is gone.
+              // next turn); dead wrapper (no state) means the queue is gone —
+              // reconcile first so undelivered text goes back to the composer
+              // instead of disappearing with the wrapper.
+              reconcilePendingQueue(d.state);
               setQueuedMessages(normalizeQueuedMessages(d.state?.queuedMessages));
             })
             .catch(() => {});
@@ -1238,6 +1277,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           // optimistic bubble; later same-text queue deliveries must render.
           const delivered = normalizeToolCalls(completed);
           const deliveredKey = userMessageKey(delivered);
+          // A queued message reaching the model is the one unambiguous delivery
+          // signal — drop it from the mirror so it is never restored twice.
+          const deliveredText = extractMessageText(delivered);
+          const mirrorIndex = pendingQueuedRef.current.findIndex((m) => m.message === deliveredText);
+          if (mirrorIndex !== -1) {
+            pendingQueuedRef.current = pendingQueuedRef.current.filter((_, i) => i !== mirrorIndex);
+          }
           const optimisticKey = optimisticUserMessageKeyRef.current;
           optimisticUserMessageKeyRef.current = null;
           setMessages((prev) => {
@@ -1311,7 +1357,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         handleExtensionUiRequest(event as ExtensionUiRequest);
         break;
     }
-  }, [addNotice, applyLiveAgentModel, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, settleUiStage]);
+  }, [addNotice, applyLiveAgentModel, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, reconcilePendingQueue, scheduleEventStreamClose, settleUiStage]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
@@ -1730,6 +1776,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         message,
         ...(piImages?.length ? { images: piImages } : {}),
       });
+      // Accepted into pi's queue. Track it until we see it delivered — a 200
+      // here is not a promise that the message ever reaches the model.
+      pendingQueuedRef.current = [
+        ...pendingQueuedRef.current,
+        { message, ...(images?.length ? { images } : {}) },
+      ];
     } catch (e) {
       console.error(`${label}:`, e);
       fail(e instanceof Error ? e.message : String(e));
@@ -1770,6 +1822,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // clearQueue also emits an empty queue_update, but that only reaches us
       // while SSE is connected — clear locally so idle recalls update the UI.
       setQueuedMessages({ steering: [], followUp: [] });
+      // The user now holds this text; the mirror must not offer it again.
+      pendingQueuedRef.current = [];
       const texts = [...(result?.steering ?? []), ...(result?.followUp ?? [])];
       if (texts.length > 0) {
         opts.chatInputRef?.current?.prependText(texts.join("\n\n"));

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -172,6 +172,12 @@ const AGENT_STATE_RECONCILE_MS = 15_000;
 const BASH_STATE_RECONCILE_MS = 1_000;
 const EVENT_STREAM_CONNECT_TIMEOUT_MS = 5_000;
 const MAX_NOTICES = 5;
+// Threshold auto-compaction stops the agent loop upstream, stranding a task
+// mid-flight. pi-web resumes it, bounded so a task that keeps overflowing
+// cannot spend tokens in a loop without the user noticing.
+const AUTO_CONTINUE_PROMPT = "Continue the task you were working on before the context was compacted.";
+const AUTO_CONTINUE_MAX_CONSECUTIVE = 3;
+
 const NOTICE_VISIBLE_MS = 5000;
 const NOTICE_EXIT_ANIMATION_MS = 180;
 const SCROLL_KEYS = new Set(["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ", "Space", "Spacebar"]);
@@ -438,6 +444,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   // addNotice is declared further down; the recovery paths above it reach the
   // current one through this ref.
   const addNoticeRef = useRef<((notice: { id?: string; message: string; type?: NoticeType }) => void) | null>(null);
+  // Threshold auto-compaction ends the agent loop by design upstream (pi's
+  // _checkCompaction: "Threshold: ... NO auto-retry (user continues
+  // manually)"), which strands a half-finished task. These drive the
+  // continuation pi-web sends on the user's behalf.
+  const autoContinueArmedRef = useRef(false);
+  const autoContinueCountRef = useRef(0);
+  const handleSendRef = useRef<
+    ((message: string, images?: AttachedImage[], options?: { auto?: boolean }) => Promise<void>) | null
+  >(null);
 
   const setToolPresetState = opts.setToolPreset ?? setToolPreset;
 
@@ -1010,6 +1025,25 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     eventStreamGraceTimerRef.current = setTimeout(() => void checkServerIdle(), EVENT_STREAM_IDLE_GRACE_MS);
   }, [cancelEventStreamGrace, closeEvents]);
 
+  // Send the continuation for a turn that threshold compaction cut short.
+  // Compaction_end can arrive either side of agent_end, so this is armed by the
+  // event and fired from wherever the run actually settles.
+  const maybeAutoContinueAfterCompaction = useCallback(() => {
+    if (!autoContinueArmedRef.current) return;
+    if (agentRunningRef.current || bashRunningRef.current) return;
+    autoContinueArmedRef.current = false;
+    if (autoContinueCountRef.current >= AUTO_CONTINUE_MAX_CONSECUTIVE) {
+      addNoticeRef.current?.({
+        type: "warning",
+        message: `Stopped auto-continuing after ${AUTO_CONTINUE_MAX_CONSECUTIVE} compactions in a row — send a message to resume.`,
+      });
+      return;
+    }
+    autoContinueCountRef.current += 1;
+    addNoticeRef.current?.({ type: "info", message: "Context compacted — continuing the task." });
+    void handleSendRef.current?.(AUTO_CONTINUE_PROMPT, undefined, { auto: true });
+  }, []);
+
   const finishPromptWithoutStream = useCallback(async (sid: string | null = sessionIdRef.current, runId = promptRunIdRef.current) => {
     // Bail out before loadSession too: a stale finish for a previous run
     // must not overwrite the messages of the run currently streaming.
@@ -1030,8 +1064,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         onAgentEnd?.();
       }
       if (sid) scheduleEventStreamClose(sid);
+      maybeAutoContinueAfterCompaction();
     }
-  }, [loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, settleUiStage]);
+  }, [loadSession, maybeAutoContinueAfterCompaction, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, settleUiStage]);
 
   const waitForPromptSettlement = useCallback(async (sid: string, runId?: number) => {
     await delay(PROMPT_SETTLE_INITIAL_DELAY_MS);
@@ -1202,6 +1237,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           scheduleEventStreamClose(sid);
         }
         if (wasRunning) onAgentEnd?.();
+        maybeAutoContinueAfterCompaction();
         break;
       }
       case "prompt_done":
@@ -1349,21 +1385,41 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           setCompactError(event.errorMessage as string);
           setCompactResult(null);
         } else if (!event.aborted) {
-          setCompactResult(readCompactResult(event.result, (event.reason as string | undefined) ?? "auto"));
+          const reason = (event.reason as string | undefined) ?? "auto";
+          setCompactResult(readCompactResult(event.result, reason));
           if (sessionIdRef.current) loadSession(sessionIdRef.current);
+          // Only threshold auto-compaction strands the task: a manual /compact
+          // is the user deliberately stopping, and willRetry means pi resumes
+          // the turn itself (the overflow path) — continuing there would double
+          // up.
+          if (reason !== "manual" && !event.willRetry) {
+            autoContinueArmedRef.current = true;
+            maybeAutoContinueAfterCompaction();
+          }
         }
         break;
       case "extension_ui_request":
         handleExtensionUiRequest(event as ExtensionUiRequest);
         break;
     }
-  }, [addNotice, applyLiveAgentModel, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, reconcilePendingQueue, scheduleEventStreamClose, settleUiStage]);
+  }, [addNotice, applyLiveAgentModel, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, maybeAutoContinueAfterCompaction, notifyPromptStage, onAgentEnd, reconcilePendingQueue, scheduleEventStreamClose, settleUiStage]);
   handleAgentEventRef.current = handleAgentEvent;
 
-  const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
+  const handleSend = useCallback(async (
+    message: string,
+    images?: AttachedImage[],
+    options?: { auto?: boolean },
+  ) => {
     const trimmedMessage = message.trim();
     if (!trimmedMessage && !images?.length) return;
     if (agentRunningRef.current || bashRunningRef.current) return;
+    // Anything the user sends themselves means the task is back under their
+    // control: the streak starts over, and a continuation still armed from a
+    // compaction they already responded to must not fire after this run.
+    if (!options?.auto) {
+      autoContinueCountRef.current = 0;
+      autoContinueArmedRef.current = false;
+    }
     const isSlashCommandPrompt = !images?.length && trimmedMessage.startsWith("/");
 
     const isBashCommand = !images?.length && trimmedMessage.startsWith("!");
@@ -1478,6 +1534,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       dispatch({ type: "end" });
     }
   }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, restoreFailedPrompt]);
+  handleSendRef.current = handleSend;
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1032,6 +1032,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     if (!autoContinueArmedRef.current) return;
     if (agentRunningRef.current || bashRunningRef.current) return;
     autoContinueArmedRef.current = false;
+    // Output after the compaction means pi carried the turn on by itself and it
+    // finished for its own reasons — nudging it again would start unasked work.
+    if (promptProducedOutputRef.current) return;
     if (autoContinueCountRef.current >= AUTO_CONTINUE_MAX_CONSECUTIVE) {
       addNoticeRef.current?.({
         type: "warning",
@@ -1388,12 +1391,19 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           const reason = (event.reason as string | undefined) ?? "auto";
           setCompactResult(readCompactResult(event.result, reason));
           if (sessionIdRef.current) loadSession(sessionIdRef.current);
-          // Only threshold auto-compaction strands the task: a manual /compact
-          // is the user deliberately stopping, and willRetry means pi resumes
-          // the turn itself (the overflow path) — continuing there would double
-          // up.
-          if (reason !== "manual" && !event.willRetry) {
+          // Arm for every auto-compaction; only a manual /compact is the user
+          // deliberately stopping. willRetry used to be excluded because pi
+          // documents that the overflow path resumes the turn itself — but an
+          // overflow compaction was observed ending the run anyway, which is
+          // exactly the case that most needs rescuing. Double-firing is not a
+          // risk: maybeAutoContinueAfterCompaction bails while the run is still
+          // active, so a turn pi really did resume never gets a second prompt.
+          if (reason !== "manual") {
             autoContinueArmedRef.current = true;
+            // Reset the output marker so it now means "did the model produce
+            // anything AFTER this compaction". If it did, pi resumed the turn
+            // on its own and the run reached a natural end — no continuation.
+            promptProducedOutputRef.current = false;
             maybeAutoContinueAfterCompaction();
           }
         }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,11 @@
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
 
+  // Probe intranet endpoints before the dispatcher is installed so the very
+  // first model request already carries the right TLS connect options.
+  const { loadTlsOverrides } = await import("@/lib/tls-overrides");
+  await loadTlsOverrides();
+
   const { configureHttpDispatcher } = await import("@/lib/http-dispatcher");
   configureHttpDispatcher();
 }

--- a/lib/http-dispatcher.ts
+++ b/lib/http-dispatcher.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
 import * as undici from "undici";
+// Relative, not "@/lib/...": http-dispatcher.test.mjs loads this module through
+// a jiti instance without tsconfig path aliases.
+import { withTlsOverride } from "./tls-overrides";
 
 export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
 
@@ -35,9 +38,13 @@ function withUndiciErrorListener<T extends undici.Dispatcher>(dispatcher: T): T 
   return dispatcher;
 }
 
+// Per-origin TLS overrides ride along here: an intranet model endpoint reached
+// by IP needs its certificate checked against the SAN name, which is a connect
+// option on the client for that origin only. Everything else passes through
+// untouched and keeps Node's strict verification.
 function createUndiciClient(origin: string | URL, options: object): undici.Dispatcher {
   return withUndiciErrorListener(
-    new undici.Client(origin, options as undici.Client.Options),
+    new undici.Client(origin, withTlsOverride(origin, options) as undici.Client.Options),
   );
 }
 
@@ -49,7 +56,7 @@ function createUndiciOriginDispatcher(origin: string | URL, options: object): un
 
   return withUndiciErrorListener(
     new undici.Pool(origin, {
-      ...dispatcherOptions,
+      ...withTlsOverride(origin, dispatcherOptions),
       factory: createUndiciClient,
     }),
   );

--- a/lib/rpc-manager-stall.test.mjs
+++ b/lib/rpc-manager-stall.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  interopDefault: true,
+  moduleCache: false,
+});
+
+const STALL_MS = 1000;
+
+async function loadWrapper() {
+  process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS = String(STALL_MS);
+  const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
+  return AgentSessionWrapper;
+}
+
+function makeInner(overrides = {}) {
+  const inner = {
+    sessionId: "stall-test",
+    sessionFile: "",
+    isStreaming: false,
+    isBashRunning: false,
+    isCompacting: false,
+    aborted: 0,
+    emitToSubscriber: null,
+    subscribe(listener) {
+      inner.emitToSubscriber = listener;
+      return () => { inner.emitToSubscriber = null; };
+    },
+    abort() {
+      inner.aborted += 1;
+    },
+    abortBash() {},
+    dispose() {},
+    sessionManager: { getCwd: () => "/tmp" },
+    ...overrides,
+  };
+  return inner;
+}
+
+/** Drive the wrapper into "a turn is running" without touching the real SDK. */
+function startTurn(wrapper) {
+  wrapper.promptRunning = true;
+  wrapper.resetStallTimer();
+}
+
+function collectEvents(wrapper) {
+  const events = [];
+  wrapper.onEvent((event) => events.push(event));
+  return events;
+}
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("a turn with no model activity is aborted once the stall window passes", async () => {
+  const AgentSessionWrapper = await loadWrapper();
+  const inner = makeInner({ isStreaming: true });
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  const events = collectEvents(wrapper);
+  startTurn(wrapper);
+
+  await wait(STALL_MS * 2);
+
+  assert.equal(inner.aborted, 1, "the wedged turn should be aborted");
+  const stallError = events.find((e) => e.type === "prompt_error");
+  assert.ok(stallError, "the abort should be explained, not silent");
+  assert.match(stallError.errorMessage, /No response from the model/);
+  wrapper.destroy();
+});
+
+test("streaming activity keeps the turn alive", async () => {
+  const AgentSessionWrapper = await loadWrapper();
+  const inner = makeInner({ isStreaming: true });
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  startTurn(wrapper);
+
+  // A chunk arrives before each deadline — the same shape as a slow but healthy
+  // response, which must never be killed.
+  for (let i = 0; i < 3; i++) {
+    await wait(STALL_MS * 0.6);
+    inner.emitToSubscriber({ type: "message_update", message: { role: "assistant" } });
+  }
+
+  assert.equal(inner.aborted, 0, "a producing turn must not be aborted");
+  wrapper.destroy();
+});
+
+test("a silent long-running shell command is not treated as a stalled model", async () => {
+  const AgentSessionWrapper = await loadWrapper();
+  const inner = makeInner({ isStreaming: true, isBashRunning: true });
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  startTurn(wrapper);
+
+  await wait(STALL_MS * 2);
+
+  assert.equal(inner.aborted, 0, "shell work emits nothing and must be left alone");
+  wrapper.destroy();
+});
+
+test("a tool still executing is not treated as a stalled model", async () => {
+  const AgentSessionWrapper = await loadWrapper();
+  const inner = makeInner({ isStreaming: true });
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  startTurn(wrapper);
+  inner.emitToSubscriber({ type: "tool_execution_start", toolCallId: "t1", toolName: "read" });
+
+  await wait(STALL_MS * 2);
+
+  assert.equal(inner.aborted, 0, "a pending tool is progress, not a stall");
+  wrapper.destroy();
+});
+
+test("an idle session is never aborted", async () => {
+  const AgentSessionWrapper = await loadWrapper();
+  const inner = makeInner();
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+
+  await wait(STALL_MS * 2);
+
+  assert.equal(inner.aborted, 0, "nothing is running, so there is nothing to abort");
+  wrapper.destroy();
+});
+
+test("the watchdog can be turned off", async () => {
+  process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS = "disabled";
+  const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
+  const inner = makeInner({ isStreaming: true });
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  startTurn(wrapper);
+
+  await wait(STALL_MS * 2);
+
+  assert.equal(inner.aborted, 0, "disabled means disabled");
+  wrapper.destroy();
+  delete process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS;
+});

--- a/lib/rpc-manager-stall.test.mjs
+++ b/lib/rpc-manager-stall.test.mjs
@@ -53,10 +53,11 @@ function collectEvents(wrapper) {
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-test("a turn with no model activity is aborted once the stall window passes", async () => {
+test("a turn with no model activity is aborted once the stall window passes", async (t) => {
   const AgentSessionWrapper = await loadWrapper();
   const inner = makeInner({ isStreaming: true });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
   const events = collectEvents(wrapper);
   startTurn(wrapper);
@@ -67,13 +68,13 @@ test("a turn with no model activity is aborted once the stall window passes", as
   const stallError = events.find((e) => e.type === "prompt_error");
   assert.ok(stallError, "the abort should be explained, not silent");
   assert.match(stallError.errorMessage, /No response from the model/);
-  wrapper.destroy();
 });
 
-test("streaming activity keeps the turn alive", async () => {
+test("streaming activity keeps the turn alive", async (t) => {
   const AgentSessionWrapper = await loadWrapper();
   const inner = makeInner({ isStreaming: true });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
   startTurn(wrapper);
 
@@ -85,26 +86,26 @@ test("streaming activity keeps the turn alive", async () => {
   }
 
   assert.equal(inner.aborted, 0, "a producing turn must not be aborted");
-  wrapper.destroy();
 });
 
-test("a silent long-running shell command is not treated as a stalled model", async () => {
+test("a silent long-running shell command is not treated as a stalled model", async (t) => {
   const AgentSessionWrapper = await loadWrapper();
   const inner = makeInner({ isStreaming: true, isBashRunning: true });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
   startTurn(wrapper);
 
   await wait(STALL_MS * 2);
 
   assert.equal(inner.aborted, 0, "shell work emits nothing and must be left alone");
-  wrapper.destroy();
 });
 
-test("a tool still executing is not treated as a stalled model", async () => {
+test("a tool still executing is not treated as a stalled model", async (t) => {
   const AgentSessionWrapper = await loadWrapper();
   const inner = makeInner({ isStreaming: true });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
   startTurn(wrapper);
   inner.emitToSubscriber({ type: "tool_execution_start", toolCallId: "t1", toolName: "read" });
@@ -112,32 +113,31 @@ test("a tool still executing is not treated as a stalled model", async () => {
   await wait(STALL_MS * 2);
 
   assert.equal(inner.aborted, 0, "a pending tool is progress, not a stall");
-  wrapper.destroy();
 });
 
-test("an idle session is never aborted", async () => {
+test("an idle session is never aborted", async (t) => {
   const AgentSessionWrapper = await loadWrapper();
   const inner = makeInner();
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
 
   await wait(STALL_MS * 2);
 
   assert.equal(inner.aborted, 0, "nothing is running, so there is nothing to abort");
-  wrapper.destroy();
 });
 
-test("the watchdog can be turned off", async () => {
+test("the watchdog can be turned off", async (t) => {
   process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS = "disabled";
   const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
   const inner = makeInner({ isStreaming: true });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
   wrapper.start();
   startTurn(wrapper);
 
   await wait(STALL_MS * 2);
 
   assert.equal(inner.aborted, 0, "disabled means disabled");
-  wrapper.destroy();
   delete process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS;
 });

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -81,6 +81,22 @@ const IDLE_RESET_EVENT_TYPES = new Set([
   "compaction_end",
 ]);
 
+// A turn waiting on the model emits nothing at all — no chunks, no tool events.
+// The HTTP dispatcher's bodyTimeout cannot catch that: it is an idle timeout
+// between chunks, so a gateway that holds the stream open without producing
+// content never trips it and the turn hangs until someone notices. This is the
+// wall-clock backstop for exactly that state.
+const DEFAULT_MODEL_STALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+function getModelStallTimeoutMs(): number {
+  const raw = process.env.PI_WEB_MODEL_STALL_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_MODEL_STALL_TIMEOUT_MS;
+  if (raw.toLowerCase() === "disabled") return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MODEL_STALL_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
 export interface RpcSessionStartOptions {
   toolNames?: string[];
   initialModel?: { provider: string; modelId: string };
@@ -148,6 +164,10 @@ export class AgentSessionWrapper {
   private forceEmptySystemPrompt = false;
   private unsubscribe: (() => void) | null = null;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private stallTimer: ReturnType<typeof setTimeout> | null = null;
+  // Tools run silently between their start and end events, so a pending tool is
+  // not a stalled model — only silence with nothing executing is.
+  private activeToolCount = 0;
   private onDestroyCallback: (() => void) | null = null;
   private shutdownPromise: Promise<void> | null = null;
   private _alive = true;
@@ -180,6 +200,11 @@ export class AgentSessionWrapper {
         invalidateSessionListCache();
       }
       if (IDLE_RESET_EVENT_TYPES.has(event.type)) this.resetIdleTimer();
+      if (event.type === "tool_execution_start") this.activeToolCount += 1;
+      else if (event.type === "tool_execution_end") this.activeToolCount = Math.max(0, this.activeToolCount - 1);
+      // Any event at all is a sign of life, so the stall clock restarts on all
+      // of them — unlike the idle clock, which only tracks completed work.
+      this.resetStallTimer();
       this.emit(event);
       if (RUNNING_STATE_EVENT_TYPES.has(event.type)) notifyRunningChange();
     });
@@ -303,6 +328,45 @@ export class AgentSessionWrapper {
     }, 10 * 60 * 1000);
   }
 
+  private resetStallTimer(): void {
+    if (this.stallTimer) {
+      clearTimeout(this.stallTimer);
+      this.stallTimer = null;
+    }
+    const timeoutMs = getModelStallTimeoutMs();
+    if (timeoutMs <= 0 || !this._alive) return;
+    if (!this.promptRunning && !this.inner.isStreaming) return;
+    this.stallTimer = setTimeout(() => this.handleModelStall(), timeoutMs);
+    this.stallTimer.unref?.();
+  }
+
+  /**
+   * Nothing has been heard from the model for the whole stall window. If work
+   * is genuinely in flight elsewhere — a shell command, a tool, a compaction —
+   * keep waiting. Otherwise the turn is wedged: abort it so the session becomes
+   * usable again, and say why instead of leaving a silent spinner.
+   */
+  private handleModelStall(): void {
+    this.stallTimer = null;
+    if (!this._alive) return;
+    if (!this.promptRunning && !this.inner.isStreaming) return;
+
+    if (this.inner.isBashRunning || this.inner.isCompacting || this.activeToolCount > 0) {
+      this.resetStallTimer();
+      return;
+    }
+
+    const minutes = Math.max(1, Math.round(getModelStallTimeoutMs() / 60_000));
+    console.warn(`[pi-web] no model activity for ${minutes}m on session ${this.sessionId} — aborting the stalled turn`);
+    this.emit({
+      type: "prompt_error",
+      errorMessage: `No response from the model for ${minutes} minutes. The turn was aborted so the session stays usable — send it again to retry.`,
+    } as AgentEvent);
+    void Promise.resolve(this.inner.abort()).catch((error) => {
+      console.error("[pi-web] failed to abort stalled turn:", error instanceof Error ? error.message : error);
+    });
+  }
+
   private persistBashOnlySession(): void {
     const manager = this.inner.sessionManager;
     const sessionFile = manager.getSessionFile();
@@ -355,6 +419,9 @@ export class AgentSessionWrapper {
         const promptImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
         const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
         this.promptRunning = true;
+        // The first token can be minutes away on a loaded gateway and produces
+        // no events until it lands, so the stall clock has to start here.
+        this.resetStallTimer();
         notifyRunningChange();
         this.inner.prompt(command.message as string, {
           ...(promptImages?.length ? { images: promptImages } : {}),
@@ -363,11 +430,13 @@ export class AgentSessionWrapper {
         }).then(() => {
           this.promptRunning = false;
           this.resetIdleTimer();
+          this.resetStallTimer();
           if (!streamingBehavior) this.emit({ type: "prompt_done" });
           notifyRunningChange();
         }).catch((error) => {
           this.promptRunning = false;
           this.resetIdleTimer();
+          this.resetStallTimer();
           invalidateSessionListCache();
           this.emit({
             type: "prompt_error",
@@ -652,6 +721,7 @@ export class AgentSessionWrapper {
     if (!this._alive) return;
     this._alive = false;
     if (this.idleTimer) clearTimeout(this.idleTimer);
+    if (this.stallTimer) clearTimeout(this.stallTimer);
     if (this.inner.isBashRunning) this.inner.abortBash();
     this.unsubscribe?.();
     for (const pending of this.pendingUiResponses.values()) pending.cancel();

--- a/lib/tls-overrides.ts
+++ b/lib/tls-overrides.ts
@@ -1,0 +1,160 @@
+/**
+ * Scoped TLS overrides for intranet HTTPS endpoints.
+ *
+ * Problem: some internal model APIs (e.g. https://172.16.111.183:9443) serve a
+ * publicly-issued certificate whose SAN only contains a DNS name
+ * (ai.secsign.online), so connecting by IP fails with
+ * ERR_TLS_CERT_ALTNAME_INVALID. The blunt workaround — a global
+ * NODE_TLS_REJECT_UNAUTHORIZED=0 — disables certificate verification for ALL
+ * traffic, including public APIs, which is unsafe.
+ *
+ * Solution: resolve per-origin TLS connect options that the global undici
+ * dispatcher applies (Node's fetch goes through it, including the
+ * Anthropic/OpenAI-compatible clients used by pi-ai):
+ *
+ *  1. For every https://<ip>:<port> provider baseUrl found in
+ *     ~/.pi/agent/models.json, probe the peer certificate and reuse its first
+ *     SAN DNS name as the TLS servername → full certificate chain AND hostname
+ *     verification still happen, just against the correct name.
+ *  2. If probing fails (VPN down, truly self-signed cert, ...), fall back to
+ *     rejectUnauthorized:false for THAT ORIGIN ONLY. Everything else keeps
+ *     strict default verification.
+ *
+ * Manual overrides (comma-separated env vars):
+ *   PI_WEB_TLS_SERVERNAME_OVERRIDES="10.0.0.1:8443=api.internal,10.0.0.2:443=gw.corp"
+ *   PI_WEB_TLS_INSECURE_HOSTS="10.0.0.3:9443"   // skip verification for these only
+ *   PI_WEB_TLS_AUTO=0                            // disable models.json auto-detection
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { connect as tlsConnect } from "node:tls";
+import { isIP } from "node:net";
+
+type Override =
+  | { kind: "servername"; servername: string }
+  | { kind: "insecure" };
+
+const overrides = new Map<string, Override>();
+let loaded: Promise<void> | null = null;
+
+function originOf(host: string, port: string): string {
+  return port === "443" ? `https://${host}` : `https://${host}:${port}`;
+}
+
+function parseHostPort(entry: string): { host: string; port: string } | null {
+  const m = entry.trim().match(/^([^:]+)(?::(\d+))?$/);
+  if (!m) return null;
+  return { host: m[1], port: m[2] ?? "443" };
+}
+
+/** Collect https://<ip> baseUrls from ~/.pi/agent/models.json providers. */
+function collectIpOriginsFromModelsJson(): { host: string; port: string }[] {
+  if (process.env.PI_WEB_TLS_AUTO === "0") return [];
+  const file = join(homedir(), ".pi", "agent", "models.json");
+  if (!existsSync(file)) return [];
+  try {
+    const json = JSON.parse(readFileSync(file, "utf8")) as { providers?: Record<string, { baseUrl?: string }> };
+    const out: { host: string; port: string }[] = [];
+    for (const provider of Object.values(json?.providers ?? {})) {
+      if (!provider?.baseUrl) continue;
+      try {
+        const url = new URL(provider.baseUrl);
+        if (url.protocol === "https:" && isIP(url.hostname) !== 0) {
+          out.push({ host: url.hostname, port: url.port || "443" });
+        }
+      } catch {
+        // ignore malformed baseUrl
+      }
+    }
+    return out;
+  } catch (err) {
+    console.warn("[tls-overrides] failed to parse models.json:", err);
+    return [];
+  }
+}
+
+/** Probe the peer certificate and return its first SAN DNS name, if any. */
+function probeServername(host: string, port: number, timeoutMs = 5000): Promise<string | null> {
+  return new Promise((resolve) => {
+    const socket = tlsConnect({ host, port, rejectUnauthorized: false, timeout: timeoutMs }, () => {
+      const cert = socket.getPeerCertificate();
+      socket.end();
+      const san: string | undefined = cert?.subjectaltname;
+      const dns = san
+        ?.split(",")
+        .map((s) => s.trim())
+        .find((s) => s.startsWith("DNS:") && !s.includes("*"))
+        ?.slice(4);
+      const cn = cert?.subject?.CN;
+      resolve(dns || (Array.isArray(cn) ? cn[0] : cn) || null);
+    });
+    socket.on("error", () => resolve(null));
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(null);
+    });
+  });
+}
+
+async function registerIpOrigin(host: string, port: string): Promise<void> {
+  const origin = originOf(host, port);
+  if (overrides.has(origin)) return;
+  const servername = await probeServername(host, Number(port));
+  if (servername && isIP(servername) === 0) {
+    overrides.set(origin, { kind: "servername", servername });
+    console.log(`[tls-overrides] ${origin} → SNI override "${servername}" (full certificate verification kept)`);
+  } else {
+    overrides.set(origin, { kind: "insecure" });
+    console.warn(`[tls-overrides] ${origin} → certificate verification disabled FOR THIS HOST ONLY (probe failed)`);
+  }
+}
+
+function loadEnvOverrides(): void {
+  for (const entry of (process.env.PI_WEB_TLS_SERVERNAME_OVERRIDES ?? "").split(",")) {
+    const [target, servername] = entry.split("=").map((s) => s?.trim());
+    const hp = target ? parseHostPort(target) : null;
+    if (hp && servername) {
+      overrides.set(originOf(hp.host, hp.port), { kind: "servername", servername });
+    }
+  }
+  for (const entry of (process.env.PI_WEB_TLS_INSECURE_HOSTS ?? "").split(",")) {
+    const hp = entry.trim() ? parseHostPort(entry) : null;
+    if (hp) {
+      overrides.set(originOf(hp.host, hp.port), { kind: "insecure" });
+    }
+  }
+}
+
+/**
+ * Detect intranet https endpoints. Safe to call multiple times; detection runs
+ * once and later calls await the same probe.
+ */
+export function loadTlsOverrides(): Promise<void> {
+  if (typeof window !== "undefined") return Promise.resolve();
+  loaded ??= (async () => {
+    loadEnvOverrides();
+    await Promise.all(
+      collectIpOriginsFromModelsJson().map(({ host, port }) => registerIpOrigin(host, port)),
+    );
+  })();
+  return loaded;
+}
+
+/**
+ * Merge this origin's TLS override into undici client/pool options. Origins
+ * without an override are returned untouched, so public traffic keeps Node's
+ * strict defaults.
+ */
+export function withTlsOverride<T extends object>(origin: string | URL, options: T): T {
+  const override = overrides.get(String(origin));
+  if (!override) return options;
+
+  const connect = (options as { connect?: Record<string, unknown> }).connect;
+  return {
+    ...options,
+    connect: override.kind === "servername"
+      ? { ...connect, servername: override.servername, rejectUnauthorized: true }
+      : { ...connect, rejectUnauthorized: false },
+  };
+}


### PR DESCRIPTION
Four fixes found while using pi-web against a self-hosted model gateway. Each is an independent commit.

### 1. Model switching looked like a no-op and needed several tries

Three causes stacked:

- `loadSession` cleared the optimistic model unconditionally, so any reload (`agent_end`, bash settle, reconcile poll) snapped the picker back to the session file — which lags a switch, since pi appends `model_change` asynchronously and a restarted wrapper replays an older leaf.
- The dropdown skipped `set_model` entirely for the entry that already looked active, so once the label went stale there was no way to correct it: clicking the model you wanted did nothing.
- Nothing was shown between the click and the response. After the wrapper's 10-minute idle destroy, the first switch has to cold-start the agent from the session file, which takes long enough to read as "ignored".

Now the choice is applied optimistically with monotonic switch ids so a slow response cannot overwrite a newer pick, the override is dropped only once a reload agrees, every click re-issues the idempotent `set_model`, and the picker syncs from live agent state — `get_state` already returned `model`, the client just discarded it. Failures revert and surface a notice instead of only reaching the console.

### 2. Typed text was lost whenever a turn failed

`ChatInput` clears the composer right after a fire-and-forget `onSend`, and pi runs `prompt()` fire-and-forget too, so the POST returns 200 and the failure arrives later as `prompt_error`. Only `EventStreamConnectionError` was recovered. Three further gaps:

- pi writes no session file until the session has an assistant message, so a first-message failure on a fresh session lost the text outright.
- A steer/follow-up pi accepted but never delivered died with the wrapper — that queue is in-memory only, so `agent_end` reading no state silently reset it to empty.
- `restoreSubmission` read the textarea to decide how to merge, but submitting queues `setValue("")` and a fast failure can land before React flushes it, so the read saw text that was about to be wiped. This is how the recovery silently bailed on "Timed out connecting to the agent event stream".

The in-flight prompt is now kept and restored from `loadSession` only when the reloaded transcript no longer contains it, so a failure that did persist the message does not duplicate it. The queue is mirrored client-side and handed back when the agent reports no state. The composer merge uses a functional update, correct in every ordering.

### 3. Threshold auto-compaction leaves the task stranded

Upstream `_checkCompaction` documents "Threshold: Context over threshold, compact, NO auto-retry (user continues manually)" and returns `hasQueuedMessages()`, so with an empty queue the agent loop just ends mid-task and the user has to nudge it by hand.

**This commit deliberately departs from that behaviour** — worth a maintainer opinion, and easy to drop if you would rather pi-web match the CLI. pi-web now sends the nudge itself, armed only for threshold compaction (`reason !== "manual"`, `!willRetry`, since the overflow path resumes on its own). Bounded to three consecutive continuations so a task that keeps overflowing cannot quietly spend tokens in a loop; any user message resets the streak.

### 4. Intranet model endpoints reached by IP fail before the request leaves the process

A provider at `https://<ip>:<port>` serving a certificate whose SAN only lists a DNS name is rejected with `ERR_TLS_CERT_ALTNAME_INVALID`, and the UI shows nothing at all — no response, no error. `curl -k` succeeds, so the endpoint looks healthy.

`lib/tls-overrides.ts` probes such origins found in `models.json`, reuses the certificate's SAN name as the TLS servername so the chain and hostname are still fully verified, and falls back to skipping verification for that one origin only if the probe fails. It resolves per-origin connect options that the existing dispatcher's client and pool factories merge in, rather than competing over `setGlobalDispatcher`. Opt-out and manual overrides via `PI_WEB_TLS_AUTO=0`, `PI_WEB_TLS_SERVERNAME_OVERRIDES`, `PI_WEB_TLS_INSECURE_HOSTS`.

Verified through the real global fetch path: the intranet endpoint answers 200, and `https://self-signed.badssl.com` is still rejected with `DEPTH_ZERO_SELF_SIGNED_CERT`, so public verification is not weakened.

### Checks

`tsc --noEmit`, `eslint .`, 240/240 tests, and `next build` all pass on top of v0.8.6.

No automated regression tests were added: these are event-ordering and TLS paths, and the existing suite renders statically with no DOM harness available. Manual verification covered each fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
