### PR TITLE
fix(app): unset orientation in PWA manifest to respect OS rotation lock

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -11,7 +11,6 @@ export default function manifest(): MetadataRoute.Manifest {
     display: "standalone",
     background_color: "#1a1a1a",
     theme_color: "#1a1a1a",
-    orientation: "any",
     categories: ["developer", "productivity"],
     lang: "en",
     icons: [


### PR DESCRIPTION
The current orientation: "any" configuration in the PWA manifest unintentionally causes Android devices to bypass the user's system-level orientation lock status.

By removing this property entirely and leaving it unset, the browser falls back to its default behavior. This ensures that the PWA correctly respects the native OS rotation settings and functions as expected across both iOS and Android platforms.

[W3C Documents](https://w3c.github.io/screen-orientation/#screen-orientation-types)
[Discourse's Practice](https://meta.discourse.org/t/manifest-orientation-property/94900/3)