### PR TITLE
fix: enable title generation after compaction

### DIFF
--- a/components/AppShell.auto-name.test.mjs
+++ b/components/AppShell.auto-name.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const source = fs.readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
+
+test("压缩后的会话仍可根据持久化消息数生成标题", () => {
+  assert.match(
+    source,
+    /\(sessionStats\?\.userMessages \?\? 0\) > 0 \|\| selectedSession\.messageCount > 0/,
+  );
+});

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1023,9 +1023,10 @@ export function AppShell() {
                  {!isMobile && <span>{translate("history.label")}</span>}
               </button>
               {(() => {
+                // 上下文压缩后当前消息可能不再包含 user 消息，需同时参考会话文件的消息总数。
                 const hasMessages = Boolean(
                   selectedSession
-                  && (sessionStats?.userMessages ?? selectedSession.messageCount) > 0,
+                  && ((sessionStats?.userMessages ?? 0) > 0 || selectedSession.messageCount > 0),
                 );
                 const disabled = !selectedSession || !hasMessages || autoNameStatus.kind === "naming";
                 const isSuccess = autoNameStatus.kind === "success";

--- a/lib/session-title.test.mjs
+++ b/lib/session-title.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
@@ -101,6 +102,48 @@ test("waits for the source reply before sending the title prompt", async () => {
 
   assert.equal(result.title, "Wait for Complete Agent Reply");
   assert.deepEqual(providerRoles, ["user", "assistant", "user"]);
+});
+
+test("generates a title when compaction removed all literal user messages", async () => {
+  let providerMessages;
+  const sourceAgent = {
+    state: {
+      systemPrompt: "system",
+      model: { provider: "test", id: "test-model" },
+      thinkingLevel: "off",
+      tools: [],
+      messages: [
+        {
+          role: "compactionSummary",
+          summary: "The user asked to fix title generation after compaction.",
+          tokensBefore: 100_000,
+          timestamp: 1,
+        },
+        assistantMessage("The implementation is complete"),
+      ],
+    },
+    waitForIdle: async () => {},
+    convertToLlm,
+    streamFunction: (_model, context) => {
+      providerMessages = context.messages;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: assistantMessage("Title Generation After Compaction"),
+        });
+      });
+      return stream;
+    },
+    sessionId: "source-session-id",
+  };
+
+  const result = await generateSessionTitle({ agent: sourceAgent });
+
+  assert.equal(result.title, "Title Generation After Compaction");
+  assert.deepEqual(providerMessages.map((message) => message.role), ["user", "assistant", "user"]);
+  assert.match(providerMessages[0].content[0].text, /fix title generation after compaction/);
 });
 
 test("temporary title agent preserves the provider-facing prefix", async () => {

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -214,7 +214,9 @@ export async function generateSessionTitle(source: AgentSession): Promise<Genera
 
   const sanitizedMessages = sanitizeTitleMessages(sourceAgent.state.messages);
   const historyLength = sanitizedMessages.length;
-  if (!sanitizedMessages.some((message) => message.role === "user")) {
+  if (!sanitizedMessages.some(
+    (message) => message.role === "user" || message.role === "compactionSummary",
+  )) {
     throw new Error("The session has no user messages to name");
   }
 


### PR DESCRIPTION
## 修改内容

- 标题生成按钮同时参考当前上下文用户消息数和持久化会话消息数
- 避免上下文压缩移除用户消息后错误禁用按钮
- 新增该场景的回归测试

## 验证

- `node --test components/AppShell.auto-name.test.mjs`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint components/AppShell.tsx components/AppShell.auto-name.test.mjs`
- `git diff --check`