### PR TITLE
fix: restore iOS PWA viewport after keyboard dismiss

### DIFF
--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -26,6 +26,9 @@ test("tracks the visual viewport while the software keyboard is open", () => {
   assert.match(appShellSource, /height: "var\(--app-viewport-height, 100dvh\)"/);
   assert.match(appShellSource, /right: "env\(safe-area-inset-right\)"/);
   assert.match(viewportHookSource, /window\.visualViewport/);
+  assert.match(viewportHookSource, /window\.requestAnimationFrame\(update\)/);
+  assert.match(viewportHookSource, /window\.addEventListener\("resize", scheduleUpdate\)/);
+  assert.match(viewportHookSource, /window\.addEventListener\("focusout", scheduleUpdate\)/);
   assert.match(viewportHookSource, /--app-viewport-height/);
   assert.match(viewportHookSource, /window\.scrollTo\(0, 0\)/);
   assert.match(cssSource, /height: var\(--app-viewport-height, 100dvh\)/);

--- a/hooks/useViewportHeight.test.mjs
+++ b/hooks/useViewportHeight.test.mjs
@@ -14,7 +14,16 @@ test("uses the visual viewport for a focused editor when the keyboard shrinks it
   }), true);
 });
 
-test("keeps the dynamic viewport height when no editor is focused", () => {
+test("does not keep the keyboard height after the visual viewport restores", () => {
+  assert.equal(shouldUseVisualViewportHeight({
+    hasFocusedEditable: true,
+    innerHeight: 844,
+    viewportHeight: 844,
+    viewportScale: 1,
+  }), false);
+});
+
+test("restores the dynamic height as soon as the editor loses focus", () => {
   assert.equal(shouldUseVisualViewportHeight({
     hasFocusedEditable: false,
     innerHeight: 844,

--- a/hooks/useViewportHeight.ts
+++ b/hooks/useViewportHeight.ts
@@ -40,8 +40,10 @@ export function useViewportHeight(): void {
     if (!viewport) return;
 
     const root = document.documentElement;
+    let frameId: number | null = null;
 
     const update = () => {
+      frameId = null;
       const keyboardOpen = shouldUseVisualViewportHeight({
         hasFocusedEditable: hasFocusedEditableElement(),
         innerHeight: window.innerHeight,
@@ -50,21 +52,42 @@ export function useViewportHeight(): void {
       });
       if (keyboardOpen) {
         root.style.setProperty("--app-viewport-height", `${viewport.height}px`);
-        if (window.scrollX !== 0 || window.scrollY !== 0) {
-          window.scrollTo(0, 0);
-        }
       } else {
         root.style.removeProperty("--app-viewport-height");
       }
+
+      const pageWasShifted = window.scrollX !== 0 || window.scrollY !== 0;
+      const isUnscaled = Math.abs(viewport.scale - 1) < 0.01;
+      if (pageWasShifted && isUnscaled) {
+        window.scrollTo(0, 0);
+      }
     };
 
-    update();
-    viewport.addEventListener("resize", update);
-    viewport.addEventListener("scroll", update);
+    // WebKit can dispatch the resize event before visualViewport.height has
+    // settled, especially when an installed PWA dismisses the keyboard. Reading
+    // it on the next animation frame prevents the keyboard-height CSS value
+    // from remaining after the keyboard has closed.
+    const scheduleUpdate = () => {
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(update);
+    };
+
+    scheduleUpdate();
+    viewport.addEventListener("resize", scheduleUpdate);
+    viewport.addEventListener("scroll", scheduleUpdate);
+    window.addEventListener("resize", scheduleUpdate);
+    window.addEventListener("focusin", scheduleUpdate);
+    window.addEventListener("focusout", scheduleUpdate);
+    window.addEventListener("pageshow", scheduleUpdate);
 
     return () => {
-      viewport.removeEventListener("resize", update);
-      viewport.removeEventListener("scroll", update);
+      viewport.removeEventListener("resize", scheduleUpdate);
+      viewport.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+      window.removeEventListener("focusin", scheduleUpdate);
+      window.removeEventListener("focusout", scheduleUpdate);
+      window.removeEventListener("pageshow", scheduleUpdate);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
       root.style.removeProperty("--app-viewport-height");
     };
   }, []);


### PR DESCRIPTION
## Summary

Fix the large blank strip left below the composer after dismissing the software keyboard in an installed iOS PWA.

## Cause

WebKit can dispatch `visualViewport.resize` before `visualViewport.height` reflects the restored full-screen height. The viewport hook read that stale value synchronously and could leave `--app-viewport-height` set to the keyboard-reduced height, so the whole chat layout remained shorter after the keyboard closed.

This event ordering is documented in WebKit bug 254861:
https://bugs.webkit.org/show_bug.cgi?id=254861#c4

## Fix

- defer visual viewport reads to `requestAnimationFrame`
- coalesce repeated viewport/window resize and scroll events
- re-evaluate on `focusin`, `focusout`, and `pageshow`
- remove the custom height as soon as the viewport restores or the editor loses focus
- reset WebKit's shifted page position after the viewport settles, without interfering with pinch zoom
- cancel the pending animation frame and remove all listeners during cleanup

## Validation

- `NODE_ENV=test node --test components/*.test.mjs hooks/*.test.mjs lib/*.test.mjs` — 241 passed
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `git diff --check`

A final physical-device check should reproduce by opening the composer keyboard in standalone mode and dismissing it using both the keyboard button and a tap outside the editor.
