### PR TITLE
fix: compare git-emitted paths correctly on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,12 @@ Newer pi emits `compaction_start` / `compaction_end`; older versions emitted `au
 - New worktrees are created under `<repoRoot>-worktrees/<sanitized-branch>`. Existing branches are reused; otherwise `git worktree add -b` creates the branch.
 - Removing a dirty worktree returns `409` with `{ dirty: true }` so the UI can ask before retrying with `force`.
 - Sessions whose cwd points at a removed worktree are inferred back into the main project instead of becoming a phantom project row.
+- git prints POSIX-style absolute paths even on Windows, so every path read out of git goes through `toNativePath()` (`lib/paths.ts`) before it is compared or returned. Compare paths with `samePath()`, never `===` — raw equality made `isTopLevel` permanently false on Windows and hid the worktree switcher entirely. Branch names are not paths and must keep their forward slashes.
 
 ### File access allow-list
 - `/api/files` is intentionally not a general filesystem browser. Allowed roots come from session cwds, their resolved project roots, `~/pi-cwd-*`, and roots explicitly added with `allowFileRoot()`.
 - `/api/cwd/validate`, `/api/default-cwd`, and `/api/worktrees` call `allowFileRoot()` when they make a new location browsable.
+- Allowed roots are stored slash-normalized, but that is a Set-key convention, not a correctness requirement: `isPathWithinRoots()` (`lib/path-security.ts`, the single implementation behind `isFilePathAllowed()`) re-resolves and case-folds both sides, so either path form authorizes correctly. Keep that one implementation — it is the security boundary.
 
 ### Plugins and skills
 - `/api/plugins` uses pi's `SettingsManager` + `DefaultPackageManager` for global/project package install, remove, update, enable, and disable. Disabling writes empty `extensions/skills/prompts/themes` arrays for that package entry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Newer pi emits `compaction_start` / `compaction_end`; older versions emitted `au
 - New worktrees are created under `<repoRoot>-worktrees/<sanitized-branch>`. Existing branches are reused; otherwise `git worktree add -b` creates the branch.
 - Removing a dirty worktree returns `409` with `{ dirty: true }` so the UI can ask before retrying with `force`.
 - Sessions whose cwd points at a removed worktree are inferred back into the main project instead of becoming a phantom project row.
-- git prints POSIX-style absolute paths even on Windows, so every path read out of git goes through `toNativePath()` (`lib/paths.ts`) before it is compared or returned. Compare paths with `samePath()`, never `===` — raw equality made `isTopLevel` permanently false on Windows and hid the worktree switcher entirely. Branch names are not paths and must keep their forward slashes.
+- git prints POSIX-style absolute paths even on Windows, so every path read out of git goes through `toNativePath()` (`lib/paths.ts`) before it is compared or returned. Compare paths with `samePath()`, never `===` — raw equality made `isTopLevel` permanently false on Windows and hid the worktree switcher entirely. Branch names are not paths and must keep their forward slashes. Browser code cannot apply Node path rules, so `/api/worktrees` resolves `currentWorktreePath` server-side; the sidebar must use that identity for highlighting and removal fallback.
 
 ### File access allow-list
 - `/api/files` is intentionally not a general filesystem browser. Allowed roots come from session cwds, their resolved project roots, `~/pi-cwd-*`, and roots explicitly added with `allowFileRoot()`.

--- a/app/api/worktrees/route.ts
+++ b/app/api/worktrees/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
-import { addWorktree, listWorktrees, removeWorktree, resolveProject } from "@/lib/worktree";
+import { addWorktree, findCurrentWorktreePath, listWorktrees, removeWorktree, resolveProject } from "@/lib/worktree";
 import { allowFileRoot, getAllowedFileRoots, isExistingFilePathAllowed, isFilePathAllowed } from "@/lib/file-access";
 
 /** Same gate as /api/files: only session cwds / project roots / explicitly
@@ -13,7 +13,7 @@ async function checkCwdAllowed(cwd: string): Promise<NextResponse | null> {
   return null;
 }
 
-// GET /api/worktrees?cwd=  →  { projectRoot, isGit, isTopLevel, worktrees }
+// GET /api/worktrees?cwd=  →  { projectRoot, isGit, isTopLevel, currentWorktreePath, worktrees }
 export async function GET(req: Request) {
   try {
     const cwd = new URL(req.url).searchParams.get("cwd");
@@ -25,11 +25,13 @@ export async function GET(req: Request) {
 
     const project = await resolveProject(cwd);
     let worktrees: Awaited<ReturnType<typeof listWorktrees>> = [];
+    let currentWorktreePath: string | null = null;
     let isGit = true;
     try {
       // For a removed-worktree cwd (session of a deleted worktree), fall back
       // to the inferred project root so the switcher still shows the project.
       worktrees = await listWorktrees(existsSync(cwd) ? cwd : project.projectRoot);
+      currentWorktreePath = findCurrentWorktreePath(worktrees, cwd);
     } catch {
       isGit = false;
     }
@@ -41,6 +43,7 @@ export async function GET(req: Request) {
       projectRoot: project.projectRoot,
       isGit,
       isTopLevel: project.isTopLevel,
+      currentWorktreePath,
       worktrees,
     });
   } catch (error) {

--- a/components/SessionSidebar.test.mjs
+++ b/components/SessionSidebar.test.mjs
@@ -24,3 +24,13 @@ test("polls running sessions only while the tab is visible", () => {
   assert.match(source, /document\.visibilityState !== "visible"/);
   assert.match(source, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/);
 });
+
+test("uses the server-resolved current worktree identity", () => {
+  assert.match(source, /currentWorktreePath: string \| null/);
+  assert.match(
+    source,
+    /const currentWorktree =[\s\S]*?worktreeState\.currentWorktreePath[\s\S]*?worktree\.path === worktreeState\.currentWorktreePath/,
+  );
+  assert.match(source, /if \(currentWorktreePath === path\) setSelectedCwd\(worktreeState\.projectRoot\)/);
+  assert.doesNotMatch(source, /const isCurrent = wt\.path === selectedCwd/);
+});

--- a/components/SessionSidebar.test.mjs
+++ b/components/SessionSidebar.test.mjs
@@ -24,13 +24,3 @@ test("polls running sessions only while the tab is visible", () => {
   assert.match(source, /document\.visibilityState !== "visible"/);
   assert.match(source, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/);
 });
-
-test("uses the server-resolved current worktree identity", () => {
-  assert.match(source, /currentWorktreePath: string \| null/);
-  assert.match(
-    source,
-    /const currentWorktree =[\s\S]*?worktreeState\.currentWorktreePath[\s\S]*?worktree\.path === worktreeState\.currentWorktreePath/,
-  );
-  assert.match(source, /if \(currentWorktreePath === path\) setSelectedCwd\(worktreeState\.projectRoot\)/);
-  assert.doesNotMatch(source, /const isCurrent = wt\.path === selectedCwd/);
-});

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -105,6 +105,8 @@ interface WorktreeState {
   /** False when forCwd is a repo subdirectory — the switcher is hidden there
    *  because subdir sessions keep their own project identity */
   isTopLevel: boolean;
+  /** Canonical path of the checkout containing forCwd, resolved server-side. */
+  currentWorktreePath: string | null;
   worktrees: WorktreeEntry[];
 }
 
@@ -616,7 +618,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     setWorktreeLoadingCwd(selectedCwd);
     fetch(`/api/worktrees?cwd=${encodeURIComponent(selectedCwd)}`)
       .then((r) => r.json())
-      .then((d: { projectRoot?: string; isGit?: boolean; isTopLevel?: boolean; worktrees?: WorktreeEntry[]; error?: string }) => {
+      .then((d: { projectRoot?: string; isGit?: boolean; isTopLevel?: boolean; currentWorktreePath?: string | null; worktrees?: WorktreeEntry[]; error?: string }) => {
         if (cancelled) return;
         setWorktreeLoadingCwd(null);
         if (d.error || !d.projectRoot) {
@@ -628,6 +630,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
           projectRoot: d.projectRoot,
           isGit: d.isGit ?? false,
           isTopLevel: d.isTopLevel ?? false,
+          currentWorktreePath: d.currentWorktreePath ?? null,
           worktrees: d.worktrees ?? [],
         });
       })
@@ -661,6 +664,18 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       if (projects.length > 0) setSelectedCwd(projects[0]);
     }
   }, [allSessions, selectedCwd, initialSessionId, skipInitialProjectSelection, onSelectSession, onInitialRestoreDone]);
+
+  // Prefer an exact UI selection while a refetch is in flight. Once the
+  // response catches up, the server-resolved path handles Windows case and
+  // separator differences without teaching the browser OS path semantics.
+  const currentWorktree = worktreeState
+    ? worktreeState.worktrees.find((worktree) => worktree.path === selectedCwd)
+      ?? (worktreeState.forCwd === selectedCwd && worktreeState.currentWorktreePath
+        ? worktreeState.worktrees.find((worktree) => worktree.path === worktreeState.currentWorktreePath)
+        : undefined)
+      ?? worktreeState.worktrees.find((worktree) => worktree.isMain)
+    : undefined;
+  const currentWorktreePath = currentWorktree?.path ?? null;
 
   const commitCustomPath = useCallback(async (candidate?: string) => {
     const path = (candidate ?? customPathValue).trim();
@@ -736,6 +751,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       setWorktreeState((prev) => prev ? {
         ...prev,
         forCwd: data.path!,
+        currentWorktreePath: data.path!,
         worktrees: [...prev.worktrees, { path: data.path!, branch, isMain: false }],
       } : prev);
       setSelectedCwd(data.path);
@@ -768,14 +784,14 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         return;
       }
       setWtConfirmRemove(null);
-      if (selectedCwd === path) setSelectedCwd(worktreeState.projectRoot);
+      if (currentWorktreePath === path) setSelectedCwd(worktreeState.projectRoot);
       setWtRefreshKey((k) => k + 1);
     } catch (e) {
       setWtError(e instanceof Error ? e.message : String(e));
     } finally {
       setWtBusy(false);
     }
-  }, [worktreeState, wtBusy, selectedCwd]);
+  }, [worktreeState, wtBusy, currentWorktreePath]);
 
   // Close dropdowns on outside click
   useEffect(() => {
@@ -1163,8 +1179,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             project share the same list anyway. */}
         {showWorktreeSwitcher && (() => {
           if (!worktreeState) return null;
-          const currentWt = worktreeState.worktrees.find((w) => w.path === selectedCwd)
-            ?? worktreeState.worktrees.find((w) => w.isMain);
           const showWtFilter = worktreeState.worktrees.length >= 8;
           const visibleWorktrees = showWtFilter && wtFilter.trim()
             ? worktreeState.worktrees.filter((w) =>
@@ -1174,7 +1188,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             <div ref={wtDropdownRef} style={{ position: "relative", marginTop: 6 }}>
               <button
                 onClick={() => setWtDropdownOpen((v) => !v)}
-                 title={currentWt ? t("sidebar.switchWorktreeTitle", { path: currentWt.path }) : t("sidebar.switchWorktree")}
+                 title={currentWorktree ? t("sidebar.switchWorktreeTitle", { path: currentWorktree.path }) : t("sidebar.switchWorktree")}
                 style={{
                   width: "100%",
                   height: 29,
@@ -1193,17 +1207,17 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                   textAlign: "left",
                 }}
               >
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, color: currentWt && !currentWt.isMain ? "var(--accent)" : "var(--text-dim)" }}>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, color: currentWorktree && !currentWorktree.isMain ? "var(--accent)" : "var(--text-dim)" }}>
                   <line x1="6" y1="3" x2="6" y2="15" />
                   <circle cx="18" cy="6" r="3" />
                   <circle cx="6" cy="18" r="3" />
                   <path d="M18 9a9 9 0 0 1-9 9" />
                 </svg>
                 <PathLabel
-                  text={currentWt ? (currentWt.branch ?? displayCwd(currentWt.path, homeDir)) : "…"}
+                  text={currentWorktree ? (currentWorktree.branch ?? displayCwd(currentWorktree.path, homeDir)) : "…"}
                   style={{ flex: 1, fontFamily: "var(--font-mono)", color: "var(--text)" }}
                 />
-                {currentWt?.isMain && (
+                {currentWorktree?.isMain && (
                    <span style={{ flexShrink: 0, color: "var(--text-dim)", fontSize: 10 }}>{t("sidebar.main")}</span>
                 )}
                 {worktreeState.worktrees.length > 1 && (
@@ -1261,7 +1275,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                   )}
                   <div style={{ maxHeight: "min(40vh, 300px)", overflowY: "auto" }}>
                     {visibleWorktrees.map((wt) => {
-                      const isCurrent = wt.path === selectedCwd || (wt.isMain && !worktreeState.worktrees.some((w) => w.path === selectedCwd));
+                      const isCurrent = wt.path === currentWorktreePath;
                       if (wtConfirmRemove === wt.path) {
                         return (
                           <div key={wt.path} style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 10px", borderBottom: "1px solid var(--border)", background: "rgba(239,68,68,0.06)" }}>

--- a/components/SessionSidebar.worktree.test.mjs
+++ b/components/SessionSidebar.worktree.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./SessionSidebar.tsx", import.meta.url), "utf8");
+
+test("uses the server-resolved current worktree identity", () => {
+  assert.match(source, /currentWorktreePath: string \| null/);
+  assert.match(
+    source,
+    /const currentWorktree =[\s\S]*?worktreeState\.currentWorktreePath[\s\S]*?worktree\.path === worktreeState\.currentWorktreePath/,
+  );
+  assert.match(source, /if \(currentWorktreePath === path\) setSelectedCwd\(worktreeState\.projectRoot\)/);
+  assert.doesNotMatch(source, /const isCurrent = wt\.path === selectedCwd/);
+});

--- a/lib/allowed-roots.ts
+++ b/lib/allowed-roots.ts
@@ -1,3 +1,5 @@
+import { toSlashPath } from "./paths";
+
 // In-memory roots that should be browsable in addition to roots derived from
 // persisted sessions. Stored on globalThis so Next.js hot-reload keeps them.
 declare global {
@@ -5,8 +7,13 @@ declare global {
   var __piAdditionalAllowedRoots: Set<string> | undefined;
 }
 
+/**
+ * Allowed roots are internal bookkeeping keys that are never displayed, so they
+ * are stored slash-normalized for consistent Set membership. Correctness does
+ * not depend on it — isPathWithinRoots() re-normalizes whatever it is given.
+ */
 export function normalizeSlashes(filePath: string): string {
-  return filePath.replace(/\\/g, "/");
+  return toSlashPath(filePath);
 }
 
 export function getAdditionalAllowedRoots(): Set<string> {

--- a/lib/file-access.test.mjs
+++ b/lib/file-access.test.mjs
@@ -4,8 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+// Loaded through jiti so the module's own extensionless imports resolve the way
+// the app resolves them (tsconfig moduleResolution: "bundler"); bare
+// `import("./path-security.ts")` only works while that file has no imports.
 async function loadSubject() {
-  return import("./path-security.ts");
+  const { createJiti } = await import("jiti");
+  return createJiti(import.meta.url).import("./path-security.ts");
 }
 
 test("rejects an existing path that escapes an allowed root through a symlink", async (t) => {

--- a/lib/file-access.ts
+++ b/lib/file-access.ts
@@ -2,9 +2,10 @@ import { readdirSync } from "fs";
 import { homedir } from "os";
 import path from "path";
 import { getAdditionalAllowedRoots, normalizeSlashes } from "./allowed-roots";
-import { isExistingPathWithinRoots } from "./path-security";
+import { isExistingPathWithinRoots, isPathWithinRoots } from "./path-security";
 import { listAllSessions } from "./session-reader";
 export { allowFileRoot, normalizeSlashes } from "./allowed-roots";
+export { isWindowsAbsolutePath } from "./paths";
 
 // Short-TTL cache for the allowed-roots set. Without this, every file list/read
 // request re-scans every pi session on disk just to check access. 5s is short
@@ -15,11 +16,6 @@ declare global {
 }
 
 const ALLOWED_ROOTS_TTL_MS = 5_000;
-const WINDOWS_ABSOLUTE_RE = /^[a-zA-Z]:[\\/]/;
-
-export function isWindowsAbsolutePath(filePath: string): boolean {
-  return WINDOWS_ABSOLUTE_RE.test(filePath) || filePath.startsWith("\\\\") || filePath.startsWith("//");
-}
 
 export async function getAllowedFileRoots(): Promise<Set<string>> {
   const now = Date.now();
@@ -52,21 +48,9 @@ export async function getAllowedFileRoots(): Promise<Set<string>> {
   return roots;
 }
 
+/** Authorize a path lexically, without touching the filesystem. */
 export function isFilePathAllowed(target: string, allowedRoots: Set<string>): boolean {
-  for (const root of allowedRoots) {
-    const useWindowsRules = isWindowsAbsolutePath(target) || isWindowsAbsolutePath(root);
-    const resolver = useWindowsRules ? path.win32 : path;
-    const sep = useWindowsRules ? "\\" : path.sep;
-    const normalized = resolver.resolve(target);
-    const normalizedRoot = resolver.resolve(root);
-    const comparable = useWindowsRules ? normalized.toLowerCase() : normalized;
-    const comparableRoot = useWindowsRules ? normalizedRoot.toLowerCase() : normalizedRoot;
-    const rootWithSep = comparableRoot.endsWith(sep) ? comparableRoot : comparableRoot + sep;
-    if (comparable === comparableRoot || comparable.startsWith(rootWithSep)) {
-      return true;
-    }
-  }
-  return false;
+  return isPathWithinRoots(target, allowedRoots);
 }
 
 /** Authorize an existing path after resolving symbolic links. */

--- a/lib/path-security.ts
+++ b/lib/path-security.ts
@@ -1,12 +1,12 @@
 import { realpathSync } from "fs";
 import path from "path";
+import { isWindowsAbsolutePath } from "./paths";
 
-const WINDOWS_ABSOLUTE_RE = /^[a-zA-Z]:[\\/]/;
-
-function isWindowsAbsolutePath(filePath: string): boolean {
-  return WINDOWS_ABSOLUTE_RE.test(filePath) || filePath.startsWith("\\\\") || filePath.startsWith("//");
-}
-
+/**
+ * Lexical containment check. Accepts either canonical form on both sides: it
+ * re-resolves through path.win32/path.posix and case-folds on Windows, so
+ * separator style and drive-letter case never decide the answer.
+ */
 export function isPathWithinRoots(target: string, roots: Set<string>): boolean {
   for (const root of roots) {
     const useWindowsRules = isWindowsAbsolutePath(target) || isWindowsAbsolutePath(root);

--- a/lib/paths.test.mjs
+++ b/lib/paths.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const isWindows = process.platform === "win32";
+
+async function loadSubject() {
+  const { createJiti } = await import("jiti");
+  return createJiti(import.meta.url).import("./paths.ts");
+}
+
+test("toNativePath converts git's POSIX output to native separators", async () => {
+  const { toNativePath } = await loadSubject();
+  if (isWindows) {
+    // The regression this guards: `git rev-parse --path-format=absolute` prints
+    // `D:/repo` on Windows, which never string-compares equal to a session cwd.
+    assert.equal(toNativePath("D:/repo/sub"), "D:\\repo\\sub");
+    assert.equal(toNativePath("D:\\repo\\sub"), "D:\\repo\\sub");
+  } else {
+    assert.equal(toNativePath("/repo/sub"), "/repo/sub");
+  }
+  assert.equal(toNativePath(""), "");
+});
+
+test("samePath ignores separator style and Windows case", async () => {
+  const { samePath } = await loadSubject();
+  assert.equal(samePath("/a/b", "/a/b"), true);
+  assert.equal(samePath("/a/b", "/a/c"), false);
+  assert.equal(samePath("", ""), true);
+  assert.equal(samePath("", "/a"), false);
+
+  if (isWindows) {
+    assert.equal(samePath("D:/repo", "D:\\repo"), true, "separator style must not matter");
+    assert.equal(samePath("d:\\repo", "D:\\repo"), true, "drive-letter case must not matter");
+    assert.equal(samePath("D:\\Repo\\Sub", "d:/repo/sub"), true);
+    assert.equal(samePath("D:\\repo", "D:\\repo2"), false);
+  } else {
+    // POSIX is case-sensitive and backslash is a legal filename character.
+    assert.equal(samePath("/Repo", "/repo"), false);
+  }
+});
+
+test("toSlashPath normalizes to forward slashes", async () => {
+  const { toSlashPath } = await loadSubject();
+  assert.equal(toSlashPath("D:\\repo\\sub"), "D:/repo/sub");
+  assert.equal(toSlashPath("/repo/sub"), "/repo/sub");
+});
+
+test("isWindowsAbsolutePath recognizes drive and UNC paths", async () => {
+  const { isWindowsAbsolutePath } = await loadSubject();
+  assert.equal(isWindowsAbsolutePath("D:\\repo"), true);
+  assert.equal(isWindowsAbsolutePath("d:/repo"), true);
+  assert.equal(isWindowsAbsolutePath("\\\\server\\share"), true);
+  assert.equal(isWindowsAbsolutePath("relative/path"), false);
+});

--- a/lib/paths.test.mjs
+++ b/lib/paths.test.mjs
@@ -24,6 +24,8 @@ test("toNativePath converts git's POSIX output to native separators", async () =
 test("samePath ignores separator style and Windows case", async () => {
   const { samePath } = await loadSubject();
   assert.equal(samePath("/a/b", "/a/b"), true);
+  assert.equal(samePath("/a/b/", "/a/b"), true, "trailing separators must not matter");
+  assert.equal(samePath("/a/./b", "/a/b"), true, "dot segments must not matter");
   assert.equal(samePath("/a/b", "/a/c"), false);
   assert.equal(samePath("", ""), true);
   assert.equal(samePath("", "/a"), false);
@@ -32,10 +34,12 @@ test("samePath ignores separator style and Windows case", async () => {
     assert.equal(samePath("D:/repo", "D:\\repo"), true, "separator style must not matter");
     assert.equal(samePath("d:\\repo", "D:\\repo"), true, "drive-letter case must not matter");
     assert.equal(samePath("D:\\Repo\\Sub", "d:/repo/sub"), true);
+    assert.equal(samePath("D:\\repo\\", "D:/repo"), true);
     assert.equal(samePath("D:\\repo", "D:\\repo2"), false);
   } else {
     // POSIX is case-sensitive and backslash is a legal filename character.
     assert.equal(samePath("/Repo", "/repo"), false);
+    assert.equal(samePath("/a\\b", "/a/b"), false);
   }
 });
 

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,0 +1,59 @@
+import { normalize } from "path";
+
+// ============================================================================
+// Path primitives.
+//
+// Two canonical forms coexist deliberately — pick by where the path is going:
+//
+//   toNativePath()  Native separators (`D:\repo` on Windows). Use for anything
+//                   that reaches fs/path APIs, gets compared against a session
+//                   cwd, or is shown to the user. This is the form pi records
+//                   cwds in, so it is the default for user-facing paths.
+//
+//   toSlashPath()   Forward slashes (`D:/repo`). Use only for internal,
+//                   never-displayed bookkeeping — the allowed-roots set, and
+//                   separator-insensitive text matching. Containment checks
+//                   re-normalize their inputs anyway (see path-security.ts),
+//                   so this form is about consistent keys, not correctness.
+//
+// Comparison always goes through samePath()/isPathWithinRoots(), never `===`:
+// git emits POSIX-style paths even on Windows, and Windows itself is
+// case-insensitive, so raw string equality silently fails on both counts.
+// ============================================================================
+
+const WINDOWS_ABSOLUTE_RE = /^[a-zA-Z]:[\\/]/;
+
+export function isWindowsAbsolutePath(filePath: string): boolean {
+  return WINDOWS_ABSOLUTE_RE.test(filePath) || filePath.startsWith("\\\\") || filePath.startsWith("//");
+}
+
+/**
+ * Convert a path to native separators. Chiefly for git output: git prints
+ * POSIX-style absolute paths even on Windows (`D:/repo/sub`), which never
+ * string-compares equal to the native paths Node and pi produce.
+ *
+ * Only pass paths — a branch name like `feature/x` would become `feature\x`.
+ */
+export function toNativePath(p: string): string {
+  if (!p || process.platform !== "win32") return p;
+  return normalize(p);
+}
+
+/** Convert a path to forward slashes. See the form guidance above. */
+export function toSlashPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Whether two paths denote the same location, tolerating separator style and —
+ * on Windows, where the filesystem is case-insensitive — case, including the
+ * drive letter (`d:\repo` vs `D:\repo`).
+ *
+ * Compares lexically: callers wanting symlinks resolved should realpath first.
+ */
+export function samePath(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (process.platform !== "win32") return false;
+  return toNativePath(a).toLowerCase() === toNativePath(b).toLowerCase();
+}

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,4 +1,4 @@
-import { normalize } from "path";
+import { normalize, parse, sep } from "path";
 
 // ============================================================================
 // Path primitives.
@@ -44,6 +44,14 @@ export function toSlashPath(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
+function normalizeForComparison(p: string): string {
+  const normalized = normalize(toNativePath(p));
+  const rootLength = parse(normalized).root.length;
+  let end = normalized.length;
+  while (end > rootLength && normalized[end - 1] === sep) end--;
+  return normalized.slice(0, end);
+}
+
 /**
  * Whether two paths denote the same location, tolerating separator style and —
  * on Windows, where the filesystem is case-insensitive — case, including the
@@ -54,6 +62,10 @@ export function toSlashPath(p: string): string {
 export function samePath(a: string, b: string): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  if (process.platform !== "win32") return false;
-  return toNativePath(a).toLowerCase() === toNativePath(b).toLowerCase();
+  const normalizedA = normalizeForComparison(a);
+  const normalizedB = normalizeForComparison(b);
+  if (process.platform === "win32") {
+    return normalizedA.toLowerCase() === normalizedB.toLowerCase();
+  }
+  return normalizedA === normalizedB;
 }

--- a/lib/worktree.test.mjs
+++ b/lib/worktree.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+
+async function loadSubject() {
+  const { createJiti } = await import("jiti");
+  return createJiti(import.meta.url).import("./worktree.ts");
+}
+
+async function git(cwd, args) {
+  await execFileAsync("git", ["-C", cwd, ...args]);
+}
+
+test("main and linked worktrees share one canonical project root", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-web-worktree-"));
+  t.after(() => rm(tempRoot, { recursive: true, force: true }));
+
+  const repo = path.join(tempRoot, "repo");
+  const linked = path.join(tempRoot, "linked");
+  await execFileAsync("git", ["init", repo]);
+  await git(repo, ["config", "user.name", "Pi Web Test"]);
+  await git(repo, ["config", "user.email", "pi-web-test@example.invalid"]);
+  await git(repo, ["config", "commit.gpgsign", "false"]);
+  await writeFile(path.join(repo, "README.md"), "# test\n");
+  await git(repo, ["add", "README.md"]);
+  await git(repo, ["commit", "-m", "initial"]);
+  await git(repo, ["worktree", "add", "-b", "feature/test", linked]);
+
+  const { findCurrentWorktreePath, listWorktrees, resolveProject } = await loadSubject();
+  const mainProject = await resolveProject(`${repo}${path.sep}`);
+  const linkedProject = await resolveProject(linked);
+
+  assert.equal(mainProject.isTopLevel, true);
+  assert.equal(mainProject.isWorktree, false);
+  assert.equal(linkedProject.isTopLevel, true);
+  assert.equal(linkedProject.isWorktree, true);
+  assert.equal(linkedProject.branch, "feature/test");
+  assert.equal(mainProject.projectRoot, linkedProject.projectRoot);
+
+  const worktrees = await listWorktrees(linked);
+  const listedLinked = worktrees.find((worktree) => worktree.branch === "feature/test");
+  assert.ok(listedLinked);
+  assert.equal(findCurrentWorktreePath(worktrees, `${linked}${path.sep}`), listedLinked.path);
+});

--- a/lib/worktree.ts
+++ b/lib/worktree.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, realpathSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { promisify } from "util";
 import { allowFileRoot } from "./allowed-roots";
+import { samePath, toNativePath } from "./paths";
 
 const execFileAsync = promisify(execFile);
 
@@ -90,7 +91,10 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
       "--git-common-dir", "--git-dir", "--show-toplevel",
       "--abbrev-ref", "HEAD",
     ]);
-    const [commonDir, gitDir, toplevel, ref] = out.split("\n").map((l) => l.trim());
+    const [commonDirRaw, gitDirRaw, toplevelRaw, ref] = out.split("\n").map((l) => l.trim());
+    // Only the first three lines are paths — `ref` is a branch name and must
+    // keep its forward slashes (`feature/foo`).
+    const [commonDir, gitDir, toplevel] = [commonDirRaw, gitDirRaw, toplevelRaw].map(toNativePath);
     // git prints resolved (symlink-free) paths; normalize cwd the same way
     let realCwd = cwd;
     try { realCwd = realpathSync(cwd); } catch { /* keep as-is */ }
@@ -99,8 +103,8 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
     // cwd is a subdirectory of a repo keeps its own project identity —
     // grouping subdirs under the repo root would change where new sessions
     // are created for existing users.
-    const isTopLevel = toplevel === realCwd;
-    const isWorktreeTopLevel = gitDir !== commonDir && isTopLevel;
+    const isTopLevel = samePath(toplevel, realCwd);
+    const isWorktreeTopLevel = !samePath(gitDir, commonDir) && isTopLevel;
     info = {
       projectRoot: isWorktreeTopLevel ? dirname(commonDir) : cwd,
       branch: ref && ref !== "HEAD" ? ref : null,
@@ -126,7 +130,7 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
 /** Main repo root (parent of the shared .git dir), or throws for non-git dirs */
 async function getRepoRoot(cwd: string): Promise<string> {
   const commonDir = await git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
-  return dirname(commonDir);
+  return dirname(toNativePath(commonDir));
 }
 
 export async function listWorktrees(cwd: string): Promise<WorktreeInfo[]> {
@@ -153,7 +157,7 @@ export async function listWorktrees(cwd: string): Promise<WorktreeInfo[]> {
   for (const line of out.split("\n")) {
     if (line.startsWith("worktree ")) {
       flush();
-      current = { path: line.slice("worktree ".length).trim() };
+      current = { path: toNativePath(line.slice("worktree ".length).trim()) };
     } else if (line.startsWith("branch ") && current) {
       current.branch = line.slice("branch ".length).trim().replace(/^refs\/heads\//, "");
     } else if (line.startsWith("prunable") && current) {
@@ -211,7 +215,7 @@ export async function addWorktree(cwd: string, branch: string): Promise<{ path: 
 
 export async function removeWorktree(cwd: string, worktreePath: string, force = false): Promise<void> {
   const worktrees = await listWorktrees(cwd);
-  const target = worktrees.find((w) => w.path === worktreePath);
+  const target = worktrees.find((w) => samePath(w.path, worktreePath));
   if (!target) throw new Error(`Not a worktree of this repository: ${worktreePath}`);
   if (target.isMain) throw new Error("Cannot remove the main worktree");
 

--- a/lib/worktree.ts
+++ b/lib/worktree.ts
@@ -60,6 +60,14 @@ async function git(cwd: string, args: string[]): Promise<string> {
   return stdout.trim();
 }
 
+function realPathOrSelf(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return filePath;
+  }
+}
+
 /**
  * addWorktree() places worktrees in `<repoRoot>-worktrees/<dir>`. When such a
  * directory no longer exists (worktree removed), group its sessions back
@@ -71,7 +79,7 @@ function inferRemovedWorktree(cwd: string): ProjectInfo | null {
   if (!parent.endsWith("-worktrees")) return null;
   const repoRoot = parent.slice(0, -"-worktrees".length);
   if (!repoRoot || !existsSync(join(repoRoot, ".git"))) return null;
-  return { projectRoot: repoRoot, branch: basename(cwd), isWorktree: true, isTopLevel: true };
+  return { projectRoot: realPathOrSelf(repoRoot), branch: basename(cwd), isWorktree: true, isTopLevel: true };
 }
 
 export async function resolveProject(cwd: string): Promise<ProjectInfo> {
@@ -96,8 +104,7 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
     // keep its forward slashes (`feature/foo`).
     const [commonDir, gitDir, toplevel] = [commonDirRaw, gitDirRaw, toplevelRaw].map(toNativePath);
     // git prints resolved (symlink-free) paths; normalize cwd the same way
-    let realCwd = cwd;
-    try { realCwd = realpathSync(cwd); } catch { /* keep as-is */ }
+    const realCwd = realPathOrSelf(cwd);
     // For a linked worktree, --git-dir differs from --git-common-dir.
     // Only collapse *worktree toplevels* into the main repo. A session whose
     // cwd is a subdirectory of a repo keeps its own project identity —
@@ -105,8 +112,9 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
     // are created for existing users.
     const isTopLevel = samePath(toplevel, realCwd);
     const isWorktreeTopLevel = !samePath(gitDir, commonDir) && isTopLevel;
+    const topLevelProjectRoot = isWorktreeTopLevel ? dirname(commonDir) : toplevel;
     info = {
-      projectRoot: isWorktreeTopLevel ? dirname(commonDir) : cwd,
+      projectRoot: isTopLevel ? realPathOrSelf(topLevelProjectRoot) : cwd,
       branch: ref && ref !== "HEAD" ? ref : null,
       isWorktree: isWorktreeTopLevel,
       isTopLevel,
@@ -130,7 +138,7 @@ export async function resolveProject(cwd: string): Promise<ProjectInfo> {
 /** Main repo root (parent of the shared .git dir), or throws for non-git dirs */
 async function getRepoRoot(cwd: string): Promise<string> {
   const commonDir = await git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
-  return dirname(toNativePath(commonDir));
+  return realPathOrSelf(dirname(toNativePath(commonDir)));
 }
 
 export async function listWorktrees(cwd: string): Promise<WorktreeInfo[]> {
@@ -168,6 +176,14 @@ export async function listWorktrees(cwd: string): Promise<WorktreeInfo[]> {
   }
   flush();
   return worktrees;
+}
+
+function findWorktreeByPath(worktrees: readonly WorktreeInfo[], candidate: string): WorktreeInfo | undefined {
+  return worktrees.find((worktree) => samePath(worktree.path, candidate));
+}
+
+export function findCurrentWorktreePath(worktrees: readonly WorktreeInfo[], cwd: string): string | null {
+  return findWorktreeByPath(worktrees, realPathOrSelf(cwd))?.path ?? null;
 }
 
 function sanitizeBranchForDir(branch: string): string {
@@ -215,12 +231,12 @@ export async function addWorktree(cwd: string, branch: string): Promise<{ path: 
 
 export async function removeWorktree(cwd: string, worktreePath: string, force = false): Promise<void> {
   const worktrees = await listWorktrees(cwd);
-  const target = worktrees.find((w) => samePath(w.path, worktreePath));
+  const target = findWorktreeByPath(worktrees, worktreePath);
   if (!target) throw new Error(`Not a worktree of this repository: ${worktreePath}`);
   if (target.isMain) throw new Error("Cannot remove the main worktree");
 
   try {
-    await git(cwd, ["worktree", "remove", ...(force ? ["--force"] : []), worktreePath]);
+    await git(cwd, ["worktree", "remove", ...(force ? ["--force"] : []), target.path]);
   } catch (error) {
     throw new Error(extractGitError(error));
   }


### PR DESCRIPTION
## Problem

`git rev-parse --path-format=absolute` prints POSIX-style absolute paths even on Windows (`D:/repo/sub`), while `realpathSync()` and the session cwds recorded by pi are native (`D:\repo\sub`). `resolveProject()` compared the two with `===`:

```ts
const isTopLevel = toplevel === realCwd;
```

On Windows that comparison can never be true, so `isTopLevel` was permanently `false`. Three user-visible consequences followed:

1. **The worktree switcher never appeared.** `showWorktreeSwitcher` requires `isTopLevel`, so Windows users only ever saw the disabled "Open repo root" hint — even standing in the root of a git repository.
2. **Linked worktrees were never grouped.** `isWorktreeTopLevel` is gated on `isTopLevel`, so it was also always false and `projectRoot` never collapsed to the main repo. Every worktree surfaced as a separate phantom project row.
3. **The current-worktree highlight was broken.** `listWorktrees()` returned slash-style paths that never matched `selectedCwd`, so `w.path === selectedCwd` in `SessionSidebar.tsx` always failed.

None of this reproduces on macOS or Linux, where git's output already matches the native form.

## Fix

Every path read out of git now goes through `toNativePath()`, and path equality goes through `samePath()` instead of `===`. `samePath()` also folds case, since Windows paths — including the drive letter — are case-insensitive.

Branch names deliberately bypass normalization: `rev-parse` returns the ref on the same output as the paths, and normalizing it would turn `feature/x` into `feature\x`.

## Consolidation

The two helpers landed in a new `lib/paths.ts`, which also absorbed duplication found nearby:

- `isWindowsAbsolutePath()` existed twice, in `lib/file-access.ts` and `lib/path-security.ts`.
- `isFilePathAllowed()` was a byte-for-byte copy of `isPathWithinRoots()`. It now delegates, leaving a single implementation of the access-control check rather than two copies to keep in sync.

Two path conventions are kept on purpose, and `lib/paths.ts` documents which to use where:

- `toNativePath()` — for anything reaching fs/path APIs, compared against a session cwd, or shown to the user.
- `toSlashPath()` — for internal, never-displayed bookkeeping (the allowed-roots Set keys, separator-insensitive text matching).

Unifying on forward slashes was considered and rejected. The allowed-roots slash form is not load-bearing — `isPathWithinRoots()` re-resolves and case-folds both sides, so either form authorizes identically — whereas worktree paths are compared against pi-recorded cwds and rendered in the sidebar, where `D:/...` would be wrong for Windows users.

## Verification

Checked on Windows against real repositories:

| Case | `isTopLevel` | `isWorktree` | |
|---|---|---|---|
| Repository root | `true` | `false` | was `false` before this change |
| Subdirectory of a repo | `false` | `false` | unchanged — no over-correction |
| Linked worktree | `true` | `true` | `projectRoot` now collapses to the main repo |
| Worktree subdirectory | `false` | `false` | branch `feature/x` keeps its slash |
| Non-git directory | `false` | `false` | unchanged |

Lowercase drive letters, trailing separators and forward-slash input all resolve correctly now as well.

Access control was re-checked after the consolidation: a native-form target, a slash-form target, and an out-of-root target all return the same verdicts as before.

`npx tsc --noEmit` and `npx eslint lib/` are clean.

## Tests

Adds `lib/paths.test.mjs` (4 tests) covering separator style, drive-letter case, UNC paths and the empty-string edge, with the platform-specific expectations guarded so the suite is meaningful on POSIX too.

`lib/file-access.test.mjs` needed one change. It loaded `path-security.ts` with a bare dynamic `import()`, which only worked while that file had no imports of its own; adding one broke resolution under `node --test`. It now loads through `jiti` so the module's extensionless imports resolve the way the app resolves them (`moduleResolution: "bundler"`). The test itself is unchanged and still passes.

All 5 tests pass:

```
node --test lib/paths.test.mjs lib/file-access.test.mjs
# tests 5
# pass 5
# fail 0
```

## Note

`npx eslint .` reports 6 pre-existing `react-hooks/preserve-manual-memoization` errors in `components/ChatInput.tsx`. They reproduce on a clean checkout of `main` and are unrelated to this change, so they are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
