### PR TITLE
fix: don't treat a single tilde as strikethrough (CJK ranges) (#385)

### DIFF
--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -37,6 +37,20 @@ test("keeps local file markdown links in the app", () => {
   assert.doesNotMatch(html, /target=|rel=|\snode=/);
 });
 
+test("keeps single-tilde CJK numeric ranges literal instead of striking them", () => {
+  const html = renderMarkdown("5~7U 保证金 × 100~200倍杠杆");
+
+  assert.doesNotMatch(html, /<del>/);
+  assert.match(html, /5~7U/);
+  assert.match(html, /100~200倍/);
+});
+
+test("still renders double-tilde strikethrough", () => {
+  const html = renderMarkdown("~~gone~~");
+
+  assert.match(html, /<del>gone<\/del>/);
+});
+
 test("renders LaTeX parenthesis delimiters as inline math", () => {
   const html = renderMarkdown(String.raw`射线为 \(r_c = K^{-1}p\)。`);
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -160,8 +160,13 @@ function normalizeInlineLatexMath(line: string): string {
   );
 }
 
-export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
-export const markdownPreviewRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
+// singleTilde:false requires ~~double~~ tildes for strikethrough. A single `~`
+// is the standard CJK numeric-range separator (e.g. "5~7U", "100~200倍"), and
+// GFM's default single-tilde strikethrough silently mangled such ranges (#385).
+const remarkGfmOptions = { singleTilde: false } as const;
+
+export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [[remarkGfm, remarkGfmOptions], remarkMath];
+export const markdownPreviewRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [[remarkGfm, remarkGfmOptions], remarkMath];
 
 export const markdownRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [
   rehypeRaw,


### PR DESCRIPTION
## Summary

Fixes #385.

`~` is the standard CJK notation for numeric ranges — `5~7U`, `100~200倍`, `8~9点`. GFM strikethrough accepts a **single** tilde as a delimiter, so any assistant message containing two `~` in one paragraph had both tildes dropped and an arbitrary span struck through. A range like `5~7U` renders as `57U` — the content is silently altered, which is especially misleading in data-heavy answers. This is very common in LLM output for CJK users.

### Root cause

`remark-gfm` enables single-tilde strikethrough by default (micromark's `singleTilde: true`), so `5~7U 保证金 × 100~200倍` parses as `5<del>7U 保证金 × 100</del>200倍`.

### Fix

Pass `singleTilde: false` (remark-gfm's supported option) so strikethrough requires `~~double~~` tildes and single-tilde ranges stay literal. Set once in the shared plugin config in `lib/markdown.ts`, so all three renderers inherit it — chat (`markdownRemarkPlugins`), file preview (`markdownPreviewRemarkPlugins`), and the minimap (which spreads the preview plugins).

`~~double-tilde~~` strikethrough still works.

## Testing

- `tsc --noEmit` passes
- `eslint` passes
- Added regression tests in `components/MarkdownBody.test.mjs` (rendered via the existing harness):
  - `5~7U 保证金 × 100~200倍杠杆` → no `<del>`, tildes preserved
  - `~~gone~~` → still `<del>gone</del>`
  - full suite: 10/10 pass
