### PR TITLE
feat: accept any file drag into the chat input (with upload fallback)

### DIFF
--- a/app/api/drop-files/route.test.mjs
+++ b/app/api/drop-files/route.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const { POST } = await jiti.import("./route.ts");
+
+function makeRequest(formData, { method = "POST" } = {}) {
+  return new Request("http://localhost/api/drop-files", { method, body: formData });
+}
+
+test("writes dropped files to a temp directory and returns absolute paths", async () => {
+  const form = new FormData();
+  form.append("files", new File(["hello world"], "a.txt", { type: "text/plain" }));
+  form.append("files", new File(["{json}"], "b.json", { type: "application/json" }));
+
+  const res = await POST(makeRequest(form));
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.paths.length, 2);
+  for (const p of data.paths) {
+    assert.ok(p.startsWith(path.join(os.tmpdir(), "pi-web-drops-")), `unexpected path: ${p}`);
+    assert.ok(fs.existsSync(p), `file should exist: ${p}`);
+  }
+  assert.equal(fs.readFileSync(data.paths[0], "utf-8"), "hello world");
+  assert.equal(fs.readFileSync(data.paths[1], "utf-8"), "{json}");
+  fs.rmSync(path.dirname(data.paths[0]), { recursive: true, force: true });
+});
+
+test("renames colliding file names instead of overwriting", async () => {
+  const form = new FormData();
+  form.append("files", new File(["first"], "same.txt"));
+  form.append("files", new File(["second"], "same.txt"));
+
+  const res = await POST(makeRequest(form));
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.paths.length, 2);
+  const contents = data.paths.map((p) => fs.readFileSync(p, "utf-8")).sort();
+  assert.deepEqual(contents, ["first", "second"]);
+  fs.rmSync(path.dirname(data.paths[0]), { recursive: true, force: true });
+});
+
+test("rejects path traversal file names", async () => {
+  const form = new FormData();
+  form.append("files", new File(["x"], "../evil.txt"));
+
+  const res = await POST(makeRequest(form));
+  assert.equal(res.status, 400);
+  const data = await res.json();
+  assert.match(data.error, /Invalid file name/);
+});
+
+test("rejects empty uploads", async () => {
+  const res = await POST(makeRequest(new FormData()));
+  assert.equal(res.status, 400);
+});

--- a/app/api/drop-files/route.ts
+++ b/app/api/drop-files/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+import { parseFormDataWithinLimit, RequestBodyTooLargeError } from "@/lib/bounded-form-data";
+
+/**
+ * Receives dropped files that the browser could not provide a real path for
+ * (e.g. drags where text/uri-list carries no file:// URI) and writes them to a
+ * per-request temporary directory, returning their absolute paths so the agent
+ * can read them with its own tools.
+ */
+
+const MAX_DROP_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_DROP_TOTAL_BYTES = 100 * 1024 * 1024;
+const MAX_DROP_REQUEST_BYTES = MAX_DROP_TOTAL_BYTES + 1024 * 1024;
+
+function uniqueDestination(directory: string, fileName: string): string {
+  const ext = path.extname(fileName);
+  const base = path.basename(fileName, ext);
+  let candidate = path.join(directory, fileName);
+  for (let i = 1; fs.existsSync(candidate); i++) {
+    candidate = path.join(directory, `${base}-${i}${ext}`);
+  }
+  return candidate;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let formData: FormData;
+  try {
+    formData = await parseFormDataWithinLimit(request, MAX_DROP_REQUEST_BYTES);
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return NextResponse.json({ error: "Dropped files must total 100MB or less" }, { status: 413 });
+    }
+    throw error;
+  }
+
+  const files = formData.getAll("files").filter((entry): entry is File => typeof entry !== "string");
+  if (files.length === 0) {
+    return NextResponse.json({ error: "No files provided" }, { status: 400 });
+  }
+  if (files.some((file) => file.size > MAX_DROP_FILE_BYTES)) {
+    return NextResponse.json({ error: "Each dropped file must be 25MB or smaller" }, { status: 413 });
+  }
+  if (files.reduce((total, file) => total + file.size, 0) > MAX_DROP_TOTAL_BYTES) {
+    return NextResponse.json({ error: "Dropped files must total 100MB or less" }, { status: 413 });
+  }
+
+  const fileNames = files.map((file) => file.name);
+  for (const fileName of fileNames) {
+    if (
+      !fileName ||
+      fileName === "." ||
+      fileName === ".." ||
+      fileName.includes("\0") ||
+      fileName.includes("/") ||
+      fileName.includes("\\") ||
+      path.basename(fileName) !== fileName
+    ) {
+      return NextResponse.json({ error: `Invalid file name: ${fileName || "(empty)"}` }, { status: 400 });
+    }
+  }
+
+  const directory = path.join(os.tmpdir(), `pi-web-drops-${randomUUID()}`);
+  fs.mkdirSync(directory, { recursive: true });
+
+  const paths: string[] = [];
+  for (const file of files) {
+    const destination = uniqueDestination(directory, file.name);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    fs.writeFileSync(destination, buffer);
+    paths.push(destination);
+  }
+
+  return NextResponse.json({ paths });
+}

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -13,7 +13,8 @@ import {
   buildEntriesFromFiles, buildAtInsertText, extractAtQuery, filterFileEntries,
   type AtQueryMatch, type FileIndexEntry,
 } from "@/lib/file-fuzzy";
-import { droppedFilePaths, droppedFileReference } from "@/lib/dropped-files";
+import { droppedFilePaths } from "@/lib/dropped-files";
+import { uploadDroppedFiles } from "@/lib/upload-dropped-files";
 import { FolderIcon, getFileIcon } from "./FileIcons";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useI18n } from "@/hooks/useI18n";
@@ -77,7 +78,7 @@ export interface ChatInputHandle {
   insertIfEmpty: (text: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
-  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void;
+  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void | Promise<void>;
 }
 
 const TOOL_PRESETS = ["off", "default", "full"] as const;
@@ -440,7 +441,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     addImages(files: File[]) {
       processImageFiles(files);
     },
-    addFiles(files: File[], dataTransfer?: DataTransfer | null) {
+    async addFiles(files: File[], dataTransfer?: DataTransfer | null) {
       if (isStreaming) return;
       // Resolve paths against the full file list so the index aligns with the
       // text/uri-list entries (which include image files too).
@@ -448,12 +449,34 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       const plainText = dataTransfer?.getData("text/plain") ?? "";
       const paths = droppedFilePaths(files, uriList, plainText);
       const imageFiles: File[] = [];
-      const references: string[] = [];
+      const refsByIndex = new Map<number, string>();
+      const uploadQueue: Array<{ file: File; index: number }> = [];
       files.forEach((file, index) => {
-        if (file.type.startsWith("image/")) imageFiles.push(file);
-        else references.push(droppedFileReference(file, paths[index]));
+        if (file.type.startsWith("image/")) {
+          imageFiles.push(file);
+          return;
+        }
+        const filePath = paths[index];
+        if (filePath) {
+          refsByIndex.set(index, filePath);
+        } else {
+          // No real path exposed by the browser — upload the content so the
+          // agent can still read it, falling back to the bare file name.
+          uploadQueue.push({ file, index });
+        }
       });
       if (imageFiles.length) processImageFiles(imageFiles);
+      if (uploadQueue.length) {
+        try {
+          const uploadedPaths = await uploadDroppedFiles(uploadQueue.map((q) => q.file));
+          uploadQueue.forEach((q, i) => refsByIndex.set(q.index, uploadedPaths[i] ?? q.file.name));
+        } catch {
+          uploadQueue.forEach((q) => refsByIndex.set(q.index, q.file.name));
+        }
+      }
+      const references = files
+        .map((_, index) => refsByIndex.get(index))
+        .filter((ref): ref is string => Boolean(ref));
       if (!references.length) return;
       insertTextAtCursor(references.join(" "));
     },

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -442,14 +442,19 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     },
     addFiles(files: File[], dataTransfer?: DataTransfer | null) {
       if (isStreaming) return;
-      const imageFiles = files.filter((f) => f.type.startsWith("image/"));
-      const otherFiles = files.filter((f) => !f.type.startsWith("image/"));
-      if (imageFiles.length) processImageFiles(imageFiles);
-      if (!otherFiles.length) return;
+      // Resolve paths against the full file list so the index aligns with the
+      // text/uri-list entries (which include image files too).
       const uriList = dataTransfer?.getData("text/uri-list") ?? "";
       const plainText = dataTransfer?.getData("text/plain") ?? "";
-      const paths = droppedFilePaths(otherFiles, uriList, plainText);
-      const references = otherFiles.map((file, index) => droppedFileReference(file, paths[index]));
+      const paths = droppedFilePaths(files, uriList, plainText);
+      const imageFiles: File[] = [];
+      const references: string[] = [];
+      files.forEach((file, index) => {
+        if (file.type.startsWith("image/")) imageFiles.push(file);
+        else references.push(droppedFileReference(file, paths[index]));
+      });
+      if (imageFiles.length) processImageFiles(imageFiles);
+      if (!references.length) return;
       insertTextAtCursor(references.join(" "));
     },
   }));

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -13,6 +13,7 @@ import {
   buildEntriesFromFiles, buildAtInsertText, extractAtQuery, filterFileEntries,
   type AtQueryMatch, type FileIndexEntry,
 } from "@/lib/file-fuzzy";
+import { droppedFilePaths, droppedFileReference } from "@/lib/dropped-files";
 import { FolderIcon, getFileIcon } from "./FileIcons";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useI18n } from "@/hooks/useI18n";
@@ -76,6 +77,7 @@ export interface ChatInputHandle {
   insertIfEmpty: (text: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
+  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void;
 }
 
 const TOOL_PRESETS = ["off", "default", "full"] as const;
@@ -379,6 +381,30 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   valueRef.current = value;
   attachedImagesRef.current = attachedImages;
 
+  const insertTextAtCursor = useCallback((text: string) => {
+    const ta = textareaRef.current;
+    if (!ta) {
+      setValue((v) => v + (v ? " " : "") + text);
+      return;
+    }
+    const start = ta.selectionStart ?? ta.value.length;
+    const end = ta.selectionEnd ?? ta.value.length;
+    const before = ta.value.slice(0, start);
+    const after = ta.value.slice(end);
+    const sep = before.length > 0 && !before.endsWith(" ") ? " " : "";
+    const newVal = before + sep + text + after;
+    setValue(newVal);
+    setAtQuery(null);
+    requestAnimationFrame(() => {
+      if (!ta) return;
+      const pos = start + sep.length + text.length;
+      ta.setSelectionRange(pos, pos);
+      ta.focus();
+      ta.style.height = "auto";
+      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+    });
+  }, []);
+
   useImperativeHandle(ref, () => ({
     insertIfEmpty(text: string) {
       const ta = textareaRef.current;
@@ -410,31 +436,21 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
       });
     },
-    insertText(text: string) {
-      const ta = textareaRef.current;
-      if (!ta) {
-        setValue((v) => v + (v ? " " : "") + text);
-        return;
-      }
-      const start = ta.selectionStart ?? ta.value.length;
-      const end = ta.selectionEnd ?? ta.value.length;
-      const before = ta.value.slice(0, start);
-      const after = ta.value.slice(end);
-      const sep = before.length > 0 && !before.endsWith(" ") ? " " : "";
-      const newVal = before + sep + text + after;
-      setValue(newVal);
-      setAtQuery(null);
-      requestAnimationFrame(() => {
-        if (!ta) return;
-        const pos = start + sep.length + text.length;
-        ta.setSelectionRange(pos, pos);
-        ta.focus();
-        ta.style.height = "auto";
-        ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-      });
-    },
+    insertText: insertTextAtCursor,
     addImages(files: File[]) {
       processImageFiles(files);
+    },
+    addFiles(files: File[], dataTransfer?: DataTransfer | null) {
+      if (isStreaming) return;
+      const imageFiles = files.filter((f) => f.type.startsWith("image/"));
+      const otherFiles = files.filter((f) => !f.type.startsWith("image/"));
+      if (imageFiles.length) processImageFiles(imageFiles);
+      if (!otherFiles.length) return;
+      const uriList = dataTransfer?.getData("text/uri-list") ?? "";
+      const plainText = dataTransfer?.getData("text/plain") ?? "";
+      const paths = droppedFilePaths(otherFiles, uriList, plainText);
+      const references = otherFiles.map((file, index) => droppedFileReference(file, paths[index]));
+      insertTextAtCursor(references.join(" "));
     },
   }));
 

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -304,12 +304,12 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   }, [ctxKey, onContextUsageChange]);
   useEffect(() => () => { onContextUsageChange?.(null); }, [onContextUsageChange]);
 
-  const onDrop = useCallback((files: File[]) => {
+  const onDrop = useCallback((files: File[], dataTransfer: DataTransfer | null) => {
     if (sessionBusy) return;
-    chatInputRef?.current?.addImages(files);
+    chatInputRef?.current?.addFiles(files, dataTransfer);
   }, [sessionBusy, chatInputRef]);
 
-  const { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } = useDragDrop(onDrop);
+  const { isDragOver, dragHasImages, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } = useDragDrop(onDrop);
 
   const visibleMessages = messages.filter((m) => m.role === "user" || m.role === "assistant");
   const inputHistory = useMemo(() => {
@@ -426,19 +426,31 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
             width="280" height="280" viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg"
             className="drop-shadow-[0_6px_18px_rgba(37,99,235,0.18)]"
           >
-            <rect x="28" y="44" width="84" height="60" rx="8" fill="rgba(37,99,235,0.08)" stroke="rgba(37,99,235,0.50)" strokeWidth="1.8"/>
-            <path d="M36 100 L54 72 L68 88 L80 74 L104 100Z" fill="rgba(37,99,235,0.16)" stroke="rgba(37,99,235,0.40)" strokeWidth="1.4" strokeLinejoin="round"/>
-            <circle cx="96" cy="58" r="8" fill="rgba(37,99,235,0.22)" stroke="rgba(37,99,235,0.55)" strokeWidth="1.6"/>
-            <g stroke="rgba(37,99,235,0.45)" strokeWidth="1.4" strokeLinecap="round">
-              <line x1="96" y1="46" x2="96" y2="43"/>
-              <line x1="96" y1="70" x2="96" y2="73"/>
-              <line x1="84" y1="58" x2="81" y2="58"/>
-              <line x1="108" y1="58" x2="111" y2="58"/>
-              <line x1="87.5" y1="49.5" x2="85.4" y2="47.4"/>
-              <line x1="104.5" y1="66.5" x2="106.6" y2="68.6"/>
-              <line x1="104.5" y1="49.5" x2="106.6" y2="47.4"/>
-              <line x1="87.5" y1="66.5" x2="85.4" y2="68.6"/>
-            </g>
+            {dragHasImages ? (
+              <g>
+                <rect x="28" y="44" width="84" height="60" rx="8" fill="rgba(37,99,235,0.08)" stroke="rgba(37,99,235,0.50)" strokeWidth="1.8"/>
+                <path d="M36 100 L54 72 L68 88 L80 74 L104 100Z" fill="rgba(37,99,235,0.16)" stroke="rgba(37,99,235,0.40)" strokeWidth="1.4" strokeLinejoin="round"/>
+                <circle cx="96" cy="58" r="8" fill="rgba(37,99,235,0.22)" stroke="rgba(37,99,235,0.55)" strokeWidth="1.6"/>
+                <g stroke="rgba(37,99,235,0.45)" strokeWidth="1.4" strokeLinecap="round">
+                  <line x1="96" y1="46" x2="96" y2="43"/>
+                  <line x1="96" y1="70" x2="96" y2="73"/>
+                  <line x1="84" y1="58" x2="81" y2="58"/>
+                  <line x1="108" y1="58" x2="111" y2="58"/>
+                  <line x1="87.5" y1="49.5" x2="85.4" y2="47.4"/>
+                  <line x1="104.5" y1="66.5" x2="106.6" y2="68.6"/>
+                  <line x1="104.5" y1="49.5" x2="106.6" y2="47.4"/>
+                  <line x1="87.5" y1="66.5" x2="85.4" y2="68.6"/>
+                </g>
+              </g>
+            ) : (
+              <g>
+                <path d="M46 30 h34 l16 16 v60 a6 6 0 0 1 -6 6 h-44 a6 6 0 0 1 -6 -6 v-70 a6 6 0 0 1 6 -6z" fill="rgba(37,99,235,0.08)" stroke="rgba(37,99,235,0.50)" strokeWidth="1.8" strokeLinejoin="round"/>
+                <polyline points="80 30 80 46 96 46" fill="none" stroke="rgba(37,99,235,0.50)" strokeWidth="1.8" strokeLinejoin="round"/>
+                <line x1="52" y1="68" x2="88" y2="68" stroke="rgba(37,99,235,0.45)" strokeWidth="1.6" strokeLinecap="round"/>
+                <line x1="52" y1="80" x2="88" y2="80" stroke="rgba(37,99,235,0.45)" strokeWidth="1.6" strokeLinecap="round"/>
+                <line x1="52" y1="92" x2="76" y2="92" stroke="rgba(37,99,235,0.45)" strokeWidth="1.6" strokeLinecap="round"/>
+              </g>
+            )}
           </svg>
         </div>
       )}

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -305,6 +305,7 @@ export interface ChatInputHandle {
   insertIfEmpty: (content: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
+  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void;
 }
 
 export interface AttachedImage {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -305,7 +305,7 @@ export interface ChatInputHandle {
   insertIfEmpty: (content: string) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
-  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void;
+  addFiles: (files: File[], dataTransfer?: DataTransfer | null) => void | Promise<void>;
 }
 
 export interface AttachedImage {

--- a/hooks/useDragDrop.ts
+++ b/hooks/useDragDrop.ts
@@ -2,21 +2,23 @@
 
 import { useState, useCallback, useRef } from "react";
 
-export function useDragDrop(onDrop: (files: File[]) => void) {
+export function useDragDrop(onDrop: (files: File[], dataTransfer: DataTransfer | null) => void) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const [dragHasImages, setDragHasImages] = useState(false);
   const counterRef = useRef(0);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    const hasImages = Array.from(e.dataTransfer.items).some((item) => item.type.startsWith("image/"));
-    if (!hasImages) return;
+    const items = Array.from(e.dataTransfer.items);
+    if (!items.some((item) => item.kind === "file")) return;
     e.preventDefault();
     counterRef.current += 1;
     setIsDragOver(true);
+    setDragHasImages(items.some((item) => item.type.startsWith("image/")));
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    const hasImages = Array.from(e.dataTransfer.items).some((item) => item.type.startsWith("image/"));
-    if (!hasImages) return;
+    const items = Array.from(e.dataTransfer.items);
+    if (!items.some((item) => item.kind === "file")) return;
     e.preventDefault();
   }, []);
 
@@ -33,8 +35,9 @@ export function useDragDrop(onDrop: (files: File[]) => void) {
     counterRef.current = 0;
     setIsDragOver(false);
     const files = Array.from(e.dataTransfer.files);
-    onDrop(files);
+    if (!files.length) return;
+    onDrop(files, e.dataTransfer);
   }, [onDrop]);
 
-  return { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop };
+  return { isDragOver, dragHasImages, handleDragEnter, handleDragOver, handleDragLeave, handleDrop };
 }

--- a/lib/dropped-files.test.mjs
+++ b/lib/dropped-files.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const { decodeDroppedFileUri, droppedFilePaths, droppedFileReference } = await jiti.import("./dropped-files.ts");
+
+test("decodes POSIX file URIs", () => {
+  assert.equal(decodeDroppedFileUri("file:///home/me/a%20b.txt"), "/home/me/a b.txt");
+});
+
+test("decodes Windows drive file URIs", () => {
+  assert.equal(decodeDroppedFileUri("file:///C:/Users/me/a.txt"), "C:/Users/me/a.txt");
+});
+
+test("rejects non-file URIs and malformed input", () => {
+  assert.equal(decodeDroppedFileUri("https://example.com/x"), null);
+  assert.equal(decodeDroppedFileUri("file:///home/me/%zz"), null);
+  assert.equal(decodeDroppedFileUri("file://"), null);
+});
+
+test("maps file URIs to files in order", () => {
+  const files = [new File(["a"], "a.txt"), new File(["b"], "b.log")];
+  const paths = droppedFilePaths(files, "file:///tmp/a.txt\r\nfile:///tmp/b.log", "");
+  assert.deepEqual(paths, ["/tmp/a.txt", "/tmp/b.log"]);
+});
+
+test("ignores comments and blank lines in uri-list", () => {
+  const files = [new File(["a"], "a.txt")];
+  const paths = droppedFilePaths(files, "# comment\r\n\r\nfile:///tmp/a.txt", "");
+  assert.deepEqual(paths, ["/tmp/a.txt"]);
+});
+
+test("falls back to null when the URI count does not match", () => {
+  const files = [new File(["a"], "a.txt")];
+  assert.deepEqual(droppedFilePaths(files, "file:///tmp/a.txt\r\nfile:///tmp/b.log", ""), [null]);
+  assert.deepEqual(droppedFilePaths(files, "https://example.com/a.txt", ""), [null]);
+});
+
+test("uses an absolute text/plain fallback for a single file", () => {
+  const files = [new File(["a"], "a.txt")];
+  assert.deepEqual(droppedFilePaths(files, "", "/tmp/a.txt"), ["/tmp/a.txt"]);
+  assert.deepEqual(droppedFilePaths(files, "", "C:\\Users\\me\\a.txt"), ["C:\\Users\\me\\a.txt"]);
+  // Bare basenames carry no location, so they are ignored.
+  assert.deepEqual(droppedFilePaths(files, "", "a.txt"), [null]);
+});
+
+test("reference falls back to the file name", () => {
+  const file = new File(["a"], "notes.md");
+  assert.equal(droppedFileReference(file, "/tmp/notes.md"), "/tmp/notes.md");
+  assert.equal(droppedFileReference(file, null), "notes.md");
+});

--- a/lib/dropped-files.ts
+++ b/lib/dropped-files.ts
@@ -1,0 +1,63 @@
+// Mapping for files dragged into the chat input from the OS file manager.
+//
+// Browsers never expose the real filesystem path of a dropped file on the
+// File object. However, when the drag originates from the OS file manager,
+// Chrome/Edge/Firefox/Safari put file:// URIs on the dataTransfer's
+// "text/uri-list". pi-web is a local app (browser and agent on the same
+// machine), so that path is directly usable by the agent.
+
+/** Decode a single file:// URI into a filesystem path, or null when malformed. */
+export function decodeDroppedFileUri(uri: string): string | null {
+  if (!uri.startsWith("file://")) return null;
+  let path: string;
+  try {
+    path = decodeURIComponent(uri.slice("file://".length));
+  } catch {
+    return null;
+  }
+  if (!path) return null;
+  // file:///C:/Users/me/a.txt -> /C:/Users/me/a.txt -> C:/Users/me/a.txt
+  if (/^\/[A-Za-z]:[\\/]/.test(path)) path = path.slice(1);
+  return path;
+}
+
+/**
+ * Best-effort mapping of dropped File objects to their real filesystem paths.
+ *
+ * The i-th file:// URI on text/uri-list corresponds to the i-th dropped file
+ * (all major browsers preserve the order). When the count does not line up —
+ * or the drop did not come from the OS file manager — fall back to text/plain
+ * for a single absolute-looking value, and null (the caller inserts the bare
+ * file name) otherwise.
+ */
+export function droppedFilePaths(files: File[], uriList: string, plainText: string): (string | null)[] {
+  const paths: (string | null)[] = files.map(() => null);
+
+  const uris = uriList
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  const fileUris = uris.filter((uri) => uri.startsWith("file://"));
+  if (fileUris.length === files.length) {
+    for (let index = 0; index < files.length; index += 1) {
+      paths[index] = decodeDroppedFileUri(fileUris[index]);
+    }
+    return paths;
+  }
+
+  // Single-file fallback: some sources put the real path on text/plain.
+  // Bare basenames are useless here, so only trust absolute-looking values.
+  if (files.length === 1 && plainText.trim()) {
+    const candidate = plainText.trim();
+    if (candidate.startsWith("/") || candidate.startsWith("~") || /^[A-Za-z]:[\\/]/.test(candidate)) {
+      paths[0] = candidate;
+    }
+  }
+
+  return paths;
+}
+
+/** The text inserted for a dropped file: its path when known, else its name. */
+export function droppedFileReference(file: File, path: string | null): string {
+  return path ?? file.name;
+}

--- a/lib/upload-dropped-files.test.mjs
+++ b/lib/upload-dropped-files.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  tsconfigPaths: true,
+});
+const { uploadDroppedFiles } = await jiti.import("./upload-dropped-files.ts");
+
+function makeFile(name, content = "data", type = "text/plain") {
+  return new File([content], name, { type });
+}
+
+test("returns an empty list for no files", async () => {
+  const result = await uploadDroppedFiles([]);
+  assert.deepEqual(result, []);
+});
+
+test("posts files and returns the uploaded paths", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody = null;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, "/api/drop-files");
+    assert.equal(init.method, "POST");
+    capturedBody = init.body;
+    return new Response(JSON.stringify({ paths: ["/tmp/pi-web-drops-x/a.txt"] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  try {
+    const paths = await uploadDroppedFiles([makeFile("a.txt")]);
+    assert.deepEqual(paths, ["/tmp/pi-web-drops-x/a.txt"]);
+    assert.ok(capturedBody instanceof FormData, "body should be FormData");
+    assert.equal(capturedBody.getAll("files").length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("throws a descriptive error when the upload fails", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: "Too large" }), { status: 413 });
+  try {
+    await assert.rejects(() => uploadDroppedFiles([makeFile("b.txt")]), /Too large/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/lib/upload-dropped-files.ts
+++ b/lib/upload-dropped-files.ts
@@ -1,0 +1,30 @@
+/**
+ * Uploads files that the browser could not expose a real path for (no
+ * file:// URI on the drag's text/uri-list) so the agent can still read them.
+ * Returns the absolute paths written by the server, aligned with `files`.
+ */
+
+export interface UploadDroppedFilesResult {
+  paths: string[];
+}
+
+export async function uploadDroppedFiles(files: File[]): Promise<string[]> {
+  if (files.length === 0) return [];
+  const form = new FormData();
+  for (const file of files) {
+    form.append("files", file);
+  }
+  const res = await fetch("/api/drop-files", { method: "POST", body: form });
+  if (!res.ok) {
+    let message = `Upload failed (${res.status})`;
+    try {
+      const data = (await res.json()) as { error?: string };
+      if (data.error) message = data.error;
+    } catch {
+      // ignore parse errors, keep the status-based message
+    }
+    throw new Error(message);
+  }
+  const data = (await res.json()) as UploadDroppedFilesResult;
+  return data.paths;
+}


### PR DESCRIPTION
## Summary

The chat input currently only accepts **image** drags. Dropping any other file silently does nothing. This PR makes the drop zone accept **any file** from the OS file manager.

> Supersedes #344 (closed). Addresses the reviewer's concern: when the browser does not expose a `file://` URI on `text/uri-list` (Firefox, several Linux desktops), the dropped file is now **uploaded** to a temp directory so the agent can still read it.

## Behavior

- **Images** — unchanged: attached as base64 multimodal content.
- **Any other file / folder** — its real filesystem path is inserted into the input at the caret, so the agent can read it with its own tools.
  - Path comes from the drag's `text/uri-list` `file://` URIs (POSIX + Windows drive paths, URL decoding).
  - **If the browser exposes no path** (verified working environments: Chrome/Windows; unreliable: Firefox/Linux), the file content is uploaded via a new `POST /api/drop-files` endpoint to a per-request temp directory (`os.tmpdir()/pi-web-drops-<uuid>/`) and that **absolute path** is inserted — the locally-running agent can read it.
  - Falls back to the bare file name only if the upload itself fails.
- The full-window drop overlay shows a document icon when the drag contains no images.

## Implementation

- `lib/dropped-files.ts` (new): parses `text/uri-list` (POSIX + Windows drive paths, URL decoding, comment/blank lines), single-file `text/plain` fallback. Unit-tested.
- `app/api/drop-files/route.ts` (new): writes dropped files to a per-request temp dir, returns absolute paths. Validates file names (no path traversal), enforces 25MB/file and 100MB total limits. Unit-tested.
- `lib/upload-dropped-files.ts` (new): client-side upload helper. Unit-tested with a stubbed fetch.
- `hooks/useDragDrop.ts`: accept any `kind === "file"` drag, pass the `dataTransfer` to the drop callback.
- `components/ChatInput.tsx`: `addFiles(files, dataTransfer)` — images → existing attach flow; others → path insertion, uploading when no path is exposed.

## Verification

- Unit tests: dropped-files (8), drop-files route (4), upload helper (3) — all passing; `tsc --noEmit` and `eslint` clean; production `next build` passes.
- End-to-end in a real browser:
  - Drop with `text/uri-list` file:// URI → real path inserted (`/home/.../real.txt`).
  - Drop with **no** uri-list (simulating Firefox/Linux) → file uploaded, `/tmp/pi-web-drops-<uuid>/no-path.txt` inserted, content verified on disk.