### PR TITLE
Skip reload when re-clicking the currently open session

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -353,6 +353,19 @@ export function AppShell() {
   }, [router, selectedSession]);
 
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
+    // Re-clicking the already-open session must not remount the chat and
+    // re-run the full load/positioning cycle. Only skip when the effective
+    // cwd context already matches — otherwise a pending cwd move still needs
+    // the full re-select flow.
+    if (!isRestore && selectedSession) {
+      const sameProject =
+        (selectedSession.projectRoot ?? selectedSession.cwd) ===
+        (session.projectRoot ?? session.cwd);
+      if (selectedSession.id === session.id && sameProject) {
+        if (isMobile) setSidebarOpen(false);
+        return;
+      }
+    }
     setNewSessionCwd(null);
     setSelectedSession(session);
     setSessionKey((k) => k + 1);


### PR DESCRIPTION
## Summary

Clicking the already-open session previously bumped `sessionKey` in
`AppShell.handleSelectSession`, remounting the chat and re-running the full
load/positioning cycle. This short-circuits that path when the session id and
effective project cwd already match, making a redundant click a no-op.

## Changes

- Guard `handleSelectSession` to return early when re-selecting the currently
  open session (same `id` **and** same effective `projectRoot ?? cwd`).
- A pending cwd move still flows through the full re-select path, so the
  optimized case never skips a genuine workspace switch.
- On mobile, the sidebar drawer still collapses when tapping the active row.

## Why this is safe

The early return only fires when `!isRestore` and both the id and the project
context already match — i.e. the exact case where nothing changed. Restore
navigation and workspace switches are unaffected.