### PR TITLE
fix: keep file icons monochrome in dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -70,6 +70,7 @@ html.dark .catppuccin-file-icon {
     -webkit-mask: center / contain no-repeat var(--catppuccin-icon-light);
   }
   html.dark .catppuccin-file-icon {
+    background: var(--text-dim);
     mask-image: var(--catppuccin-icon-dark);
     -webkit-mask-image: var(--catppuccin-icon-dark);
   }


### PR DESCRIPTION
## Fix
Dark theme file icons rendered half-gray/half-color because the base
html.dark rule re-applied the colorful Mocha SVG over the monochrome
gray, and the semi-transparent mask let it bleed through.

## Behavior
- Dark theme icons are now uniform gray, matching the light theme.
- Graceful fallback for browsers without mask-image is preserved.

## Implementation
Single change to app/globals.css (+1 line): add
background: var(--text-dim) in the masked html.dark branch.

## Testing
node_modules/.bin/tsc --noEmit   # pass
npm run lint                     # pass