### PR TITLE
feat: theme-aware icons in written-file tags

### DIFF
--- a/components/TurnWrittenFiles.tsx
+++ b/components/TurnWrittenFiles.tsx
@@ -3,6 +3,7 @@
 import { useI18n } from "@/hooks/useI18n";
 import { getFileName } from "@/lib/file-paths";
 import type { WrittenFile } from "@/lib/turn-written-files";
+import { getFileIcon } from "./FileIcons";
 
 /**
  * Lists the files a turn actually wrote, as buttons that open each one in the
@@ -41,20 +42,7 @@ export function TurnWrittenFiles({ files, onOpenFile }: {
               cursor: "pointer",
             }}
           >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M9 1.5H4A1.5 1.5 0 0 0 2.5 3v10A1.5 1.5 0 0 0 4 14.5h8A1.5 1.5 0 0 0 13.5 13V6z" />
-              <path d="M9 1.5V6h4.5" />
-            </svg>
+            {getFileIcon(name, 12)}
             <span>{name}</span>
           </button>
         );


### PR DESCRIPTION
## Feat: theme-aware icons in written-file tags
Replace the hardcoded generic file SVG in the turn-written-files tags
with the shared theme-aware getFileIcon helper.
<img width="1286" height="121" alt="image" src="https://github.com/user-attachments/assets/3520ffef-6f3d-4480-891b-7f8e098455e0" />
<img width="424" height="117" alt="image" src="https://github.com/user-attachments/assets/b90e69d2-9439-46a4-acfd-66844a6cbd52" />


## Behavior
- Written-file tags now show a type-specific icon (ts/md/json/... plus
  specials like package-lock.json, .env, next.config.*) instead of one
  generic document icon.
- Icons follow the theme: Latte assets in light mode, Mocha in dark,
  and stay monochrome per the app's restrained palette — consistent
  with the file tree and tab bar.

## Implementation
Single change to TurnWrittenFiles.tsx (~2 lines): swap the inline
<svg> for {getFileIcon(name, 12)} and import the helper.

## Testing
- node_modules/.bin/tsc --noEmit  (pass)
- npm run lint                    (pass)