### PR TITLE
fix: cap the user message bubble height with a scrollbar

### DIFF
--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -28,6 +28,10 @@ import type {
 const MAX_THINKING_CACHE_ENTRIES = 100;
 const thinkingContentCache = new Map<string, Promise<string>>();
 
+// Cap the user "sent" bubble's height so an abnormally long message does not
+// push the conversation off screen; overflow scrolls inside the bubble.
+const USER_BUBBLE_MAX_HEIGHT = 300;
+
 function loadThinkingContent(sessionId: string, entryId: string, blockIndex: number): Promise<string> {
   const key = `${sessionId}:${entryId}:${blockIndex}`;
   const cached = thinkingContentCache.get(key);
@@ -263,6 +267,8 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
             lineHeight: 1.6,
             color: "var(--text)",
             wordBreak: "break-word",
+            maxHeight: USER_BUBBLE_MAX_HEIGHT,
+            overflowY: "auto",
           }}
         >
           {commandText ? (


### PR DESCRIPTION
## Fix

> 为User信息框添加滚动条和最大高度限制，避免过长的内容（例如展开的skill、超长日志等）占用过多空间。

A very long sent message could push the whole conversation off screen.
This caps the user bubble at 300px and lets overflow scroll inside the
bubble instead, keeping the action buttons and surrounding messages stable.
<img width="1474" height="641" alt="image" src="https://github.com/user-attachments/assets/66df2b0a-b45f-42ef-b78a-5ba6dea4e1db" />


## Behavior

- **Short messages**: unchanged (no scrollbar when under 300px).
- **Long messages**: bubble is capped at 300px, content scrolls inside it.
- **Action buttons (copy / fork)**: unaffected, they live outside the bubble.

## Implementation

Single change in `components/MessageView.tsx` (+6 lines): a named
`USER_BUBBLE_MAX_HEIGHT = 300` constant applied as `maxHeight` +
`overflowY: "auto"` on the user-sent bubble's inline style.

## Testing

- `node_modules/.bin/tsc --noEmit` — clean