### PR TITLE
feat: support self-update via pi-web update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ npm install -g @agegr/pi-web
 pi-web
 ```
 
+**Update to the latest version:**
+
+```bash
+pi-web update
+```
+
+`pi-web update` checks the npm registry for a newer release and reinstalls pi-web globally with the package manager that was used to install it (npm, pnpm, yarn, or bun). If pi-web was run through `npx`, the update installs the latest version globally. Restart pi-web after updating.
+
 Then open [http://127.0.0.1:30141](http://127.0.0.1:30141). The CLI will try to open the browser automatically after the server is ready. Pi Web listens on `127.0.0.1` by default.
 
 **Options:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,14 @@ npm install -g @agegr/pi-web
 pi-web
 ```
 
+**更新到最新版本：**
+
+```bash
+pi-web update
+```
+
+`pi-web update` 会检查 npm registry 中是否有新版本，并使用安装 pi-web 时所用的包管理器（npm、pnpm、yarn 或 bun）重新全局安装。如果通过 `npx` 运行 pi-web，该命令会将最新版本全局安装到本机。更新完成后请重启 pi-web。
+
 启动后打开 [http://127.0.0.1:30141](http://127.0.0.1:30141)。命令行版本会在服务就绪后尝试自动打开浏览器。Pi Web 默认仅监听 `127.0.0.1`。
 
 **可选参数：**

--- a/bin/pi-web-update.js
+++ b/bin/pi-web-update.js
@@ -1,0 +1,159 @@
+"use strict";
+
+// Implements `pi-web update`: check the npm registry for a newer release of
+// @agegr/pi-web, then reinstall the package globally with the same package
+// manager that was used to install it (npm, pnpm, yarn, or bun).
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { spawnSync } = require("child_process");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { name: PACKAGE_NAME, version: CURRENT_VERSION } = require("../package.json");
+const VERSION_CHECK_TIMEOUT_MS = 15_000;
+
+const STABLE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+
+function parseStableVersion(version) {
+  const match = STABLE_VERSION_PATTERN.exec(String(version).trim());
+  if (!match) return null;
+  const parts = match.slice(1).map(Number);
+  if (parts.some((part) => !Number.isSafeInteger(part))) return null;
+  return parts;
+}
+
+function isNewerVersion(candidate, current) {
+  const candidateParts = parseStableVersion(candidate);
+  const currentParts = parseStableVersion(current);
+  if (!candidateParts || !currentParts) return false;
+
+  for (let index = 0; index < candidateParts.length; index += 1) {
+    if (candidateParts[index] !== currentParts[index]) {
+      return candidateParts[index] > currentParts[index];
+    }
+  }
+  return false;
+}
+
+// Detect the package manager that installed this copy of pi-web from the
+// installation path. Global installs always live under
+// `<something>/node_modules/@agegr/pi-web/bin`, and each package manager uses
+// a recognizable directory layout above that.
+function detectInstallMethod(dir = __dirname) {
+  const normalized = dir.toLowerCase().replace(/\\/g, "/");
+  if (normalized.includes("/pnpm/") || normalized.includes("/.pnpm/")) return "pnpm";
+  if (normalized.includes("/yarn/") || normalized.includes("/.yarn/")) return "yarn";
+  if (normalized.includes("/install/global/node_modules/")) return "bun";
+  if (normalized.includes("/npm/") || normalized.includes("/node_modules/")) return "npm";
+  return "unknown";
+}
+
+function getUpdateCommand(method, version) {
+  const spec = `${PACKAGE_NAME}@${version}`;
+  switch (method) {
+    case "pnpm":
+      return { command: "pnpm", args: ["install", "-g", spec] };
+    case "yarn":
+      return { command: "yarn", args: ["global", "add", spec] };
+    case "bun":
+      return { command: "bun", args: ["add", "-g", spec] };
+    default:
+      return { command: "npm", args: ["install", "-g", spec] };
+  }
+}
+
+function runCommand(command, args) {
+  // npm/pnpm/yarn ship as .cmd shims on Windows and cannot be spawned
+  // directly, so resolve them through the shell there.
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with code ${result.status ?? "unknown"}`);
+  }
+}
+
+// Query the registry through npm so the check and the install use the same
+// registry, proxy, and timeout configuration as the package manager itself.
+function getLatestVersion() {
+  const result = spawnSync(
+    "npm",
+    ["view", PACKAGE_NAME, "version", "--json", `--fetch-timeout=${VERSION_CHECK_TIMEOUT_MS}`],
+    { encoding: "utf8", shell: process.platform === "win32" },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = (result.stderr || "").trim() || `npm view exited with code ${result.status}`;
+    throw new Error(detail);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("npm view returned unexpected output");
+  }
+  if (typeof parsed === "string") return parsed;
+  if (Array.isArray(parsed)) {
+    const versions = parsed.filter((value) => typeof value === "string");
+    if (versions.length > 0) return versions[versions.length - 1];
+  }
+  return "";
+}
+
+function getManualInstallHint(version = "latest") {
+  return `npm install -g ${PACKAGE_NAME}@${version}`;
+}
+
+function runUpdateInternal() {
+  const method = detectInstallMethod();
+  if (method === "unknown") {
+    console.error("error: could not determine how pi-web was installed.");
+    console.error(`Update it manually with: ${getManualInstallHint()}`);
+    return 1;
+  }
+
+  console.log(`Checking for updates to ${PACKAGE_NAME}...`);
+  let latestVersion;
+  try {
+    latestVersion = getLatestVersion();
+  } catch (error) {
+    console.error(`error: could not check for updates: ${error.message}`);
+    console.error(`Update it manually with: ${getManualInstallHint()}`);
+    return 1;
+  }
+  if (!latestVersion || !isNewerVersion(latestVersion, CURRENT_VERSION)) {
+    console.log(`${PACKAGE_NAME} is already up to date (v${CURRENT_VERSION})`);
+    return 0;
+  }
+
+  const updateCommand = getUpdateCommand(method, latestVersion);
+  const commandDisplay = [updateCommand.command, ...updateCommand.args].join(" ");
+  console.log(`Updating ${PACKAGE_NAME} from v${CURRENT_VERSION} to v${latestVersion} with ${commandDisplay}...`);
+  try {
+    runCommand(updateCommand.command, updateCommand.args);
+  } catch (error) {
+    console.error(`error: update failed: ${error.message}`);
+    console.error(`If this keeps failing, run the command yourself: ${getManualInstallHint(latestVersion)}`);
+    return 1;
+  }
+  console.log(`${PACKAGE_NAME} updated to v${latestVersion}. Restart pi-web to use the new version.`);
+  return 0;
+}
+
+function runUpdate() {
+  try {
+    return runUpdateInternal();
+  } catch (error) {
+    console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(`Update it manually with: ${getManualInstallHint()}`);
+    return 1;
+  }
+}
+
+module.exports = {
+  detectInstallMethod,
+  getUpdateCommand,
+  isNewerVersion,
+  runUpdate,
+};

--- a/bin/pi-web-update.test.mjs
+++ b/bin/pi-web-update.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { detectInstallMethod, getUpdateCommand, isNewerVersion } = require("./pi-web-update.js");
+
+test("detects newer stable versions", () => {
+  assert.equal(isNewerVersion("0.8.8", "0.8.7"), true);
+  assert.equal(isNewerVersion("0.9.0", "0.8.7"), true);
+  assert.equal(isNewerVersion("1.0.0", "0.9.9"), true);
+});
+
+test("does not report equal, older, or unsupported versions as updates", () => {
+  assert.equal(isNewerVersion("0.8.7", "0.8.7"), false);
+  assert.equal(isNewerVersion("0.8.6", "0.8.7"), false);
+  assert.equal(isNewerVersion("0.8.8-beta.1", "0.8.7"), false);
+  assert.equal(isNewerVersion("invalid", "0.8.7"), false);
+});
+
+test("detects the package manager from the installation path", () => {
+  assert.equal(detectInstallMethod("C:/Users/x/AppData/Roaming/npm/node_modules/@agegr/pi-web/bin"), "npm");
+  assert.equal(detectInstallMethod("/usr/local/lib/node_modules/@agegr/pi-web/bin"), "npm");
+  assert.equal(detectInstallMethod("C:/Users/x/AppData/Local/npm-cache/_npx/abc123/node_modules/@agegr/pi-web/bin"), "npm");
+  assert.equal(detectInstallMethod("/home/x/.npm/_npx/abc123/node_modules/@agegr/pi-web/bin"), "npm");
+  assert.equal(detectInstallMethod("C:/Users/x/AppData/Local/pnpm/global/5/node_modules/.pnpm/@agegr+pi-web@0.8.7/node_modules/@agegr/pi-web/bin"), "pnpm");
+  assert.equal(detectInstallMethod("/home/x/.local/share/pnpm/global/5/node_modules/@agegr/pi-web/bin"), "pnpm");
+  assert.equal(detectInstallMethod("C:/Users/x/AppData/Local/Yarn/Config/global/node_modules/@agegr/pi-web/bin"), "yarn");
+  assert.equal(detectInstallMethod("/home/x/.yarn/global/node_modules/@agegr/pi-web/bin"), "yarn");
+  assert.equal(detectInstallMethod("C:/Users/x/.bun/install/global/node_modules/@agegr/pi-web/bin"), "bun");
+  assert.equal(detectInstallMethod("/home/x/.bun/install/global/node_modules/@agegr/pi-web/bin"), "bun");
+});
+
+test("does not guess a package manager for non-global checkouts", () => {
+  assert.equal(detectInstallMethod("C:/Users/x/projects/pi-web/bin"), "unknown");
+  assert.equal(detectInstallMethod("/home/x/pi-web/bin"), "unknown");
+});
+
+test("builds the update command for each package manager", () => {
+  assert.deepEqual(getUpdateCommand("npm", "0.8.8"), {
+    command: "npm",
+    args: ["install", "-g", "@agegr/pi-web@0.8.8"],
+  });
+  assert.deepEqual(getUpdateCommand("pnpm", "0.8.8"), {
+    command: "pnpm",
+    args: ["install", "-g", "@agegr/pi-web@0.8.8"],
+  });
+  assert.deepEqual(getUpdateCommand("yarn", "0.8.8"), {
+    command: "yarn",
+    args: ["global", "add", "@agegr/pi-web@0.8.8"],
+  });
+  assert.deepEqual(getUpdateCommand("bun", "0.8.8"), {
+    command: "bun",
+    args: ["add", "-g", "@agegr/pi-web@0.8.8"],
+  });
+});

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -9,6 +9,13 @@ if (!isNodeVersionSupported(process.versions.node)) {
   process.exit(1);
 }
 
+const args = process.argv.slice(2);
+if (args.includes("update")) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { runUpdate } = require("./pi-web-update");
+  process.exit(runUpdate());
+}
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { spawn } = require("child_process");
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start": "next start -H 127.0.0.1 -p 30141",
     "start:lan": "next start -H 0.0.0.0 -p 30141",
     "lint": "eslint .",
-    "test": "node --experimental-strip-types --test \"app/**/*.test.mjs\" \"components/**/*.test.mjs\" \"hooks/**/*.test.mjs\" \"lib/**/*.test.mjs\" \"public/**/*.test.mjs\"",
+    "test": "node --experimental-strip-types --test \"app/**/*.test.mjs\" \"components/**/*.test.mjs\" \"hooks/**/*.test.mjs\" \"lib/**/*.test.mjs\" \"public/**/*.test.mjs\" \"bin/**/*.test.mjs\"",
     "release": "npm version patch --no-git-tag-version && npm run build && npm publish --access public"
   },
   "dependencies": {


### PR DESCRIPTION
## 中文

支持 `pi-web update` 直接自更新，无需再手动执行 `npm install -g @agegr/pi-web`。

- 新增 `pi-web update` 子命令：检查 npm registry 中的新版本，并用安装 pi-web 时所用的包管理器（npm、pnpm、yarn 或 bun）重新全局安装
- 无法识别安装方式、registry 不可达或安装失败时，输出手动更新命令提示
- 通过 `npx` 运行时，`pi-web update` 会将最新版本全局安装到本机
- 版本比较沿用 `lib/app-update.ts` 的稳定版语义（预发布版本不触发更新）
- 新增 `bin/pi-web-update.test.mjs` 单元测试，并纳入 `npm test`
- README（英文/中文）补充更新说明

注：`README.ja.md` / `README.ru.md` 为社区翻译，欢迎补充对应段落。

## English

Adds a `pi-web update` command so users can self-update without running `npm install -g @agegr/pi-web` manually.

- `pi-web update` checks the npm registry for a newer release and reinstalls pi-web globally with the package manager that installed it (npm, pnpm, yarn, or bun)
- Prints a manual fallback command when the install method cannot be detected, the registry is unreachable, or the update fails
- When pi-web was run through `npx`, the update installs the latest version globally
- Version comparison reuses the stable-only semantics of `lib/app-update.ts` (prereleases never trigger an update)
- Adds `bin/pi-web-update.test.mjs` unit tests, wired into `npm test`
- Documents the command in the English and Chinese READMEs

Note: `README.ja.md` / `README.ru.md` are community translations; updates welcome.
