### PR TITLE
feat: offline context usage estimation for sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,12 @@ app/api/
 
 lib/
   agent-client.ts      typed fetch helper for /api/agent commands
+  context-usage.ts     offline context-usage estimation from session files
   draft-store.ts       local draft persistence helpers
   file-access.ts       allowed file roots for /api/files and worktrees
   file-paths.ts        client/server path encoding helpers
   markdown.ts          shared markdown helpers
+  models-loader.ts     loadModels() — models registry loader shared by /api/models and session routes
   npx.ts               npx runner used by skill install
   pi-types.ts          local structural types for pi SDK objects
   rpc-manager.ts      AgentSessionWrapper + registry + startRpcSession

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,87 +1,10 @@
 import { stat } from "fs/promises";
 import { resolve } from "path";
-import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
-import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
-import { loadModelsWithCache, withModelRuntimeError, type ModelsData } from "@/lib/models-cache";
-import { resolveVisibleModels, selectInitialModelScope } from "@/lib/model-scope";
+import { loadModelsWithCache, type ModelsData } from "@/lib/models-cache";
+import { loadModels } from "@/lib/models-loader";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
-import { projectTrustReloadOptions } from "@/lib/project-trust";
 
 export const dynamic = "force-dynamic";
-
-const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-
-function compareModelEntries(
-  a: { id: string; name: string; provider: string },
-  b: { id: string; name: string; provider: string }
-): number {
-  return modelNameCollator.compare(a.name || a.id, b.name || b.id)
-    || modelNameCollator.compare(a.provider, b.provider)
-    || modelNameCollator.compare(a.id, b.id);
-}
-
-async function loadModels(cwd: string): Promise<ModelsData> {
-  const nameMap = new Map<string, string>();
-  let modelList: { id: string; name: string; provider: string }[] = [];
-  let defaultModel: { provider: string; modelId: string } | null = null;
-  const thinkingLevels: Record<string, string[]> = {};
-  const thinkingLevelMaps: Record<string, Record<string, string | null>> = {};
-
-  const agentDir = getAgentDir();
-  // Gate untrusted project extensions: enumerating models still imports and
-  // runs a repository's .pi/extensions factories, so honor project trust here
-  // too (see lib/project-trust.ts, #236).
-  const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
-  const services = await createAgentSessionServices({
-    cwd,
-    agentDir,
-    ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
-  });
-  const modelError = services.modelRuntime.getError();
-  const settings: SettingsManager = services.settingsManager;
-  // `enabledModels` supports globs and fuzzy patterns, so resolve it the same
-  // way the CLI does instead of comparing pattern strings literally (#307).
-  const scope = await resolveVisibleModels(
-    services.modelRuntime,
-    settings.getEnabledModels(),
-  );
-  const { visible, thinkingLevelPins, warnings } = scope;
-  modelList = visible.map((m) => ({
-    id: m.id,
-    name: m.name,
-    provider: m.provider,
-  })).sort(compareModelEntries);
-  for (const m of visible) {
-    const key = `${m.provider}:${m.id}`;
-    nameMap.set(key, m.name);
-    thinkingLevels[key] = getSupportedThinkingLevels(m);
-    if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
-  }
-
-  const defaultProvider = settings.getDefaultProvider();
-  const defaultModelId = settings.getDefaultModel();
-  const initial = selectInitialModelScope(scope, {
-    ...(defaultProvider && defaultModelId
-      ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
-      : {}),
-  });
-  if (initial.model) {
-    defaultModel = { provider: initial.model.provider, modelId: initial.model.id };
-  }
-
-  return withModelRuntimeError(
-    {
-      models: Object.fromEntries(nameMap),
-      modelList,
-      defaultModel,
-      thinkingLevels,
-      thinkingLevelMaps,
-      thinkingLevelPins,
-      ...(warnings.length > 0 ? { modelScopeWarnings: warnings } : {}),
-    },
-    modelError,
-  );
-}
 
 const EMPTY_MODELS: ModelsData = {
   models: {},

--- a/app/api/sessions/[id]/context/route.ts
+++ b/app/api/sessions/[id]/context/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { resolveSessionPath, buildSessionContext } from "@/lib/session-reader";
+import { loadModelsWithCache } from "@/lib/models-cache";
+import { loadModels } from "@/lib/models-loader";
+import { computeSessionContextUsage } from "@/lib/context-usage";
 
 export async function GET(
   req: Request,
@@ -24,7 +27,14 @@ export async function GET(
       deferToolResultImages,
     });
 
-    return NextResponse.json({ context });
+    let contextUsage = null;
+    try {
+      const cwd = sm.getCwd();
+      const modelsData = await loadModelsWithCache(cwd, () => loadModels(cwd));
+      contextUsage = computeSessionContextUsage(sm as never, leafId, modelsData);
+    } catch { /* usage is best-effort; never fail the context response */ }
+
+    return NextResponse.json({ context, contextUsage });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
   }

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -12,6 +12,9 @@ import {
 } from "@/lib/session-reader";
 import { sessionPathKey } from "@/lib/session-path";
 import { getRpcSession } from "@/lib/rpc-manager";
+import { loadModelsWithCache } from "@/lib/models-cache";
+import { loadModels } from "@/lib/models-loader";
+import { computeSessionContextUsage } from "@/lib/context-usage";
 import { computeSessionTotalActiveMs } from "@/lib/session-timing";
 
 // BranchNavigator still traverses recursively, so keep the response tree shallow.
@@ -135,6 +138,13 @@ export async function GET(
     const context = buildSessionContext(entries as never, leafId, { deferThinking, deferToolResultImages });
     const totalActiveMs = computeSessionTotalActiveMs(entries);
 
+    let contextUsage = null;
+    try {
+      const cwd = sm.getCwd();
+      const modelsData = await loadModelsWithCache(cwd, () => loadModels(cwd));
+      contextUsage = computeSessionContextUsage(sm as never, leafId ?? undefined, modelsData);
+    } catch { /* usage is best-effort; never fail the detail response */ }
+
     const header = sm.getHeader();
     let modified = header?.timestamp ?? new Date().toISOString();
     try { modified = statSync(filePath).mtime.toISOString(); } catch { /* use header timestamp */ }
@@ -166,6 +176,7 @@ export async function GET(
       leafId,
       tree,
       context,
+      contextUsage,
       totalActiveMs,
     });
   } catch (error) {

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { useViewportHeight } from "@/hooks/useViewportHeight";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { useAudio } from "@/hooks/useAudio";
+import { sendAgentCommand } from "@/lib/agent-client";
 import { copyText } from "@/lib/clipboard";
 import { getFileName } from "@/lib/file-paths";
 import { buildAtMentionText, buildFileAtMentionsText, buildFileLineMentionText } from "@/lib/file-fuzzy";
@@ -183,6 +184,7 @@ export function AppShell() {
   }, []);
 
   const [systemPrompt, setSystemPrompt] = useState<string | null>(null);
+  const [systemPromptLoading, setSystemPromptLoading] = useState(false);
   const systemBtnRef = useRef<HTMLButtonElement>(null);
 
   const handleSystemPromptChange = useCallback((prompt: string | null) => {
@@ -229,6 +231,23 @@ export function AppShell() {
     if (isMobile) setSidebarOpen(false);
     setActiveTopPanel((cur) => cur === panel ? null : panel);
   }, [isMobile]);
+
+  // System panel: lazily start the RPC session to fetch the real system prompt
+  const handleSystemToggle = useCallback(() => {
+    const opening = activeTopPanel !== "system";
+    toggleTopPanel("system");
+    const sid = selectedSession?.id;
+    if (!opening || systemPrompt !== null || systemPromptLoading || !sid) return;
+    setSystemPromptLoading(true);
+    sendAgentCommand<{ systemPrompt?: string; contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null }>(sid, { type: "get_state" })
+      .then((state) => {
+        if (activeSessionIdRef.current !== sid) return;
+        if (state?.systemPrompt !== undefined) setSystemPrompt(state.systemPrompt ?? null);
+        if (state?.contextUsage !== undefined) setContextUsage(state.contextUsage ?? null);
+      })
+      .catch(() => {})
+      .finally(() => setSystemPromptLoading(false));
+  }, [activeTopPanel, systemPrompt, systemPromptLoading, selectedSession?.id, toggleTopPanel]);
 
   const openSessionStatsPanel = useCallback(() => {
     if (isMobile) setSidebarOpen(false);
@@ -1272,7 +1291,7 @@ export function AppShell() {
               />
               <button
                 ref={systemBtnRef}
-                onClick={() => toggleTopPanel("system")}
+                onClick={handleSystemToggle}
                  title={translate("system.prompt")}
                  aria-label={translate("system.prompt")}
                 aria-pressed={activeTopPanel === "system"}
@@ -1474,6 +1493,10 @@ export function AppShell() {
                   ) : systemPrompt === "" ? (
                     <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-muted)", fontStyle: "italic" }}>
                        {translate("system.empty")}
+                    </div>
+                  ) : systemPromptLoading ? (
+                    <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-muted)", fontStyle: "italic" }}>
+                      {translate("system.loading")}
                     </div>
                   ) : (
                     <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--text-muted)", fontStyle: "italic" }}>

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -317,3 +317,13 @@ test("sizes the message tail from the rendered bottom composer", () => {
   assert.match(chatWindowSource, /<div ref=\{bottomComposerRef\} className="relative">/);
   assert.match(chatWindowSource, /height: bottomComposerHeight/);
 });
+
+test("loadSession and loadContext consume file-derived contextUsage", () => {
+  const loadSessionSource = source.slice(source.indexOf("const loadSession"), source.indexOf("const loadTools"));
+  const loadContextSource = source.slice(source.indexOf("const loadContext"), source.indexOf("const loadTools"));
+
+  assert.match(loadSessionSource, /d\.contextUsage !== undefined/);
+  assert.match(loadSessionSource, /setContextUsage\(d\.contextUsage\)/);
+  assert.match(loadContextSource, /d\.contextUsage !== undefined/);
+  assert.match(loadContextSource, /setContextUsage\(d\.contextUsage/);
+});

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -35,6 +35,7 @@ export interface SessionData {
     thinkingLevel: string;
     model: { provider: string; modelId: string } | null;
   };
+  contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null;
 }
 
 interface AgentEvent {
@@ -477,6 +478,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setActiveLeafId(d.leafId);
       setMessages(persistedMessages);
       setEntryIds(d.context.entryIds ?? []);
+      if (d.contextUsage !== undefined) setContextUsage(d.contextUsage);
       setCurrentModelOverride((current) => modelSwitchPendingRef.current ? current : null);
       setError(null);
       if (d.context.thinkingLevel && d.context.thinkingLevel !== "off") {
@@ -524,9 +526,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const url = `/api/sessions/${encodeURIComponent(sid)}/context?${params}`;
       const res = await fetch(url);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = await res.json() as { context: { messages: AgentMessage[]; entryIds: string[] } };
+      const d = await res.json() as { context: { messages: AgentMessage[]; entryIds: string[] }; contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null };
       setMessages(d.context.messages);
       setEntryIds(d.context.entryIds ?? []);
+      if (d.contextUsage !== undefined) setContextUsage(d.contextUsage ?? null);
     } catch (e) {
       console.error("Failed to load context:", e);
     }

--- a/lib/context-usage.test.mjs
+++ b/lib/context-usage.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { computeFileContextUsage, computeSessionContextUsage } = await jiti.import("./context-usage.ts");
+
+function createTempManager(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-web-context-usage-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const manager = SessionManager.create(dir, dir);
+  manager.newSession();
+  return manager;
+}
+
+const userMsg = (text) => ({ role: "user", content: text, timestamp: 1 });
+const assistantMsg = (totalTokens) => ({
+  role: "assistant",
+  content: [{ type: "text", text: "answer" }],
+  stopReason: "stop",
+  usage: { input: totalTokens - 5, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens, cost: { total: 0 } },
+  timestamp: 2,
+});
+
+test("no compaction: tokens = last assistant usage + trailing estimate", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  m.appendMessage(assistantMsg(1000));
+
+  const exact = computeFileContextUsage(m, undefined, 200000);
+  assert.equal(exact.tokens, 1000);
+  assert.equal(exact.contextWindow, 200000);
+  assert.equal(exact.percent, 0.5);
+
+  m.appendMessage(userMsg("hello again"));
+  const withTrailing = computeFileContextUsage(m, undefined, 200000);
+  assert.ok(withTrailing.tokens > 1000, "trailing user message adds estimated tokens");
+  assert.equal(withTrailing.percent, (withTrailing.tokens / 200000) * 100);
+});
+
+test("compaction without post-compaction usage yields null tokens", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  const a1 = m.appendMessage(assistantMsg(50000));
+  m.appendCompaction("summary", a1, 50000);
+
+  const usage = computeFileContextUsage(m, undefined, 200000);
+  assert.equal(usage.tokens, null);
+  assert.equal(usage.percent, null);
+  assert.equal(usage.contextWindow, 200000);
+});
+
+test("compaction followed by fresh usage computes normally", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  const a1 = m.appendMessage(assistantMsg(50000));
+  m.appendCompaction("summary", a1, 50000);
+  m.appendMessage(userMsg("next"));
+  m.appendMessage(assistantMsg(3000));
+
+  const usage = computeFileContextUsage(m, undefined, 200000);
+  assert.equal(usage.tokens, 3000);
+  assert.equal(usage.percent, 1.5);
+});
+
+test("missing or zero contextWindow returns null", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  m.appendMessage(assistantMsg(1000));
+
+  assert.equal(computeFileContextUsage(m, undefined, undefined), null);
+  assert.equal(computeFileContextUsage(m, undefined, 0), null);
+});
+
+test("aborted trailing assistant message with a toolCall block estimates without crashing", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  m.appendMessage(assistantMsg(1000));
+  // Aborted mid-tool-call turn, raw on-disk SDK shape (name/arguments).
+  m.appendMessage({
+    role: "assistant",
+    content: [{ type: "toolCall", id: "t1", name: "bash", arguments: {} }],
+    stopReason: "aborted",
+    timestamp: 3,
+  });
+
+  const usage = computeFileContextUsage(m, undefined, 200000);
+  assert.equal(typeof usage.tokens, "number");
+  assert.ok(usage.tokens > 1000, "trailing aborted toolCall adds estimated tokens");
+});
+
+test("computeSessionContextUsage resolves the branch model from a model_change entry", (t) => {
+  const m = createTempManager(t);
+  m.appendMessage(userMsg("hello"));
+  m.appendModelChange("p1", "m1");
+  m.appendMessage(userMsg("still on p1/m1"));
+
+  const usage = computeSessionContextUsage(m, undefined, {
+    modelList: [
+      { provider: "p0", id: "m0", contextWindow: 999999 },
+      { provider: "p1", id: "m1", contextWindow: 123456 },
+    ],
+    defaultModel: { provider: "p0", modelId: "m0" },
+  });
+  assert.equal(usage.contextWindow, 123456);
+  assert.equal(typeof usage.tokens, "number");
+});
+
+test("session routes wire offline context usage via the shared models cache", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const detailSource = await readFile(new URL("../app/api/sessions/[id]/route.ts", import.meta.url), "utf8");
+  const contextSource = await readFile(new URL("../app/api/sessions/[id]/context/route.ts", import.meta.url), "utf8");
+  const modelsRouteSource = await readFile(new URL("../app/api/models/route.ts", import.meta.url), "utf8");
+
+  for (const source of [detailSource, contextSource]) {
+    assert.match(source, /computeSessionContextUsage\(/);
+    assert.match(source, /loadModelsWithCache\(/);
+  }
+  assert.match(modelsRouteSource, /from "@\/lib\/models-loader"/);
+  assert.match(modelsRouteSource, /loadModelsWithCache\(cwd, \(\) => loadModels\(cwd\)\)/);
+});

--- a/lib/context-usage.ts
+++ b/lib/context-usage.ts
@@ -1,0 +1,131 @@
+/**
+ * Offline context-usage estimation for session files on disk.
+ * Mirrors AgentSession.getContextUsage() (pi SDK) without starting a session:
+ * same compaction gate, same last-valid-usage + trailing-estimate formula.
+ *
+ * Estimation runs over the SDK's own buildSessionContext output — raw
+ * `name`/`arguments` toolCall fields that estimateTokens can read. The
+ * UI-converted messages from session-reader rename those fields and crash it.
+ */
+import {
+  buildSessionContext as piBuildSessionContext,
+  calculateContextTokens,
+  estimateTokens,
+  getLatestCompactionEntry,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  SessionContext as PiSessionContext,
+  SessionEntry as PiSessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import type { SessionEntry } from "./types";
+
+/** Structural subset of the SDK SessionManager this module needs. */
+export interface ContextUsageSource {
+  getEntries(): SessionEntry[];
+  getBranch(fromId?: string): SessionEntry[];
+}
+
+export interface FileContextUsage {
+  percent: number | null;
+  contextWindow: number;
+  tokens: number | null;
+}
+
+interface UsageLike {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens?: number;
+}
+
+function validAssistantUsage(message: unknown): UsageLike | undefined {
+  const msg = message as { role?: string; stopReason?: string; usage?: UsageLike };
+  if (msg.role !== "assistant") return undefined;
+  if (msg.stopReason === "aborted" || msg.stopReason === "error") return undefined;
+  if (!msg.usage) return undefined;
+  return calculateContextTokens(msg.usage as never) > 0 ? msg.usage : undefined;
+}
+
+/**
+ * SDK-shaped context for the active branch: messages safe for estimateTokens,
+ * plus the branch-scoped current model (model_change entries and assistant
+ * messages along the branch only — not other branches).
+ */
+function buildBranchContext(sm: ContextUsageSource, leafId: string | undefined): PiSessionContext {
+  const entries = sm.getEntries() as unknown as PiSessionEntry[];
+  const byId = new Map<string, PiSessionEntry>();
+  for (const e of entries) byId.set(e.id, e);
+  return piBuildSessionContext(entries, leafId, byId);
+}
+
+function usageForBranch(
+  sm: ContextUsageSource,
+  leafId: string | undefined,
+  contextWindow: number | undefined,
+  branch: PiSessionContext,
+): FileContextUsage | null {
+  if (!contextWindow || contextWindow <= 0) return null;
+
+  // Compaction gate: after compaction, pre-compaction usage is meaningless
+  const branchEntries = sm.getBranch(leafId);
+  const latestCompaction = getLatestCompactionEntry(branchEntries as never);
+  if (latestCompaction) {
+    const compactionIndex = branchEntries.lastIndexOf(latestCompaction as never);
+    let hasPostCompactionUsage = false;
+    for (let i = branchEntries.length - 1; i > compactionIndex; i--) {
+      const entry = branchEntries[i];
+      if (entry.type === "message" && validAssistantUsage(entry.message)) {
+        hasPostCompactionUsage = true;
+        break;
+      }
+    }
+    if (!hasPostCompactionUsage) {
+      return { tokens: null, contextWindow, percent: null };
+    }
+  }
+
+  // Last valid assistant usage + estimated trailing messages (same as SDK)
+  const { messages } = branch;
+  let lastUsageIndex = -1;
+  let usageTokens = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const usage = validAssistantUsage(messages[i]);
+    if (usage) {
+      lastUsageIndex = i;
+      usageTokens = calculateContextTokens(usage as never);
+      break;
+    }
+  }
+  let trailingTokens = 0;
+  for (let i = lastUsageIndex + 1; i < messages.length; i++) {
+    trailingTokens += estimateTokens(messages[i]);
+  }
+  const tokens = usageTokens + trailingTokens;
+  return { tokens, contextWindow, percent: (tokens / contextWindow) * 100 };
+}
+
+export function computeFileContextUsage(
+  sm: ContextUsageSource,
+  leafId: string | undefined,
+  contextWindow: number | undefined,
+): FileContextUsage | null {
+  return usageForBranch(sm, leafId, contextWindow, buildBranchContext(sm, leafId));
+}
+
+/** Resolve the branch's current model (else default) and compute usage. */
+export function computeSessionContextUsage(
+  sm: ContextUsageSource,
+  leafId: string | undefined,
+  modelsData: {
+    modelList: { provider: string; id: string; contextWindow?: number }[];
+    defaultModel: { provider: string; modelId: string } | null;
+  },
+): FileContextUsage | null {
+  const branch = buildBranchContext(sm, leafId);
+  const modelRef = branch.model ?? modelsData.defaultModel ?? undefined;
+  const contextWindow = modelRef
+    ? modelsData.modelList.find((m) => m.provider === modelRef.provider && m.id === modelRef.modelId)?.contextWindow
+    : undefined;
+  return usageForBranch(sm, leafId, contextWindow, branch);
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -29,6 +29,7 @@ export const enLocale: LocalePlugin = {
     "system.prompt": "System prompt",
     "system.empty": "System prompt is empty (tools are disabled)",
     "system.load": "Send a message to load the system prompt",
+    "system.loading": "Loading system prompt…",
     "system.label": "System",
     "session.info": "Session info",
     "session.name": "Name",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -29,6 +29,7 @@ export const zhCNLocale: LocalePlugin = {
     "system.prompt": "系统提示词",
     "system.empty": "系统提示词为空（工具已禁用）",
     "system.load": "发送消息以加载系统提示词",
+    "system.loading": "正在加载系统提示词…",
     "system.label": "系统",
     "session.info": "会话信息",
     "session.name": "名称",

--- a/lib/models-cache.ts
+++ b/lib/models-cache.ts
@@ -1,6 +1,6 @@
 export interface ModelsData {
   models: Record<string, string>;
-  modelList: { id: string; name: string; provider: string }[];
+  modelList: { id: string; name: string; provider: string; contextWindow?: number }[];
   defaultModel: { provider: string; modelId: string } | null;
   thinkingLevels: Record<string, string[]>;
   thinkingLevelMaps: Record<string, Record<string, string | null>>;

--- a/lib/models-loader.ts
+++ b/lib/models-loader.ts
@@ -1,0 +1,80 @@
+import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { withModelRuntimeError, type ModelsData } from "@/lib/models-cache";
+import { resolveVisibleModels, selectInitialModelScope } from "@/lib/model-scope";
+import { projectTrustReloadOptions } from "@/lib/project-trust";
+
+const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
+function compareModelEntries(
+  a: { id: string; name: string; provider: string },
+  b: { id: string; name: string; provider: string }
+): number {
+  return modelNameCollator.compare(a.name || a.id, b.name || b.id)
+    || modelNameCollator.compare(a.provider, b.provider)
+    || modelNameCollator.compare(a.id, b.id);
+}
+
+export async function loadModels(cwd: string): Promise<ModelsData> {
+  const nameMap = new Map<string, string>();
+  let modelList: { id: string; name: string; provider: string; contextWindow?: number }[] = [];
+  let defaultModel: { provider: string; modelId: string } | null = null;
+  const thinkingLevels: Record<string, string[]> = {};
+  const thinkingLevelMaps: Record<string, Record<string, string | null>> = {};
+
+  const agentDir = getAgentDir();
+  // Gate untrusted project extensions: enumerating models still imports and
+  // runs a repository's .pi/extensions factories, so honor project trust here
+  // too (see lib/project-trust.ts, #236).
+  const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
+  const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
+  });
+  const modelError = services.modelRuntime.getError();
+  const settings: SettingsManager = services.settingsManager;
+  // `enabledModels` supports globs and fuzzy patterns, so resolve it the same
+  // way the CLI does instead of comparing pattern strings literally (#307).
+  const scope = await resolveVisibleModels(
+    services.modelRuntime,
+    settings.getEnabledModels(),
+  );
+  const { visible, thinkingLevelPins, warnings } = scope;
+  modelList = visible.map((m) => ({
+    id: m.id,
+    name: m.name,
+    provider: m.provider,
+    contextWindow: m.contextWindow,
+  })).sort(compareModelEntries);
+  for (const m of visible) {
+    const key = `${m.provider}:${m.id}`;
+    nameMap.set(key, m.name);
+    thinkingLevels[key] = getSupportedThinkingLevels(m);
+    if (m.thinkingLevelMap) thinkingLevelMaps[key] = m.thinkingLevelMap;
+  }
+
+  const defaultProvider = settings.getDefaultProvider();
+  const defaultModelId = settings.getDefaultModel();
+  const initial = selectInitialModelScope(scope, {
+    ...(defaultProvider && defaultModelId
+      ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
+      : {}),
+  });
+  if (initial.model) {
+    defaultModel = { provider: initial.model.provider, modelId: initial.model.id };
+  }
+
+  return withModelRuntimeError(
+    {
+      models: Object.fromEntries(nameMap),
+      modelList,
+      defaultModel,
+      thinkingLevels,
+      thinkingLevelMaps,
+      thinkingLevelPins,
+      ...(warnings.length > 0 ? { modelScopeWarnings: warnings } : {}),
+    },
+    modelError,
+  );
+}

--- a/lib/project-trust.test.mjs
+++ b/lib/project-trust.test.mjs
@@ -76,7 +76,7 @@ test("the reload resolver reads the latest persisted trust decision", async (t) 
 
 test("all project resource loaders and reloads enforce project trust", async () => {
   const rpcSource = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
-  const modelsSource = await readFile(new URL("../app/api/models/route.ts", import.meta.url), "utf8");
+  const modelsSource = await readFile(new URL("./models-loader.ts", import.meta.url), "utf8");
   const skillsSource = await readFile(new URL("./skills-service.ts", import.meta.url), "utf8");
   const skillsInstallSource = await readFile(new URL("../app/api/skills/install/route.ts", import.meta.url), "utf8");
   const pluginsSource = await readFile(new URL("../app/api/plugins/route.ts", import.meta.url), "utf8");


### PR DESCRIPTION
## What

Estimates a session's context-window usage (percent + token counts) by reading the session `.jsonl` file directly — no live AgentSession required — and serves it from the session API routes:

- `GET /api/sessions/[id]` and `GET /api/sessions/[id]/context?leafId=` responses gain a best-effort `contextUsage` field (failures never fail the response)
- The hook consumes file-derived `contextUsage` on session/context load, so non-running sessions show usage immediately; the system-prompt panel is loaded on demand via `get_state` and refreshes live usage
- Extracts the inline model loading from `/api/models` into `lib/models-loader.ts` (shared, adds `contextWindow` to `modelList`) since the estimator needs model context windows

## Notes

- Purely additive to server responses; no UI behavior changes for running sessions.
- 9 new tests (7 lib + 1 hook + 1 route-wiring). Full suite: 432 pass / 0 fail; `tsc --noEmit` and eslint clean.
- Heads-up: this touches `app/api/sessions/[id]/route.ts` imports/response, as does the companion branch-labels PR — the second one to land may need a trivial rebase.