### PR TITLE
feat: click-to-preview for images in chat messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -479,6 +479,81 @@ pre, code {
   outline-offset: -2px;
 }
 
+.image-preview-dialog {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  max-width: none;
+  height: 100dvh;
+  max-height: none;
+  margin: 0;
+  padding-top: max(16px, env(safe-area-inset-top));
+  padding-right: max(16px, env(safe-area-inset-right));
+  padding-bottom: max(16px, env(safe-area-inset-bottom));
+  padding-left: max(16px, env(safe-area-inset-left));
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.image-preview-dialog[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-preview-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.72);
+}
+
+.image-preview-image {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.image-preview-close {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: max(12px, env(safe-area-inset-right));
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background-color 0.12s, color 0.12s;
+}
+
+.image-preview-close:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.image-preview-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (pointer: coarse) {
+  .image-preview-close {
+    width: 44px;
+    height: 44px;
+  }
+}
+
 .mermaid-zoom-dialog {
   width: 100vw;
   max-width: none;

--- a/components/ImagePreview.test.mjs
+++ b/components/ImagePreview.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./ImagePreview.tsx", import.meta.url), "utf8");
+
+test("Escape closes image preview without reaching global shortcuts", () => {
+  assert.match(
+    source,
+    /event\.key !== "Escape"[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?setOpen\(false\)/,
+  );
+});

--- a/components/ImagePreview.test.mjs
+++ b/components/ImagePreview.test.mjs
@@ -3,10 +3,44 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./ImagePreview.tsx", import.meta.url), "utf8");
+const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+
+test("uses a native modal dialog and restores focus to its trigger", () => {
+  assert.match(source, /useRef<HTMLDialogElement>\(null\)/);
+  assert.match(source, /dialog\.showModal\(\)/);
+  assert.match(source, /closeButtonRef\.current\?\.focus\(\{ preventScroll: true \}\)/);
+  assert.match(source, /const trigger = triggerRef\.current[\s\S]*?trigger\?\.isConnected[\s\S]*?trigger\.focus\(\{ preventScroll: true \}\)/);
+  assert.doesNotMatch(source, /createPortal/);
+});
 
 test("Escape closes image preview without reaching global shortcuts", () => {
   assert.match(
     source,
-    /event\.key !== "Escape"[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?setOpen\(false\)/,
+    /const closePreview = \(\) => \{[\s\S]*?dialogRef\.current\?\.open[\s\S]*?dialogRef\.current\.close\(\)[\s\S]*?setOpen\(false\)/,
   );
+  assert.match(
+    source,
+    /event\.key !== "Escape"[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?closePreview\(\)/,
+  );
+  assert.match(
+    source,
+    /onCancel=\{\(event\) => \{[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?closePreview\(\)/,
+  );
+});
+
+test("closes only when the backdrop itself is clicked", () => {
+  assert.match(source, /event\.target === event\.currentTarget[\s\S]*?closePreview\(\)/);
+});
+
+test("keeps the preview and Pi-style close button inside mobile safe areas", () => {
+  assert.match(
+    cssSource,
+    /\.image-preview-dialog \{[\s\S]*?env\(safe-area-inset-top\)[\s\S]*?env\(safe-area-inset-right\)[\s\S]*?env\(safe-area-inset-bottom\)[\s\S]*?env\(safe-area-inset-left\)/,
+  );
+  assert.match(
+    cssSource,
+    /\.image-preview-close \{[\s\S]*?top: max\(12px, env\(safe-area-inset-top\)\)[\s\S]*?right: max\(12px, env\(safe-area-inset-right\)\)[\s\S]*?border-radius: 6px[\s\S]*?background: var\(--bg-panel\)/,
+  );
+  assert.match(cssSource, /@media \(pointer: coarse\) \{[\s\S]*?\.image-preview-close \{[\s\S]*?width: 44px;[\s\S]*?height: 44px;/);
+  assert.match(source, /<path d="M6 6l12 12M18 6 6 18" \/>/);
 });

--- a/components/ImagePreview.tsx
+++ b/components/ImagePreview.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { useI18n } from "@/hooks/useI18n";
 
 interface ImagePreviewProps {
@@ -15,27 +14,39 @@ interface ImagePreviewProps {
 export function ImagePreview({ src, alt = "", children, className, style }: ImagePreviewProps) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setPortalTarget(document.body);
-  }, []);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      event.stopPropagation();
-      setOpen(false);
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const trigger = triggerRef.current;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    dialog.showModal();
+    closeButtonRef.current?.focus({ preventScroll: true });
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (dialog.open) dialog.close();
+      if (trigger?.isConnected) {
+        trigger.focus({ preventScroll: true });
+      }
     };
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => document.removeEventListener("keydown", onKeyDown, true);
   }, [open]);
+
+  const closePreview = () => {
+    if (dialogRef.current?.open) dialogRef.current.close();
+    setOpen(false);
+  };
 
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         className={className}
         style={{
@@ -49,66 +60,47 @@ export function ImagePreview({ src, alt = "", children, className, style }: Imag
         }}
         onClick={() => setOpen(true)}
         aria-label={t("chat.previewImage")}
+        aria-haspopup="dialog"
+        aria-expanded={open}
         title={t("chat.previewImage")}
       >
         {children}
       </button>
-      {open && portalTarget && createPortal(
-        <div
-          role="dialog"
-          aria-modal="true"
+      {open && (
+        <dialog
+          ref={dialogRef}
+          className="image-preview-dialog"
           aria-label={t("chat.previewImage")}
-          onClick={(event) => {
-            if (event.target === event.currentTarget) setOpen(false);
+          onCancel={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            closePreview();
           }}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 1100,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: 16,
-            background: "rgba(0, 0, 0, 0.72)",
+          onKeyDown={(event) => {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            event.stopPropagation();
+            closePreview();
+          }}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) closePreview();
           }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={src}
-            alt={alt}
-            style={{
-              display: "block",
-              maxWidth: "100%",
-              maxHeight: "100%",
-              objectFit: "contain",
-              borderRadius: 8,
-              boxShadow: "0 20px 60px rgba(0, 0, 0, 0.4)",
-            }}
-          />
+          <img className="image-preview-image" src={src} alt={alt} />
           <button
+            ref={closeButtonRef}
             type="button"
-            onClick={() => setOpen(false)}
+            className="image-preview-close"
+            onClick={closePreview}
             aria-label={t("chat.close")}
             title={t("chat.close")}
-            style={{
-              position: "absolute",
-              top: 16,
-              right: 16,
-              width: 34,
-              height: 34,
-              border: "1px solid rgba(255, 255, 255, 0.5)",
-              borderRadius: "50%",
-              background: "rgba(0, 0, 0, 0.45)",
-              color: "#fff",
-              cursor: "pointer",
-              fontSize: 24,
-              lineHeight: 1,
-            }}
           >
-            ×
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+              <path d="M6 6l12 12M18 6 6 18" />
+            </svg>
           </button>
-        </div>,
-        portalTarget,
+        </dialog>
       )}
     </>
   );

--- a/components/ImagePreview.tsx
+++ b/components/ImagePreview.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useI18n } from "@/hooks/useI18n";
+
+interface ImagePreviewProps {
+  src: string;
+  alt?: string;
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function ImagePreview({ src, alt = "", children, className, style }: ImagePreviewProps) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(document.body);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={className}
+        style={{
+          display: "block",
+          padding: 0,
+          border: "none",
+          background: "none",
+          color: "inherit",
+          cursor: "zoom-in",
+          ...style,
+        }}
+        onClick={() => setOpen(true)}
+        aria-label={t("chat.previewImage")}
+        title={t("chat.previewImage")}
+      >
+        {children}
+      </button>
+      {open && portalTarget && createPortal(
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("chat.previewImage")}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) setOpen(false);
+          }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1100,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 16,
+            background: "rgba(0, 0, 0, 0.72)",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={alt}
+            style={{
+              display: "block",
+              maxWidth: "100%",
+              maxHeight: "100%",
+              objectFit: "contain",
+              borderRadius: 8,
+              boxShadow: "0 20px 60px rgba(0, 0, 0, 0.4)",
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label={t("chat.close")}
+            title={t("chat.close")}
+            style={{
+              position: "absolute",
+              top: 16,
+              right: 16,
+              width: 34,
+              height: 34,
+              border: "1px solid rgba(255, 255, 255, 0.5)",
+              borderRadius: "50%",
+              background: "rgba(0, 0, 0, 0.45)",
+              color: "#fff",
+              cursor: "pointer",
+              fontSize: 24,
+              lineHeight: 1,
+            }}
+          >
+            ×
+          </button>
+        </div>,
+        portalTarget,
+      )}
+    </>
+  );
+}

--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -95,3 +95,29 @@ test("keeps attached images when restoring a compact command for editing", () =>
     image,
   ]);
 });
+
+test("renders user-message images as buttons that open a larger preview", () => {
+  const html = renderMessage({
+    role: "user",
+    content: [
+      { type: "text", text: "inspect this" },
+      { type: "image", data: "YWJj", mimeType: "image/png" },
+    ],
+    timestamp: Date.now(),
+  });
+
+  assert.match(html, /<button[^>]+aria-label="Preview image"[^>]*>/);
+  assert.match(html, /<img[^>]+src="data:image\/png;base64,YWJj"/);
+});
+
+test("renders custom-message images as buttons that open a larger preview", () => {
+  const html = renderMessage({
+    role: "custom",
+    customType: "extension",
+    content: [{ type: "image", data: "YWJj", mimeType: "image/png" }],
+    timestamp: Date.now(),
+  });
+
+  assert.match(html, /<button[^>]+aria-label="Preview image"[^>]*>/);
+  assert.match(html, /<img[^>]+src="data:image\/png;base64,YWJj"/);
+});

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useState, useRef, useEffect, useMemo } from "react";
 import { MarkdownBody } from "./MarkdownBody";
+import { ImagePreview } from "./ImagePreview";
 import { copyText } from "@/lib/clipboard";
 import { useI18n } from "@/hooks/useI18n";
 import { parseCompactionSummary } from "@/lib/compaction-summary";
@@ -290,13 +291,14 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
             ? `data:${flat.mimeType};base64,${flat.data}`
             : "";
         return (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            key={i}
-            src={src}
-            alt=""
-            style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid rgba(59,130,246,0.15)" }}
-          />
+          <ImagePreview key={i} src={src}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt=""
+              style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid rgba(59,130,246,0.15)" }}
+            />
+          </ImagePreview>
         );
       })}
     </div>
@@ -1392,13 +1394,14 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
                   const src = imageSource(img);
                   if (!src) return null;
                   return (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      key={i}
-                      src={src}
-                      alt=""
-                      style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid var(--border)" }}
-                    />
+                    <ImagePreview key={i} src={src}>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={src}
+                        alt=""
+                        style={{ maxWidth: 240, maxHeight: 240, borderRadius: 6, objectFit: "contain", display: "block", border: "1px solid var(--border)" }}
+                      />
+                    </ImagePreview>
                   );
                 })}
               </div>

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -205,6 +205,7 @@ export const enLocale: LocalePlugin = {
     "chat.followUp": "Follow-up",
     "chat.send": "Send",
     "chat.attachImage": "Attach image",
+    "chat.previewImage": "Preview image",
     "chat.filterModels": "Filter models…",
     "chat.noMatchingModels": "No matching models",
     "chat.moreControls": "More controls",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -205,6 +205,7 @@ export const zhCNLocale: LocalePlugin = {
     "chat.followUp": "后续消息",
     "chat.send": "发送",
     "chat.attachImage": "附加图片",
+    "chat.previewImage": "预览图片",
     "chat.filterModels": "筛选模型…",
     "chat.noMatchingModels": "没有匹配的模型",
     "chat.moreControls": "更多控件",


### PR DESCRIPTION
## What

Wraps images in user and custom chat messages with a button that opens a larger preview, instead of bare `<img>` tags. The preview uses a native `<dialog>` so focus stays inside the modal and returns to the thumbnail when it closes. Escape, backdrop click, and the close button all dismiss it without reaching Pi Web's global shortcuts.

The close control now matches Pi Web's square icon-button styling, expands to a 44px touch target on coarse pointers, and respects iOS safe-area insets together with the preview image.

## Notes

- 6 new tests cover both message wiring sites plus modal lifecycle, Escape propagation, backdrop behavior, focus restoration, safe-area layout, and close-button styling.
- Full suite: 430 pass / 0 fail; `tsc --noEmit` and ESLint clean.
- Browser QA passed at desktop and 390px mobile viewports.