### PR TITLE
fix: custom headers and compat for custom models

### DIFF
--- a/components/ModelsConfig.test.mjs
+++ b/components/ModelsConfig.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./ModelsConfig.tsx", import.meta.url), "utf8");
+
+test("custom model config exposes provider-level request headers", () => {
+  const providerDetail = source.slice(
+    source.indexOf("function ProviderDetail"),
+    source.indexOf("// ── ThinkingLevelMap editor"),
+  );
+  assert.match(providerDetail, /<HeaderListEditor/);
+  assert.match(providerDetail, /headers=\{provider\.headers\}/);
+  assert.match(providerDetail, /set\("headers", headers\)/);
+});
+
+test("custom model config exposes model headers and supportsDeveloperRole compat flag", () => {
+  // Model-level headers editor, wired to the model entry.
+  assert.match(source, /headers=\{model\.headers\}/);
+  assert.match(source, /set\("headers", headers\)/);
+
+  // Model-level compat toggle reads the effective (provider+model) value so
+  // hand-edited models.json settings are reflected, while writes stay on the
+  // model entry as an explicit per-model override.
+  assert.match(source, /effectiveCompat\(provider, model\)\["supportsDeveloperRole"\] !== false/);
+  assert.match(source, /setCompatBool\(model, "supportsDeveloperRole", v\)/);
+});

--- a/components/ModelsConfig.test.mjs
+++ b/components/ModelsConfig.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+const {
+  serializeHeaderRows,
+  setCompatBool,
+  updateHeaderRow,
+} = await jiti.import("./models-config-helpers.ts");
 
 const source = await readFile(new URL("./ModelsConfig.tsx", import.meta.url), "utf8");
 
@@ -24,4 +32,41 @@ test("custom model config exposes model headers and supportsDeveloperRole compat
   // model entry as an explicit per-model override.
   assert.match(source, /effectiveCompat\(provider, model\)\["supportsDeveloperRole"\] !== false/);
   assert.match(source, /setCompatBool\(model, "supportsDeveloperRole", v\)/);
+});
+
+test("disabling the developer role writes an explicit false override", () => {
+  assert.deepEqual(
+    setCompatBool({ compat: { supportsStore: true } }, "supportsDeveloperRole", false),
+    { compat: { supportsStore: true, supportsDeveloperRole: false } },
+  );
+});
+
+test("editing a header preserves row order and stable identities", () => {
+  const rows = [
+    { id: 10, name: "X-First", value: "one" },
+    { id: 11, name: "X-Second", value: "two" },
+  ];
+  const updated = updateHeaderRow(rows, 10, { name: "X-First-Edited" });
+
+  assert.deepEqual(updated.map(({ id, name }) => ({ id, name })), [
+    { id: 10, name: "X-First-Edited" },
+    { id: 11, name: "X-Second" },
+  ]);
+  assert.deepEqual(serializeHeaderRows(updated), {
+    "X-First-Edited": "one",
+    "X-Second": "two",
+  });
+});
+
+test("blank header drafts are omitted until they have a name", () => {
+  const rows = [
+    { id: 1, name: "X-Existing", value: "kept" },
+    { id: 2, name: "", value: "draft value" },
+  ];
+
+  assert.deepEqual(serializeHeaderRows(rows), { "X-Existing": "kept" });
+  assert.deepEqual(
+    serializeHeaderRows(updateHeaderRow(rows, 2, { name: "X-Draft" })),
+    { "X-Existing": "kept", "X-Draft": "draft value" },
+  );
 });

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -5,6 +5,12 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { useI18n } from "@/hooks/useI18n";
 import type { ModelCatalogPreset, ModelCatalogRecommendation } from "@/lib/model-catalog";
 import type { DiscoveredModel } from "@/lib/model-discovery";
+import {
+  serializeHeaderRows,
+  setCompatBool,
+  updateHeaderRow,
+  type HeaderRow,
+} from "./models-config-helpers";
 // Color icons (have their own fill colors — no background needed)
 import AnthropicIcon from "@lobehub/icons/es/Anthropic/components/Mono";
 import OpenAIIcon from "@lobehub/icons/es/OpenAI/components/Mono";
@@ -715,15 +721,6 @@ function setDeepseekCompat(model: ModelEntry, enabled: boolean): ModelEntry {
   return { ...model, compat: Object.keys(rest).length ? rest : undefined };
 }
 
-// Generic helper for boolean compat flags. An empty compat map is collapsed to
-// `undefined` so the saved models.json stays free of `{}` noise.
-function setCompatBool(model: ModelEntry, key: string, value: boolean): ModelEntry {
-  const next = { ...(model.compat ?? {}) };
-  if (value) next[key] = true;
-  else delete next[key];
-  return { ...model, compat: Object.keys(next).length ? next : undefined };
-}
-
 // Compat can be configured at the provider or model level; provider-composer
 // merges them (model wins) at runtime. The UI reads the effective value so
 // hand-edited models.json settings are reflected correctly, while toggles
@@ -732,23 +729,26 @@ function effectiveCompat(provider: ProviderEntry, model: ModelEntry): Record<str
   return { ...(provider.compat ?? {}), ...(model.compat ?? {}) };
 }
 
-// Editable key/value request-header list for a provider or model. Rebuilds a
-// fresh object on each edit so empty keys/values are dropped instead of being
-// persisted as noise in models.json.
+// Editable key/value request-header list for a provider or model. Rows stay
+// local so a blank draft is never persisted as an invalid HTTP header name.
 function HeaderListEditor({ headers, onChange }: {
   headers: Record<string, string> | undefined;
   onChange: (h: Record<string, string> | undefined) => void;
 }) {
-  const entries = Object.entries(headers ?? {});
-  const setEntry = (row: number, k: string, v: string): void => {
-    const next: Record<string, string> = {};
-    entries.forEach(([ok, ov], j) => { if (j !== row) next[ok] = ov; });
-    if (k.trim()) next[k.trim()] = v;
-    onChange(Object.keys(next).length ? next : undefined);
+  const [rows, setRows] = useState<HeaderRow[]>(() => Object.entries(headers ?? {}).map(
+    ([name, value], id) => ({ id, name, value }),
+  ));
+  const nextRowIdRef = useRef(rows.length);
+
+  const applyRows = (next: HeaderRow[]): void => {
+    setRows(next);
+    onChange(serializeHeaderRows(next));
   };
-  const removeEntry = (row: number): void => {
-    const next = entries.filter((_, j) => j !== row);
-    onChange(Object.keys(next).length ? Object.fromEntries(next) : undefined);
+  const setEntry = (id: number, changes: Partial<Pick<HeaderRow, "name" | "value">>): void => {
+    applyRows(updateHeaderRow(rows, id, changes));
+  };
+  const removeEntry = (id: number): void => {
+    applyRows(rows.filter((row) => row.id !== id));
   };
   const rowBtnStyle = {
     padding: "6px 9px",
@@ -762,16 +762,19 @@ function HeaderListEditor({ headers, onChange }: {
   } satisfies React.CSSProperties;
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-      {entries.map(([k, v], i) => (
-        <div key={i} style={{ display: "flex", gap: 6 }}>
-          <input value={k} onChange={(e) => setEntry(i, e.target.value, v)}
+      {rows.map((row) => (
+        <div key={row.id} style={{ display: "flex", gap: 6 }}>
+          <input value={row.name} onChange={(e) => setEntry(row.id, { name: e.target.value })}
             placeholder="Header-Name" style={{ ...inputStyle, fontFamily: "var(--font-mono)", flex: 1 }} />
-          <input value={v} onChange={(e) => setEntry(i, k, e.target.value)}
+          <input value={row.value} onChange={(e) => setEntry(row.id, { value: e.target.value })}
             placeholder="value" style={{ ...inputStyle, fontFamily: "var(--font-mono)", flex: 1 }} />
-          <button onClick={() => removeEntry(i)} style={rowBtnStyle}>✕</button>
+          <button onClick={() => removeEntry(row.id)} style={rowBtnStyle}>✕</button>
         </div>
       ))}
-      <button onClick={() => onChange({ ...(headers ?? {}), "": "" })}
+      <button onClick={() => setRows((current) => [
+        ...current,
+        { id: nextRowIdRef.current++, name: "", value: "" },
+      ])}
         style={{ padding: "5px 9px", background: "none", border: "1px solid var(--border)", borderRadius: 4, color: "var(--text-muted)", cursor: "pointer", fontSize: 11, display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 5, alignSelf: "flex-start" }}>
         + Add header
       </button>

--- a/components/ModelsConfig.tsx
+++ b/components/ModelsConfig.tsx
@@ -127,6 +127,7 @@ interface ModelEntry {
   contextWindow?: number;
   maxTokens?: number;
   cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+  headers?: Record<string, string>;
   compat?: Record<string, unknown>;
 }
 
@@ -437,6 +438,16 @@ function ProviderDetail({ name, provider, onChange, onRename, onDelete, onAddMod
         <Select value={provider.api ?? "openai-completions"} onChange={(v) => set("api", v)} options={API_OPTIONS} required />
       </Field>
 
+      <Field label="Headers">
+        <HeaderListEditor
+          headers={provider.headers}
+          onChange={(headers) => set("headers", headers)}
+        />
+        <span style={{ fontSize: 10, color: "var(--text-dim)", marginTop: 2 }}>
+          Added to every request from this provider (e.g. User-Agent). Useful for gateways with bot detection.
+        </span>
+      </Field>
+
       <div style={{ borderTop: "1px solid var(--border)", paddingTop: 14, display: "flex", flexDirection: "column", gap: 10 }}>
         {discoveryState.phase !== "success" && (
           <button
@@ -702,6 +713,70 @@ function setDeepseekCompat(model: ModelEntry, enabled: boolean): ModelEntry {
   delete rest.thinkingFormat;
   delete rest.requiresReasoningContentOnAssistantMessages;
   return { ...model, compat: Object.keys(rest).length ? rest : undefined };
+}
+
+// Generic helper for boolean compat flags. An empty compat map is collapsed to
+// `undefined` so the saved models.json stays free of `{}` noise.
+function setCompatBool(model: ModelEntry, key: string, value: boolean): ModelEntry {
+  const next = { ...(model.compat ?? {}) };
+  if (value) next[key] = true;
+  else delete next[key];
+  return { ...model, compat: Object.keys(next).length ? next : undefined };
+}
+
+// Compat can be configured at the provider or model level; provider-composer
+// merges them (model wins) at runtime. The UI reads the effective value so
+// hand-edited models.json settings are reflected correctly, while toggles
+// write to the model entry so a per-model override is explicit.
+function effectiveCompat(provider: ProviderEntry, model: ModelEntry): Record<string, unknown> {
+  return { ...(provider.compat ?? {}), ...(model.compat ?? {}) };
+}
+
+// Editable key/value request-header list for a provider or model. Rebuilds a
+// fresh object on each edit so empty keys/values are dropped instead of being
+// persisted as noise in models.json.
+function HeaderListEditor({ headers, onChange }: {
+  headers: Record<string, string> | undefined;
+  onChange: (h: Record<string, string> | undefined) => void;
+}) {
+  const entries = Object.entries(headers ?? {});
+  const setEntry = (row: number, k: string, v: string): void => {
+    const next: Record<string, string> = {};
+    entries.forEach(([ok, ov], j) => { if (j !== row) next[ok] = ov; });
+    if (k.trim()) next[k.trim()] = v;
+    onChange(Object.keys(next).length ? next : undefined);
+  };
+  const removeEntry = (row: number): void => {
+    const next = entries.filter((_, j) => j !== row);
+    onChange(Object.keys(next).length ? Object.fromEntries(next) : undefined);
+  };
+  const rowBtnStyle = {
+    padding: "6px 9px",
+    background: "none",
+    border: "1px solid rgba(239,68,68,0.3)",
+    borderRadius: 4,
+    color: "#ef4444",
+    cursor: "pointer",
+    fontSize: 11,
+    lineHeight: 1,
+  } satisfies React.CSSProperties;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {entries.map(([k, v], i) => (
+        <div key={i} style={{ display: "flex", gap: 6 }}>
+          <input value={k} onChange={(e) => setEntry(i, e.target.value, v)}
+            placeholder="Header-Name" style={{ ...inputStyle, fontFamily: "var(--font-mono)", flex: 1 }} />
+          <input value={v} onChange={(e) => setEntry(i, k, e.target.value)}
+            placeholder="value" style={{ ...inputStyle, fontFamily: "var(--font-mono)", flex: 1 }} />
+          <button onClick={() => removeEntry(i)} style={rowBtnStyle}>✕</button>
+        </div>
+      ))}
+      <button onClick={() => onChange({ ...(headers ?? {}), "": "" })}
+        style={{ padding: "5px 9px", background: "none", border: "1px solid var(--border)", borderRadius: 4, color: "var(--text-muted)", cursor: "pointer", fontSize: 11, display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 5, alignSelf: "flex-start" }}>
+        + Add header
+      </button>
+    </div>
+  );
 }
 
 function fillEmptyModelFields(
@@ -1019,6 +1094,16 @@ function ModelDetail({
         <Select value={model.api ?? ""} onChange={(v) => set("api", v || undefined)} options={API_OPTIONS} />
       </Field>
 
+      <Field label="Headers">
+        <HeaderListEditor
+          headers={model.headers}
+          onChange={(headers) => set("headers", headers)}
+        />
+        <span style={{ fontSize: 10, color: "var(--text-dim)", marginTop: 2 }}>
+          Added to this model&apos;s requests; overrides the provider headers for this model.
+        </span>
+      </Field>
+
       <div style={{ display: "flex", gap: 20, flexWrap: "wrap" }}>
         <Check label="Reasoning / thinking" checked={model.reasoning ?? false} onChange={(v) => set("reasoning", v || undefined)} />
         <Check label="Image input" checked={model.input?.includes("image") ?? false}
@@ -1031,6 +1116,11 @@ function ModelDetail({
             label="DeepSeek thinking compat"
             checked={hasDeepseekCompat(model)}
             onChange={(v) => onChange(setDeepseekCompat(model, v))}
+          />
+          <Check
+            label="Use 'developer' role for the system prompt (disable if server rejects it)"
+            checked={effectiveCompat(provider, model)["supportsDeveloperRole"] !== false}
+            onChange={(v) => onChange(setCompatBool(model, "supportsDeveloperRole", v))}
           />
           <div>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>

--- a/components/models-config-helpers.ts
+++ b/components/models-config-helpers.ts
@@ -1,0 +1,33 @@
+export interface CompatEntry {
+  compat?: Record<string, unknown>;
+}
+
+export interface HeaderRow {
+  id: number;
+  name: string;
+  value: string;
+}
+
+export function setCompatBool<T extends CompatEntry>(entry: T, key: string, value: boolean): T {
+  return {
+    ...entry,
+    compat: { ...(entry.compat ?? {}), [key]: value },
+  };
+}
+
+export function updateHeaderRow(
+  rows: readonly HeaderRow[],
+  id: number,
+  changes: Partial<Pick<HeaderRow, "name" | "value">>,
+): HeaderRow[] {
+  return rows.map((row) => row.id === id ? { ...row, ...changes } : row);
+}
+
+export function serializeHeaderRows(rows: readonly HeaderRow[]): Record<string, string> | undefined {
+  const headers: Record<string, string> = {};
+  for (const row of rows) {
+    const name = row.name.trim();
+    if (name) headers[name] = row.value;
+  }
+  return Object.keys(headers).length ? headers : undefined;
+}


### PR DESCRIPTION
## fix
> 自定义配置的模型供应商许多会拒绝 pi 默认使用的 `developer` 角色，该项修复在模型配置页面提供了自定义 header 选项和角色配置入口

Custom OpenAI-compatible endpoints frequently need per-request headers
(such as `User-Agent` for gateway bot detection) and a compat flag to
fall back to the `system` role when the server rejects the `developer`
role. Both previously required hand-editing `~/.pi/agent/models.json`,
because the custom-model UI exposed neither header nor developer-role
compatibility controls.

<img width="1245" height="247" alt="image" src="https://github.com/user-attachments/assets/d0b12158-e514-4ad8-bcca-5687083534d1" />
<img width="847" height="205" alt="image" src="https://github.com/user-attachments/assets/40f9ab92-7328-425a-8e8d-db4fa9055856" />

## Changes

New:

* `components/models-config-helpers.ts` - pure helpers for explicit boolean
  compat overrides and stable header-row editing/serialization
* `components/ModelsConfig.test.mjs` - wiring and behavioral coverage for
  provider/model headers, developer-role disabling, row identity, and blank drafts

Edited:

* `components/ModelsConfig.tsx` - provider- and model-level header editors,
  `supportsDeveloperRole` toggle, stable local header drafts, and
  `ModelEntry.headers`

Net: 3 files, +198/-0

Notes for maintainers:

* Form labels are hardcoded English to match the existing ModelsConfig
  convention ("API override", "DeepSeek thinking compat", ...). No i18n
  keys were added; happy to switch to `models.*` flat keys if preferred.
* Session affinity flags (`sendSessionAffinityHeaders` /
  `sessionAffinityFormat`) are intentionally out of scope.

## Testing

* `node_modules/.bin/tsc --noEmit` - pass
* `node_modules/.bin/eslint components/ModelsConfig.tsx components/ModelsConfig.test.mjs components/models-config-helpers.ts` - pass
* `node --test components/ModelsConfig.test.mjs` - 5/5 pass
* `npm test` - 445/445 pass
