### PR TITLE
fix: strip skill XML from session auto-naming

### DIFF
--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, type CSSProperties, type ReactNode } from "react";
 import type { SessionInfo } from "@/lib/types";
 import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
+import { skillExpansionToCommand } from "@/lib/slash-display";
 import { useI18n } from "@/hooks/useI18n";
 import { DirectoryPicker } from "./DirectoryPicker";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
@@ -1957,19 +1958,25 @@ function SessionItem({
     }
   }, [renaming]);
 
-  const title = session.name || session.firstMessage.slice(0, 50) || session.id.slice(0, 12);
+  // A stored first message may be an SDK-expanded <skill> block; collapse it
+  // back to the compact /skill:name args command the user typed before using
+  // it as the auto-name fallback, mirroring MessageView's rendering.
+  const displayFirstMessage = skillExpansionToCommand(session.firstMessage) ?? session.firstMessage;
+  const title = session.name || displayFirstMessage.slice(0, 50) || session.id.slice(0, 12);
 
   const startRename = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setRenameValue(session.name || session.firstMessage.slice(0, 50) || session.id.slice(0, 12));
+    setRenameValue(session.name || displayFirstMessage.slice(0, 50) || session.id.slice(0, 12));
     setRenaming(true);
-  }, [session.name, session.firstMessage, session.id]);
+  }, [session.name, displayFirstMessage, session.id]);
 
   const commitRename = useCallback(async () => {
     const name = renameValue.trim();
     setRenaming(false);
     // No-op when unchanged: the fallback title (first message / id) isn't a
-    // real stored name, so don't persist it as one.
+    // real stored name, so don't persist it as one. (The rename input seeds
+    // from the same collapsed displayFirstMessage, so an untouched rename of
+    // a skill-invoked session stays a no-op instead of persisting raw XML.)
     if (renameValue === title || name === (session.name ?? "")) return;
     try {
       await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {

--- a/lib/slash-display.test.mjs
+++ b/lib/slash-display.test.mjs
@@ -49,3 +49,17 @@ test("does not collapse incomplete or lookalike user text", () => {
   );
   assert.equal(skillExpansionToCommand("ordinary user text"), null);
 });
+
+test("collapse keeps session auto-naming free of skill XML", () => {
+  const firstMessage = skillExpansion({ name: "agent-md", args: "写计划" });
+  const collapsed = skillExpansionToCommand(firstMessage) ?? firstMessage;
+  assert.equal(collapsed, "/skill:agent-md 写计划");
+  // The sidebar slices the display form to 50 chars for the fallback title.
+  assert.ok(collapsed.length <= 50);
+  assert.ok(!collapsed.includes("<skill"));
+});
+
+test("plain first messages pass through unchanged for naming", () => {
+  assert.equal(skillExpansionToCommand("hello world") ?? "hello world", "hello world");
+  assert.equal(skillExpansionToCommand("") ?? "", "");
+});


### PR DESCRIPTION
## Fix
> 该修复让自动截取的session标题避免包含skill内容的XML块

A new session whose first message is a `/skill:` invocation stores the
SDK-expanded `<skill>` block as the message, so the no-name fallback
(`firstMessage.slice(0, 50)`) leaked raw XML into the sidebar session
title and the rename input.
<img width="484" height="122" alt="image" src="https://github.com/user-attachments/assets/66c57163-1c92-4e9c-a4f7-e3eb94e6b283" />

## Behavior

- The sidebar title of an unnamed skill-invoked session now shows
  `/skill:name args` instead of the expanded `<skill>` XML block.
- The rename input seeds from the same collapsed form, so an untouched
  rename stays a no-op instead of persisting the raw XML as the session
  name.
- Plain first messages and already-named sessions are unaffected.

## Implementation

- Collapse via the existing `skillExpansionToCommand` helper in
  `lib/slash-display.ts` (the same one MessageView uses) before the
  50-char slice.
- Two call sites in `components/SessionSidebar.tsx` (title + rename
  initial value), ~15 lines.
- Two new tests in `lib/slash-display.test.mjs`.

## Testing

- `node_modules/.bin/tsc --noEmit` — pass
- `npx eslint components/SessionSidebar.tsx lib/slash-display.test.mjs` — pass
- `node --experimental-strip-types --test lib/slash-display.test.mjs` — 7/7 pass