### PR TITLE
fix: resolve hydration mismatch from browser extensions and responsiv…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body translate="no" className="notranslate">
+      <body translate="no" className="notranslate" suppressHydrationWarning>
         {children}
         <PwaRegistration />
       </body>

--- a/hooks/useResizablePanel.ts
+++ b/hooks/useResizablePanel.ts
@@ -75,6 +75,8 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
   const restoredRef = useRef(false);
   const [width, setWidth] = useState(defaultWidth);
   const [isResizing, setIsResizing] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
 
   const effectiveMaxWidth = useCallback(
     () => Math.min(maxWidth, Math.max(minWidth, getMaxWidth())),
@@ -264,7 +266,7 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
     separatorProps: {
       "aria-label": ariaLabel,
       "aria-orientation": "vertical" as const,
-      "aria-valuemax": effectiveMaxWidth(),
+      "aria-valuemax": mounted ? effectiveMaxWidth() : maxWidth,
       "aria-valuemin": minWidth,
       "aria-valuenow": width,
       "aria-valuetext": `${width} px`,


### PR DESCRIPTION
…e aria-valuemax

Two sources of hydration mismatch on initial page load:

1. Browser extensions (Grammarly, translation, password managers) mutate the <body> element's attributes before React hydrates. <html> already had suppressHydrationWarning but <body> did not.

2. The sidebar resize separator's aria-valuemax was computed via effectiveMaxWidth() during render, which calls getMaxWidth(). On the server this returns the constant maxWidth, but on the client it returns a viewport-dependent value, causing a mismatch for viewports between 641px and 799px wide. Gate the responsive computation behind a mounted flag so the initial render uses the constant maxWidth.