### PR TITLE
fix(streaming): count CJK as ~1 token for accurate TPS estimate

### DIFF
--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -25,6 +25,18 @@ import type {
   ThinkingContent,
 } from "@/lib/types";
 
+// CJK chars ~1 token each (GLM/DeepSeek/GPT-o200k); other chars ~4 chars/token.
+const CJK_PATTERN = /[\u3000-\u30ff\u3400-\u9fff\uf900-\ufaff\u{20000}-\u{2fa1f}\uac00-\ud7af]/u;
+function estimateTokens(text: string): number {
+  let cjk = 0;
+  let rest = 0;
+  for (const ch of text) {
+    if (CJK_PATTERN.test(ch)) cjk++;
+    else rest++;
+  }
+  return cjk + rest / 4;
+}
+
 const MAX_THINKING_CACHE_ENTRIES = 100;
 const thinkingContentCache = new Map<string, Promise<string>>();
 
@@ -633,16 +645,16 @@ function AssistantMessageView({
         return changed ? next : prev;
       });
 
-      let chars = 0;
+      let tokens = 0;
       for (const b of bs) {
-        if (b.type === "text") chars += (b as TextContent).text?.length ?? 0;
-        else if (b.type === "thinking") chars += (b as ThinkingContent).thinking?.length ?? 0;
-        else if (b.type === "toolCall") chars += JSON.stringify((b as ToolCallContent).input ?? {}).length;
+        if (b.type === "text") tokens += estimateTokens((b as TextContent).text ?? "");
+        else if (b.type === "thinking") tokens += estimateTokens((b as ThinkingContent).thinking ?? "");
+        else if (b.type === "toolCall") tokens += estimateTokens(JSON.stringify((b as ToolCallContent).input ?? {}));
       }
-      if (chars === 0) return;
+      if (tokens === 0) return;
       if (streamStartRef.current === null) streamStartRef.current = now;
       const elapsed = (now - streamStartRef.current) / 1000;
-      if (elapsed > 0.5) setTps(chars / 4 / elapsed);
+      if (elapsed > 0.5) setTps(tokens / elapsed);
     };
     const id = setInterval(tick, 300);
     return () => clearInterval(id);
@@ -671,13 +683,13 @@ function AssistantMessageView({
           <span>{modelNames?.[`${message.provider}:${message.model}`] ?? modelNames?.[message.model] ?? message.model}</span>
         )}
         {isStreaming && (() => {
-          let chars = 0;
+          let tokens = 0;
           for (const b of blocks) {
-            if (b.type === "text") chars += (b as TextContent).text?.length ?? 0;
-            else if (b.type === "thinking") chars += (b as ThinkingContent).thinking?.length ?? 0;
-            else if (b.type === "toolCall") chars += JSON.stringify((b as ToolCallContent).input ?? {}).length;
+            if (b.type === "text") tokens += estimateTokens((b as TextContent).text ?? "");
+            else if (b.type === "thinking") tokens += estimateTokens((b as ThinkingContent).thinking ?? "");
+            else if (b.type === "toolCall") tokens += estimateTokens(JSON.stringify((b as ToolCallContent).input ?? {}));
           }
-          const est = Math.round(chars / 4);
+          const est = Math.round(tokens);
           return (
             <>
 

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -37,6 +37,45 @@ function estimateTokens(text: string): number {
   return cjk + rest / 4;
 }
 
+interface TokenEstimateCacheEntry {
+  text: string;
+  tokens: number;
+}
+
+function getTokenEstimateText(block: AssistantContentBlock): string | null {
+  if (block.type === "text") return block.text;
+  if (block.type === "thinking") return block.thinking;
+  if (block.type === "toolCall") return JSON.stringify(block.input ?? {}) ?? "";
+  return null;
+}
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function estimateUpdatedTokens(previous: TokenEstimateCacheEntry | undefined, text: string): number {
+  if (!previous || !text.startsWith(previous.text)) return estimateTokens(text);
+
+  let baseTokens = previous.tokens;
+  let suffixStart = previous.text.length;
+  // A streamed delta can complete a surrogate pair that was counted as two
+  // non-CJK code points in the previous update.
+  if (
+    suffixStart > 0
+    && suffixStart < text.length
+    && isHighSurrogate(previous.text.charCodeAt(suffixStart - 1))
+    && isLowSurrogate(text.charCodeAt(suffixStart))
+  ) {
+    baseTokens -= 1 / 4;
+    suffixStart--;
+  }
+  return baseTokens + estimateTokens(text.slice(suffixStart));
+}
+
 const MAX_THINKING_CACHE_ENTRIES = 100;
 const thinkingContentCache = new Map<string, Promise<string>>();
 
@@ -552,10 +591,10 @@ function AssistantMessageView({
 }) {
   const { t } = useI18n();
   const time = showTimestamp ? formatTime(message.timestamp) : null;
-  const blockItems = (message.content ?? [])
+  const blockItems = useMemo(() => (message.content ?? [])
     .map((block, originalIndex) => ({ block, originalIndex }))
-    .filter(({ block }) => !isEmptyThinkingBlock(block, { isStreaming }));
-  const blocks = blockItems.map(({ block }) => block);
+    .filter(({ block }) => !isEmptyThinkingBlock(block, { isStreaming })), [message.content, isStreaming]);
+  const blocks = useMemo(() => blockItems.map(({ block }) => block), [blockItems]);
   const providerError = getAssistantErrorMessage(message, { isStreaming });
   const [hovered, setHovered] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -563,6 +602,26 @@ function AssistantMessageView({
   const [tps, setTps] = useState<number | null>(null);
   const blockItemsRef = useRef(blockItems);
   blockItemsRef.current = blockItems;
+  const tokenEstimateCacheRef = useRef<Map<number, TokenEstimateCacheEntry>>(new Map());
+  const estimatedTokens = useMemo(() => {
+    if (!isStreaming) {
+      tokenEstimateCacheRef.current = new Map();
+      return 0;
+    }
+    const nextCache = new Map<number, TokenEstimateCacheEntry>();
+    let total = 0;
+    for (const { block, originalIndex } of blockItems) {
+      const text = getTokenEstimateText(block);
+      if (text === null) continue;
+      const tokens = estimateUpdatedTokens(tokenEstimateCacheRef.current.get(originalIndex), text);
+      nextCache.set(originalIndex, { text, tokens });
+      total += tokens;
+    }
+    tokenEstimateCacheRef.current = nextCache;
+    return total;
+  }, [blockItems, isStreaming]);
+  const estimatedTokensRef = useRef(estimatedTokens);
+  estimatedTokensRef.current = estimatedTokens;
 
   // Streaming-based timing for thinking blocks
   const blockStartTimesRef = useRef<Map<number, number>>(new Map());
@@ -620,7 +679,6 @@ function AssistantMessageView({
     }
     const tick = () => {
       const items = blockItemsRef.current;
-      const bs = items.map(({ block }) => block);
       const now = Date.now();
 
       // Record start time for each block the first time we see it
@@ -645,12 +703,7 @@ function AssistantMessageView({
         return changed ? next : prev;
       });
 
-      let tokens = 0;
-      for (const b of bs) {
-        if (b.type === "text") tokens += estimateTokens((b as TextContent).text ?? "");
-        else if (b.type === "thinking") tokens += estimateTokens((b as ThinkingContent).thinking ?? "");
-        else if (b.type === "toolCall") tokens += estimateTokens(JSON.stringify((b as ToolCallContent).input ?? {}));
-      }
+      const tokens = estimatedTokensRef.current;
       if (tokens === 0) return;
       if (streamStartRef.current === null) streamStartRef.current = now;
       const elapsed = (now - streamStartRef.current) / 1000;
@@ -683,13 +736,7 @@ function AssistantMessageView({
           <span>{modelNames?.[`${message.provider}:${message.model}`] ?? modelNames?.[message.model] ?? message.model}</span>
         )}
         {isStreaming && (() => {
-          let tokens = 0;
-          for (const b of blocks) {
-            if (b.type === "text") tokens += estimateTokens((b as TextContent).text ?? "");
-            else if (b.type === "thinking") tokens += estimateTokens((b as ThinkingContent).thinking ?? "");
-            else if (b.type === "toolCall") tokens += estimateTokens(JSON.stringify((b as ToolCallContent).input ?? {}));
-          }
-          const est = Math.round(tokens);
+          const est = Math.round(estimatedTokens);
           return (
             <>
 


### PR DESCRIPTION
## Problem

The streaming TPS badge and estimated-token count use a flat `chars / 4` heuristic. This is calibrated for ASCII (~4 chars/token) but **under-counts CJK by ~4-5×**: one CJK character is ~1 token in modern multilingual BPEs (GPT o200k, DeepSeek-V3, GLM-4), yet `chars / 4` scores it as only 0.25 token.

For CJK-heavy sessions the reported `t/s` and token estimate are therefore roughly 4× too low.

## Solution

Add a small inline `estimateTokens()` in `MessageView.tsx`:
- **CJK code points** (CJK symbols/punctuation, Unified + Ext A/B, compatibility ideographs, Hangul) -> **~1 token per character**
- **Other characters** -> keep the existing **~4 chars/token** rule

Both the streaming TPS calculation and the estimated-token badge now call it, replacing the inline `chars / 4`.

## Scope

Single-file change, no new files or dependencies:
- `components/MessageView.tsx` — add `estimateTokens()`, replace the two `chars / 4` call sites

## Verification

- `tsc --noEmit` passes (0 errors)
- Logic mirrors the CJK-aware estimator already shipped in the lyhue1991 fork