### PR TITLE
fix: suppress DEP0190 deprecation when auto-opening browser

### DIFF
--- a/bin/pi-web-options.js
+++ b/bin/pi-web-options.js
@@ -9,6 +9,19 @@ function isEnabled(value) {
   return typeof value === "string" && TRUE_VALUES.has(value.trim().toLowerCase());
 }
 
+function normalizePort(value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error("Port must be a non-negative integer.");
+  }
+
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port > 65535) {
+    throw new Error("Port must be between 0 and 65535.");
+  }
+
+  return String(port);
+}
+
 function parseLaunchOptions(args = process.argv.slice(2), env = process.env) {
   const { values: cliArgs } = parseArgs({
     args,
@@ -21,7 +34,7 @@ function parseLaunchOptions(args = process.argv.slice(2), env = process.env) {
   });
 
   return {
-    port: cliArgs.port ?? env.PORT ?? "30141",
+    port: normalizePort(cliArgs.port ?? env.PORT ?? "30141"),
     hostname: cliArgs.hostname ?? env.PI_WEB_HOSTNAME ?? "127.0.0.1",
     openBrowser: !cliArgs["no-open"] && !isEnabled(env.PI_WEB_NO_OPEN),
   };

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -87,8 +87,9 @@ child.stdout.on("data", (chunk) => {
     if (isWindows) {
       // `start` is a cmd.exe built-in, so invoke cmd directly. The empty
       // title argument is required by `start` before the target URL.
-      opener = spawn("cmd", ["/c", "start", "", url], {
+      opener = spawn(process.env.ComSpec || "cmd.exe", ["/c", "start", "", url], {
         stdio: "ignore",
+        detached: true,
       });
     } else if (isMac) {
       opener = spawn("open", [url], {

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -78,12 +78,29 @@ child.stdout.on("data", (chunk) => {
     browserOpened = true;
     const isWindows = process.platform === "win32";
     const isMac = process.platform === "darwin";
-    const openCmd = isWindows ? "start" : isMac ? "open" : "xdg-open";
-    const opener = spawn(openCmd, [url], {
-      shell: isWindows,
-      stdio: "ignore",
-      detached: true,
-    });
+    // Avoid `shell: true` to suppress Node.js DEP0190 deprecation
+    // ("Passing args to a child process with shell option true can lead to
+    // security vulnerabilities, as the arguments are not escaped").
+    // Pass a structured argv so Node.js handles escaping instead of
+    // concatenating the args into a shell command string.
+    let opener;
+    if (isWindows) {
+      // `start` is a cmd.exe built-in, so invoke cmd directly. The empty
+      // title argument is required by `start` before the target URL.
+      opener = spawn("cmd", ["/c", "start", "", url], {
+        stdio: "ignore",
+      });
+    } else if (isMac) {
+      opener = spawn("open", [url], {
+        stdio: "ignore",
+        detached: true,
+      });
+    } else {
+      opener = spawn("xdg-open", [url], {
+        stdio: "ignore",
+        detached: true,
+      });
+    }
 
     opener.on("error", (error) => {
       console.warn(`Could not open browser automatically: ${error.message}`);

--- a/lib/pi-web-options.test.mjs
+++ b/lib/pi-web-options.test.mjs
@@ -40,6 +40,17 @@ test("preserves port and hostname options", () => {
   );
 });
 
+test("rejects port values that could inject cmd arguments", () => {
+  assert.throws(
+    () => parseLaunchOptions(["-p", "30141&whoami"], {}),
+    /Port must be a non-negative integer/,
+  );
+  assert.throws(
+    () => parseLaunchOptions([], { PORT: "30141&whoami" }),
+    /Port must be a non-negative integer/,
+  );
+});
+
 test("supports PI_WEB_HOSTNAME without trusting the ambient system HOSTNAME", () => {
   assert.equal(
     parseLaunchOptions([], { HOSTNAME: "container-id" }).hostname,


### PR DESCRIPTION
## Problem

Starting `pi-web` on Windows prints a Node.js `DEP0190` deprecation warning every time:

```
(node:XXXXX) [DEP0190] DeprecationWarning: Passing args to a child process
with shell option true can lead to security vulnerabilities, as the
arguments are not escaped, only concatenated.
```

This comes from the browser auto-open call in `bin/pi-web.js`, which used:

```js
const openCmd = isWindows ? "start" : isMac ? "open" : "xdg-open";
const opener = spawn(openCmd, [url], {
  shell: isWindows,   // ← triggers DEP0190 (args + shell:true)
  stdio: "ignore",
  detached: true,
});
```

DEP0190 fires whenever an `args` array is passed together with `shell: true`.

## Fix

Refactor the call to avoid `shell: true` entirely while preserving the exact same auto-open behavior:

- **Windows**: invoke `cmd.exe /c start "" <url>` directly (`start` is a cmd built-in; the empty title argument is required).
- **macOS / Linux**: spawn `open` / `xdg-open` without `shell`, keeping the original `detached` behavior.

```js
let opener;
if (isWindows) {
  opener = spawn("cmd", ["/c", "start", "", url], { stdio: "ignore" });
} else if (isMac) {
  opener = spawn("open", [url], { stdio: "ignore", detached: true });
} else {
  opener = spawn("xdg-open", [url], { stdio: "ignore", detached: true });
}
```

## Verification

Tested on Windows 11 with Node 22:
- ✅ No more `DEP0190` warning on startup
- ✅ Browser still auto-opens to the correct URL