### PR TITLE
feat: 会话 Token 统计区新增平均缓存命中率

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1526,6 +1526,10 @@ export function AppShell() {
                     const extraTokenRows = [
                        ...(sessionStats.cost > 0 ? [[translate("session.cost"), `$${sessionStats.cost.toFixed(4)}`]] : []),
                        ...(ctx?.contextWindow ? [[translate("session.context"), `${ctx.percent !== null ? `${ctx.percent.toFixed(1)}%` : "?"} / ${formatCompact(ctx.contextWindow)}`]] : []),
+                       // Cache hit rate = cache reads / (input + cache writes + cache reads) — the denominator covers all input-class tokens.
+                       ...(sessionStats.tokens.cacheRead + sessionStats.tokens.cacheWrite > 0 && sessionStats.tokens.cacheRead + sessionStats.tokens.cacheWrite + sessionStats.tokens.input > 0
+                         ? [[translate("session.cacheHitRate"), `${(sessionStats.tokens.cacheRead / (sessionStats.tokens.cacheRead + sessionStats.tokens.cacheWrite + sessionStats.tokens.input) * 100).toFixed(1)}%`]]
+                         : []),
                     ];
                     const section = (
                       title: string,

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -46,6 +46,7 @@ export const enLocale: LocalePlugin = {
     "session.cacheWrite": "Cache Write",
     "session.cost": "Cost",
     "session.context": "Context",
+    "session.cacheHitRate": "Avg cache hit rate",
     "session.copy": "Copy {value}",
     "session.copied": "Copied",
     "session.title": "Session info",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -46,6 +46,7 @@ export const zhCNLocale: LocalePlugin = {
     "session.cacheWrite": "缓存写入",
     "session.cost": "费用",
     "session.context": "上下文",
+    "session.cacheHitRate": "平均缓存命中率",
     "session.copy": "复制{value}",
     "session.copied": "已复制",
     "session.title": "会话信息",


### PR DESCRIPTION
## 改动内容

在会话信息面板的 **Token 统计区**（「上下文」行之后）新增一行「平均缓存命中率」（英文界面显示 "Avg cache hit rate"）。

### 计算公式

```
缓存命中率 = 缓存读取 / (输入 + 缓存创建 + 缓存读取)
```

- 分母覆盖全部输入类 token（未命中输入 + 缓存创建 + 缓存读取）
- 仅当会话存在缓存读取或缓存创建时才显示该行，避免无缓存会话显示误导性的 0%
- 命中率保留 1 位小数

### 涉及文件

- `components/AppShell.tsx`：Token 统计区新增缓存命中率计算与展示
- `lib/i18n/messages/en.ts` / `lib/i18n/messages/zh-CN.ts`：新增 `session.cacheHitRate` 文案键

### 验证

- `tsc --noEmit` 通过
- 444 个测试中 443 通过（1 个失败为既有环境问题：`web-auth.test.mjs` 在未改动代码的基线版本上同样失败，与本次改动无关）
- 本地构建并部署后实测正常显示

### 背景

公式参考了 Claude Code 的缓存命中率遥测定义（`cache_read_input_tokens / (input_tokens + cache_creation_input_tokens + cache_read_input_tokens)`），比常见的 `缓存读取 / (缓存读取 + 输入)` 更准确——后者遗漏了缓存创建 token，会高估命中率。