### PR TITLE
feat: add Pi Web version check opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For port and hostname, command-line options override the corresponding environme
 | `--port <port>`, `-p <port>`, or `PORT` | Server port | `30141` |
 | `--hostname <host>`, `-H <host>`, or `PI_WEB_HOSTNAME` | Bind hostname | `127.0.0.1` |
 | `--no-open` or `PI_WEB_NO_OPEN=1` | Do not open a browser automatically | Browser opens |
+| `PI_WEB_SKIP_VERSION_CHECK=1` | Disable Pi Web update checks | Unset |
 | `PI_WEB_ALLOWED_HOSTS` | Additional exact proxy or custom hostnames, comma-separated | Unset |
 | `PI_WEB_PASSWORD` | Enable HTTP Basic Auth; the username is always `pi` | Authentication disabled |
 

--- a/app/api/app-update/route.ts
+++ b/app/api/app-update/route.ts
@@ -8,6 +8,12 @@ const CURRENT_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
 const NPM_LATEST_URL = "https://registry.npmjs.org/@agegr%2Fpi-web/latest";
 const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 5_000;
+const SKIP_VERSION_CHECK = [
+  "PI_OFFLINE",
+  "PI_WEB_OFFLINE",
+  "PI_SKIP_VERSION_CHECK",
+  "PI_WEB_SKIP_VERSION_CHECK",
+].some((name) => process.env[name] === "1");
 
 interface AppUpdateCache {
   value?: AppUpdateResponse;
@@ -66,6 +72,14 @@ async function loadUpdateStatus(): Promise<AppUpdateResponse> {
 }
 
 export async function GET() {
+  if (SKIP_VERSION_CHECK) {
+    return NextResponse.json({
+      currentVersion: CURRENT_VERSION,
+      latestVersion: CURRENT_VERSION,
+      updateAvailable: false,
+      releaseUrl: "",
+    } satisfies AppUpdateResponse);
+  }
   try {
     return NextResponse.json(await loadUpdateStatus());
   } catch (error) {

--- a/app/api/app-update/route.ts
+++ b/app/api/app-update/route.ts
@@ -8,12 +8,7 @@ const CURRENT_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
 const NPM_LATEST_URL = "https://registry.npmjs.org/@agegr%2Fpi-web/latest";
 const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 5_000;
-const SKIP_VERSION_CHECK = [
-  "PI_OFFLINE",
-  "PI_WEB_OFFLINE",
-  "PI_SKIP_VERSION_CHECK",
-  "PI_WEB_SKIP_VERSION_CHECK",
-].some((name) => process.env[name] === "1");
+const SKIP_VERSION_CHECK = process.env.PI_WEB_SKIP_VERSION_CHECK === "1";
 
 interface AppUpdateCache {
   value?: AppUpdateResponse;


### PR DESCRIPTION
Add `PI_WEB_SKIP_VERSION_CHECK=1` to skip Pi Web's npm version check for users who manage updates themselves and prefer not to see update notices.

This setting only affects Pi Web's version check.
