### PR TITLE
fix: isolate project command environments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Pi Web
+
+Pi Web hosts coding-agent sessions for user-selected projects while keeping the web server's runtime concerns separate from project work.
+
+## Language
+
+**Host Runtime Environment**:
+The environment owned by the Pi Web server and its framework runtime.
+_Avoid_: Project environment, shell environment
+
+**Project Command Environment**:
+The environment presented to a command that Pi Web runs on behalf of a user-selected project.
+_Avoid_: Host environment, inherited environment
+
+**Built-in Project Shell**:
+A shell entry point owned and operated by Pi Web for commands associated with a project.
+_Avoid_: Extension shell, arbitrary child process

--- a/docs/adr/0001-isolate-project-command-environments.md
+++ b/docs/adr/0001-isolate-project-command-environments.md
@@ -1,0 +1,3 @@
+# Isolate project command environments from the web host
+
+Pi Web sanitizes the environment of its built-in project shells instead of exposing the Next.js host runtime wholesale. The agent `bash` tool and direct user shell commands remove `PORT`, `NODE_ENV`, and `NEXT_*` variables while preserving the SDK-managed PATH, Pi session metadata, and all other inherited values; explicit variables set by a project command still take effect. Third-party extensions retain control of their own tools and subprocesses so existing overrides and remote execution integrations are not intercepted.

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentSessionEvent,
+  BashOperations,
   SessionManager,
   SettingsManager,
   SlashCommandInfo,
@@ -153,7 +154,10 @@ export interface AgentSessionLike {
     preflightResult?: (success: boolean) => void;
   }): Promise<void>;
   abort(): Promise<void>;
-  executeBash(command: string, onChunk?: (chunk: string) => void, options?: { excludeFromContext?: boolean }): Promise<{ output: string; exitCode?: number; cancelled?: boolean; truncated?: boolean; fullOutputPath?: string }>;
+  executeBash(command: string, onChunk?: (chunk: string) => void, options?: {
+    excludeFromContext?: boolean;
+    operations?: BashOperations;
+  }): Promise<{ output: string; exitCode?: number; cancelled?: boolean; truncated?: boolean; fullOutputPath?: string }>;
   abortBash(): void;
   readonly isBashRunning: boolean;
   setModel(model: ModelLike): Promise<void>;

--- a/lib/project-command-env.test.mjs
+++ b/lib/project-command-env.test.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+import {
+  DefaultResourceLoader,
+  createLocalBashOperations,
+  getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import { createJiti } from "jiti";
+
+const {
+  createProjectCommandBashExtension,
+  createProjectCommandBashOperations,
+  preferUserBashExtension,
+  sanitizeProjectCommandEnvironment,
+} = await createJiti(import.meta.url).import("./project-command-env.ts");
+
+const HOST_ENVIRONMENT = {
+  PORT: "30141",
+  NODE_ENV: "production",
+  NEXT_RUNTIME: "nodejs",
+  NEXT_PRIVATE_WORKER: "1",
+  PATH: "/usr/local/bin:/usr/bin",
+  HOME: "/home/pi",
+  HTTPS_PROXY: "http://proxy.example",
+  OPENROUTER_API_KEY: "secret",
+  PI_USER_SETTING: "preserved",
+};
+
+test("sanitizes only Pi Web host variables on POSIX", () => {
+  assert.deepEqual(
+    sanitizeProjectCommandEnvironment(HOST_ENVIRONMENT, "linux"),
+    {
+      PATH: HOST_ENVIRONMENT.PATH,
+      HOME: HOST_ENVIRONMENT.HOME,
+      HTTPS_PROXY: HOST_ENVIRONMENT.HTTPS_PROXY,
+      OPENROUTER_API_KEY: HOST_ENVIRONMENT.OPENROUTER_API_KEY,
+      PI_USER_SETTING: HOST_ENVIRONMENT.PI_USER_SETTING,
+    },
+  );
+});
+
+test("uses case-insensitive environment names on Windows", () => {
+  assert.deepEqual(
+    sanitizeProjectCommandEnvironment(
+      {
+        Port: "30141",
+        node_env: "production",
+        Next_Runtime: "nodejs",
+        NEXT_PUBLIC_FLAG: "1",
+        Path: "C:\\Windows",
+      },
+      "win32",
+    ),
+    { Path: "C:\\Windows" },
+  );
+});
+
+test("keeps differently-cased names distinct on POSIX", () => {
+  assert.deepEqual(
+    sanitizeProjectCommandEnvironment(
+      {
+        PORT: "30141",
+        Port: "project-value",
+        NODE_ENV: "production",
+        node_env: "project-mode",
+        NEXT_RUNTIME: "nodejs",
+        Next_Runtime: "project-runtime",
+      },
+      "linux",
+    ),
+    {
+      Port: "project-value",
+      node_env: "project-mode",
+      Next_Runtime: "project-runtime",
+    },
+  );
+});
+
+test("agent bash removes host variables while preserving SDK and user environment", async () => {
+  const original = {
+    PORT: process.env.PORT,
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_RUNTIME: process.env.NEXT_RUNTIME,
+    NEXT_PRIVATE_WORKER: process.env.NEXT_PRIVATE_WORKER,
+    PI_USER_SETTING: process.env.PI_USER_SETTING,
+  };
+  Object.assign(process.env, {
+    PORT: "30141",
+    NODE_ENV: "production",
+    NEXT_RUNTIME: "nodejs",
+    NEXT_PRIVATE_WORKER: "1",
+    PI_USER_SETTING: "preserved",
+  });
+
+  try {
+    const extension = createProjectCommandBashExtension({
+      cwd: process.cwd(),
+      settings: {
+        getShellCommandPrefix: () => undefined,
+        getShellPath: () => undefined,
+      },
+    });
+    let registeredTool;
+    await extension.factory({
+      registerTool(tool) {
+        registeredTool = tool;
+      },
+    });
+
+    const result = await registeredTool.execute(
+      "issue-484",
+      {
+        command: `node -e 'console.log(JSON.stringify({PORT:process.env.PORT,NODE_ENV:process.env.NODE_ENV,NEXT_RUNTIME:process.env.NEXT_RUNTIME,NEXT_PRIVATE_WORKER:process.env.NEXT_PRIVATE_WORKER,PI_USER_SETTING:process.env.PI_USER_SETTING,PI_SESSION_ID:process.env.PI_SESSION_ID,PATH:process.env.PATH}))'`,
+      },
+      undefined,
+      undefined,
+      {
+        model: undefined,
+        thinkingLevel: "off",
+        sessionManager: {
+          getSessionId: () => "session-484",
+          getSessionFile: () => undefined,
+        },
+      },
+    );
+    const childEnvironment = JSON.parse(result.content[0].text);
+
+    assert.equal(childEnvironment.PORT, undefined);
+    assert.equal(childEnvironment.NODE_ENV, undefined);
+    assert.equal(childEnvironment.NEXT_RUNTIME, undefined);
+    assert.equal(childEnvironment.NEXT_PRIVATE_WORKER, undefined);
+    assert.equal(childEnvironment.PI_USER_SETTING, "preserved");
+    assert.equal(childEnvironment.PI_SESSION_ID, "session-484");
+    assert.ok(childEnvironment.PATH.split(delimiter).includes(join(getAgentDir(), "bin")));
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});
+
+test("agent bash reads current shell settings for every execution", async () => {
+  let commandPrefix = "export PI_WEB_PREFIX=first";
+  const extension = createProjectCommandBashExtension({
+    cwd: process.cwd(),
+    settings: {
+      getShellCommandPrefix: () => commandPrefix,
+      getShellPath: () => undefined,
+    },
+  });
+  let registeredTool;
+  await extension.factory({
+    registerTool(tool) {
+      registeredTool = tool;
+    },
+  });
+  const execute = () => registeredTool.execute(
+    "settings-reload",
+    { command: "printf %s \"$PI_WEB_PREFIX\"" },
+    undefined,
+    undefined,
+    undefined,
+  );
+
+  assert.equal((await execute()).content[0].text, "first");
+  commandPrefix = "export PI_WEB_PREFIX=second";
+  assert.equal((await execute()).content[0].text, "second");
+});
+
+test("direct bash removes host variables and allows explicit project values", async () => {
+  const agentBinDir = join(process.cwd(), ".test-agent", "bin");
+  const operations = createProjectCommandBashOperations({
+    agentBinDir,
+    baseEnvironment: {
+      ...HOST_ENVIRONMENT,
+      PATH: process.env.PATH,
+      PI_SESSION_ID: "stale-host-value",
+    },
+    localOperations: createLocalBashOperations(),
+  });
+  let output = "";
+
+  await operations.exec(
+    `NODE_ENV=test PORT=3200 node -e 'console.log(JSON.stringify({PORT:process.env.PORT,NODE_ENV:process.env.NODE_ENV,NEXT_RUNTIME:process.env.NEXT_RUNTIME,PI_USER_SETTING:process.env.PI_USER_SETTING,PATH:process.env.PATH}))'`,
+    process.cwd(),
+    { onData: (chunk) => { output += chunk.toString(); } },
+  );
+  const childEnvironment = JSON.parse(output);
+
+  assert.equal(childEnvironment.PORT, "3200");
+  assert.equal(childEnvironment.NODE_ENV, "test");
+  assert.equal(childEnvironment.NEXT_RUNTIME, undefined);
+  assert.equal(childEnvironment.PI_USER_SETTING, "preserved");
+  assert.ok(childEnvironment.PATH.split(delimiter).includes(agentBinDir));
+});
+
+test("direct bash preserves execution controls and streaming callbacks", async () => {
+  const signal = new AbortController().signal;
+  let received;
+  let streamed = "";
+  const operations = createProjectCommandBashOperations({
+    baseEnvironment: HOST_ENVIRONMENT,
+    localOperations: {
+      async exec(command, cwd, options) {
+        received = { command, cwd, options };
+        options.onData(Buffer.from("streamed"));
+        return { exitCode: 0 };
+      },
+    },
+  });
+
+  await operations.exec("echo ready", "/project", {
+    onData: (chunk) => { streamed += chunk.toString(); },
+    signal,
+    timeout: 12,
+  });
+
+  assert.equal(received.command, "echo ready");
+  assert.equal(received.cwd, "/project");
+  assert.equal(received.options.signal, signal);
+  assert.equal(received.options.timeout, 12);
+  assert.equal(streamed, "streamed");
+});
+
+test("direct bash updates only the platform PATH key", async () => {
+  let receivedEnvironment;
+  const agentBinDir = join(process.cwd(), ".test-agent", "bin");
+  const operations = createProjectCommandBashOperations({
+    agentBinDir,
+    baseEnvironment: {
+      Path: "project-metadata",
+      PATH: "/usr/bin",
+    },
+    platform: "linux",
+    localOperations: {
+      async exec(_command, _cwd, options) {
+        receivedEnvironment = options.env;
+        return { exitCode: 0 };
+      },
+    },
+  });
+
+  await operations.exec("echo ready", "/project", {
+    onData() {},
+  });
+
+  assert.equal(receivedEnvironment.Path, "project-metadata");
+  assert.equal(receivedEnvironment.PATH, `${agentBinDir}${delimiter}/usr/bin`);
+});
+
+test("direct bash reuses a case-insensitive Windows Path key", async () => {
+  let receivedEnvironment;
+  const operations = createProjectCommandBashOperations({
+    agentBinDir: "C:\\pi-agent\\bin",
+    baseEnvironment: {
+      Path: "C:\\Windows",
+    },
+    platform: "win32",
+    localOperations: {
+      async exec(_command, _cwd, options) {
+        receivedEnvironment = options.env;
+        return { exitCode: 0 };
+      },
+    },
+  });
+
+  await operations.exec("echo ready", "C:\\project", {
+    onData() {},
+  });
+
+  assert.equal(receivedEnvironment.Path, "C:\\pi-agent\\bin;C:\\Windows");
+  assert.equal(receivedEnvironment.PATH, undefined);
+});
+
+test("a user extension keeps priority over the Pi Web fallback bash tool", async () => {
+  const userBash = {
+    name: "user-bash",
+    factory: (pi) => {
+      pi.registerTool({
+        name: "bash",
+        label: "user bash",
+        description: "user override",
+        parameters: { type: "object", properties: {} },
+        async execute() {
+          return { content: [{ type: "text", text: "user override" }], details: undefined };
+        },
+      });
+    },
+  };
+  const hostBash = createProjectCommandBashExtension({
+    cwd: process.cwd(),
+    settings: {
+      getShellCommandPrefix: () => undefined,
+      getShellPath: () => undefined,
+    },
+  });
+  const loader = new DefaultResourceLoader({
+    cwd: process.cwd(),
+    agentDir: join(process.cwd(), ".test-agent"),
+    extensionFactories: [userBash, hostBash],
+    noExtensions: true,
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+    extensionsOverride: (base) => preferUserBashExtension(base),
+  });
+  await loader.reload();
+  const extensions = loader.getExtensions();
+  const bashDefinitions = extensions.extensions
+    .map((extension) => extension.tools.get("bash")?.definition)
+    .filter(Boolean);
+
+  assert.equal(bashDefinitions.length, 1);
+  assert.equal(bashDefinitions[0].description, "user override");
+  assert.deepEqual(extensions.errors, []);
+});

--- a/lib/project-command-env.test.mjs
+++ b/lib/project-command-env.test.mjs
@@ -27,7 +27,7 @@ const HOST_ENVIRONMENT = {
   PI_USER_SETTING: "preserved",
 };
 
-test("sanitizes only Pi Web host variables on POSIX", () => {
+test("sanitizes host variables using platform casing rules", () => {
   assert.deepEqual(
     sanitizeProjectCommandEnvironment(HOST_ENVIRONMENT, "linux"),
     {
@@ -38,9 +38,6 @@ test("sanitizes only Pi Web host variables on POSIX", () => {
       PI_USER_SETTING: HOST_ENVIRONMENT.PI_USER_SETTING,
     },
   );
-});
-
-test("uses case-insensitive environment names on Windows", () => {
   assert.deepEqual(
     sanitizeProjectCommandEnvironment(
       {
@@ -54,9 +51,6 @@ test("uses case-insensitive environment names on Windows", () => {
     ),
     { Path: "C:\\Windows" },
   );
-});
-
-test("keeps differently-cased names distinct on POSIX", () => {
   assert.deepEqual(
     sanitizeProjectCommandEnvironment(
       {
@@ -224,54 +218,39 @@ test("direct bash preserves execution controls and streaming callbacks", async (
   assert.equal(streamed, "streamed");
 });
 
-test("direct bash updates only the platform PATH key", async () => {
-  let receivedEnvironment;
-  const agentBinDir = join(process.cwd(), ".test-agent", "bin");
+async function captureOperationEnvironment(options) {
+  let environment;
   const operations = createProjectCommandBashOperations({
-    agentBinDir,
-    baseEnvironment: {
-      Path: "project-metadata",
-      PATH: "/usr/bin",
-    },
-    platform: "linux",
+    ...options,
     localOperations: {
-      async exec(_command, _cwd, options) {
-        receivedEnvironment = options.env;
+      async exec(_command, _cwd, executionOptions) {
+        environment = executionOptions.env;
         return { exitCode: 0 };
       },
     },
   });
-
   await operations.exec("echo ready", "/project", {
     onData() {},
   });
+  return environment;
+}
 
-  assert.equal(receivedEnvironment.Path, "project-metadata");
-  assert.equal(receivedEnvironment.PATH, `${agentBinDir}${delimiter}/usr/bin`);
-});
-
-test("direct bash reuses a case-insensitive Windows Path key", async () => {
-  let receivedEnvironment;
-  const operations = createProjectCommandBashOperations({
-    agentBinDir: "C:\\pi-agent\\bin",
-    baseEnvironment: {
-      Path: "C:\\Windows",
+test("direct bash updates the platform PATH key", async () => {
+  const agentBinDir = join(process.cwd(), ".test-agent", "bin");
+  const cases = [
+    {
+      options: { agentBinDir, baseEnvironment: { Path: "project-metadata", PATH: "/usr/bin" }, platform: "linux" },
+      expected: { Path: "project-metadata", PATH: `${agentBinDir}${delimiter}/usr/bin` },
     },
-    platform: "win32",
-    localOperations: {
-      async exec(_command, _cwd, options) {
-        receivedEnvironment = options.env;
-        return { exitCode: 0 };
-      },
+    {
+      options: { agentBinDir: "C:\\pi-agent\\bin", baseEnvironment: { Path: "C:\\Windows" }, platform: "win32" },
+      expected: { Path: "C:\\pi-agent\\bin;C:\\Windows" },
     },
-  });
+  ];
 
-  await operations.exec("echo ready", "C:\\project", {
-    onData() {},
-  });
-
-  assert.equal(receivedEnvironment.Path, "C:\\pi-agent\\bin;C:\\Windows");
-  assert.equal(receivedEnvironment.PATH, undefined);
+  for (const { options, expected } of cases) {
+    assert.deepEqual(await captureOperationEnvironment(options), expected);
+  }
 });
 
 test("a user extension keeps priority over the Pi Web fallback bash tool", async () => {

--- a/lib/project-command-env.ts
+++ b/lib/project-command-env.ts
@@ -11,8 +11,6 @@ import { join } from "node:path";
 const HOST_EXTENSION_NAME = "pi-web-project-command-environment";
 const HOST_EXTENSION_PATH = `<inline:${HOST_EXTENSION_NAME}>`;
 
-type CommandEnvironment = Record<string, string | undefined>;
-
 type ProjectShellSettings = {
   getShellCommandPrefix(): string | undefined;
   getShellPath(): string | undefined;
@@ -20,7 +18,7 @@ type ProjectShellSettings = {
 
 type ProjectCommandBashOperationsOptions = {
   agentBinDir?: string;
-  baseEnvironment?: CommandEnvironment;
+  baseEnvironment?: NodeJS.ProcessEnv;
   localOperations?: BashOperations;
   platform?: NodeJS.Platform;
   shellPath?: string;
@@ -34,39 +32,31 @@ function isHostRuntimeVariable(name: string, platform: NodeJS.Platform): boolean
 }
 
 export function sanitizeProjectCommandEnvironment(
-  baseEnvironment: CommandEnvironment,
+  baseEnvironment: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
-): CommandEnvironment {
-  const environment: CommandEnvironment = {};
-  for (const [name, value] of Object.entries(baseEnvironment)) {
-    if (!isHostRuntimeVariable(name, platform)) {
-      environment[name] = value;
-    }
+): NodeJS.ProcessEnv {
+  const environment = { ...baseEnvironment };
+  for (const name of Object.keys(environment)) {
+    if (isHostRuntimeVariable(name, platform)) delete environment[name];
   }
   return environment;
 }
 
 function withAgentBinDirectory(
-  environment: CommandEnvironment,
+  environment: NodeJS.ProcessEnv,
   agentBinDir: string,
   platform: NodeJS.Platform,
-): CommandEnvironment {
+): NodeJS.ProcessEnv {
   const pathKey = platform === "win32"
     ? Object.keys(environment).find((name) => name.toUpperCase() === "PATH") ?? "PATH"
     : "PATH";
   const pathDelimiter = platform === "win32" ? ";" : ":";
   const currentPath = environment[pathKey] ?? "";
   const pathEntries = currentPath.split(pathDelimiter).filter(Boolean);
-  if (pathEntries.includes(agentBinDir)) return environment;
-
-  return {
-    ...environment,
-    [pathKey]: [agentBinDir, currentPath].filter(Boolean).join(pathDelimiter),
-  };
-}
-
-function toProcessEnvironment(environment: CommandEnvironment): NodeJS.ProcessEnv {
-  return environment as NodeJS.ProcessEnv;
+  if (!pathEntries.includes(agentBinDir)) {
+    environment[pathKey] = [agentBinDir, currentPath].filter(Boolean).join(pathDelimiter);
+  }
+  return environment;
 }
 
 export function createProjectCommandBashOperations(
@@ -88,7 +78,7 @@ export function createProjectCommandBashOperations(
       );
       return localOperations.exec(command, cwd, {
         ...executionOptions,
-        env: toProcessEnvironment(environment),
+        env: environment,
       });
     },
   };
@@ -108,10 +98,8 @@ export function createProjectCommandBashExtension(options: {
         execute(toolCallId, params, signal, onUpdate, context) {
           const executionDefinition = createBashToolDefinition(options.cwd, {
             commandPrefix: options.settings.getShellCommandPrefix(),
-            shellPath: options.settings.getShellPath(),
-            spawnHook: (spawnContext) => ({
-              ...spawnContext,
-              env: toProcessEnvironment(sanitizeProjectCommandEnvironment(spawnContext.env)),
+            operations: createProjectCommandBashOperations({
+              shellPath: options.settings.getShellPath(),
             }),
           });
           return executionDefinition.execute(toolCallId, params, signal, onUpdate, context);

--- a/lib/project-command-env.ts
+++ b/lib/project-command-env.ts
@@ -1,0 +1,141 @@
+import {
+  createBashToolDefinition,
+  createLocalBashOperations,
+  getAgentDir,
+  type BashOperations,
+  type InlineExtension,
+  type LoadExtensionsResult,
+} from "@earendil-works/pi-coding-agent";
+import { join } from "node:path";
+
+const HOST_EXTENSION_NAME = "pi-web-project-command-environment";
+const HOST_EXTENSION_PATH = `<inline:${HOST_EXTENSION_NAME}>`;
+
+type CommandEnvironment = Record<string, string | undefined>;
+
+type ProjectShellSettings = {
+  getShellCommandPrefix(): string | undefined;
+  getShellPath(): string | undefined;
+};
+
+type ProjectCommandBashOperationsOptions = {
+  agentBinDir?: string;
+  baseEnvironment?: CommandEnvironment;
+  localOperations?: BashOperations;
+  platform?: NodeJS.Platform;
+  shellPath?: string;
+};
+
+function isHostRuntimeVariable(name: string, platform: NodeJS.Platform): boolean {
+  const comparableName = platform === "win32" ? name.toUpperCase() : name;
+  return comparableName === "PORT"
+    || comparableName === "NODE_ENV"
+    || comparableName.startsWith("NEXT_");
+}
+
+export function sanitizeProjectCommandEnvironment(
+  baseEnvironment: CommandEnvironment,
+  platform: NodeJS.Platform = process.platform,
+): CommandEnvironment {
+  const environment: CommandEnvironment = {};
+  for (const [name, value] of Object.entries(baseEnvironment)) {
+    if (!isHostRuntimeVariable(name, platform)) {
+      environment[name] = value;
+    }
+  }
+  return environment;
+}
+
+function withAgentBinDirectory(
+  environment: CommandEnvironment,
+  agentBinDir: string,
+  platform: NodeJS.Platform,
+): CommandEnvironment {
+  const pathKey = platform === "win32"
+    ? Object.keys(environment).find((name) => name.toUpperCase() === "PATH") ?? "PATH"
+    : "PATH";
+  const pathDelimiter = platform === "win32" ? ";" : ":";
+  const currentPath = environment[pathKey] ?? "";
+  const pathEntries = currentPath.split(pathDelimiter).filter(Boolean);
+  if (pathEntries.includes(agentBinDir)) return environment;
+
+  return {
+    ...environment,
+    [pathKey]: [agentBinDir, currentPath].filter(Boolean).join(pathDelimiter),
+  };
+}
+
+function toProcessEnvironment(environment: CommandEnvironment): NodeJS.ProcessEnv {
+  return environment as NodeJS.ProcessEnv;
+}
+
+export function createProjectCommandBashOperations(
+  options: ProjectCommandBashOperationsOptions = {},
+): BashOperations {
+  const {
+    agentBinDir = join(getAgentDir(), "bin"),
+    baseEnvironment = process.env,
+    localOperations = createLocalBashOperations({ shellPath: options.shellPath }),
+    platform = process.platform,
+  } = options;
+
+  return {
+    exec(command, cwd, executionOptions) {
+      const environment = withAgentBinDirectory(
+        sanitizeProjectCommandEnvironment(executionOptions.env ?? baseEnvironment, platform),
+        agentBinDir,
+        platform,
+      );
+      return localOperations.exec(command, cwd, {
+        ...executionOptions,
+        env: toProcessEnvironment(environment),
+      });
+    },
+  };
+}
+
+export function createProjectCommandBashExtension(options: {
+  cwd: string;
+  settings: ProjectShellSettings;
+}): InlineExtension {
+  return {
+    name: HOST_EXTENSION_NAME,
+    hidden: true,
+    factory: (pi) => {
+      const displayDefinition = createBashToolDefinition(options.cwd);
+      pi.registerTool({
+        ...displayDefinition,
+        execute(toolCallId, params, signal, onUpdate, context) {
+          const executionDefinition = createBashToolDefinition(options.cwd, {
+            commandPrefix: options.settings.getShellCommandPrefix(),
+            shellPath: options.settings.getShellPath(),
+            spawnHook: (spawnContext) => ({
+              ...spawnContext,
+              env: toProcessEnvironment(sanitizeProjectCommandEnvironment(spawnContext.env)),
+            }),
+          });
+          return executionDefinition.execute(toolCallId, params, signal, onUpdate, context);
+        },
+      });
+    },
+  };
+}
+
+export function preferUserBashExtension(base: LoadExtensionsResult): LoadExtensionsResult {
+  const hostExtensionIndex = base.extensions.findIndex((extension) => extension.path === HOST_EXTENSION_PATH);
+  if (hostExtensionIndex < 0) return base;
+
+  const userBashOwner = base.extensions
+    .slice(0, hostExtensionIndex)
+    .find((extension) => extension.tools.has("bash"));
+  if (!userBashOwner) return base;
+
+  return {
+    ...base,
+    extensions: base.extensions.filter((_, index) => index !== hostExtensionIndex),
+    errors: base.errors.filter((error) => !(
+      error.path === HOST_EXTENSION_PATH
+      && error.error === `Tool "bash" conflicts with ${userBashOwner.path}`
+    )),
+  };
+}

--- a/lib/rpc-manager-shutdown.test.mjs
+++ b/lib/rpc-manager-shutdown.test.mjs
@@ -330,3 +330,43 @@ test("direct destruction disposes the SDK session before unregistering the wrapp
   assert.deepEqual(calls, ["dispose", "destroy"]);
   assert.equal(wrapper.isAlive(), false);
 });
+
+test("direct bash commands use sanitized project operations with current shell settings", async (t) => {
+  let received;
+  let shellPath = "/bin/bash";
+  const inner = {
+    isBashRunning: false,
+    isStreaming: false,
+    isCompacting: false,
+    extensionRunner: {},
+    settingsManager: {
+      getShellPath: () => shellPath,
+    },
+    sessionManager: {
+      getCwd: () => process.cwd(),
+      getSessionFile: () => undefined,
+    },
+    agent: { state: {} },
+    getContextUsage: () => null,
+    getSteeringMessages: () => [],
+    getFollowUpMessages: () => [],
+    executeBash: async (command, _onChunk, options) => {
+      received = { command, options };
+      return { output: "", exitCode: 0 };
+    },
+    dispose() {},
+  };
+  const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
+
+  shellPath = "/custom/bash";
+  await wrapper.send({
+    type: "bash",
+    command: "echo ready",
+    excludeFromContext: true,
+  });
+
+  assert.equal(received.command, "echo ready");
+  assert.equal(received.options.excludeFromContext, true);
+  assert.equal(typeof received.options.operations.exec, "function");
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,5 +1,5 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, Theme } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
 import { existsSync, realpathSync, writeFileSync } from "fs";
@@ -7,6 +7,11 @@ import { resolve } from "path";
 import { validateAgentImages } from "./image-attachments";
 import { invalidateModelsCache } from "./models-cache";
 import { resolveVisibleModels, selectInitialModelScope } from "./model-scope";
+import {
+  createProjectCommandBashExtension,
+  createProjectCommandBashOperations,
+  preferUserBashExtension,
+} from "./project-command-env";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import { getProjectTrustStatus, projectTrustReloadOptions } from "./project-trust";
 import { persistExplicitStartupPreferences } from "./startup-preferences";
@@ -738,7 +743,12 @@ export class AgentSessionWrapper {
         const execution = this.inner.executeBash(
           command.command as string,
           undefined,
-          { excludeFromContext: command.excludeFromContext as boolean | undefined },
+          {
+            excludeFromContext: command.excludeFromContext as boolean | undefined,
+            operations: createProjectCommandBashOperations({
+              shellPath: this.inner.settingsManager.getShellPath(),
+            }),
+          },
         );
         notifyRunningChange();
         try {
@@ -1600,9 +1610,20 @@ export async function startRpcSession(
     // Gate untrusted project extensions so opening a repository does not run
     // its .pi/extensions code automatically (see lib/project-trust.ts, #236).
     const trustReloadOptions = projectTrustReloadOptions(sessionCwd, agentDir);
+    const settingsManager = SettingsManager.create(sessionCwd, agentDir);
     const services = await createAgentSessionServices({
       cwd: sessionCwd,
       agentDir,
+      settingsManager,
+      resourceLoaderOptions: {
+        extensionFactories: [
+          createProjectCommandBashExtension({
+            cwd: sessionCwd,
+            settings: settingsManager,
+          }),
+        ],
+        extensionsOverride: preferUserBashExtension,
+      },
       ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
     });
     const scope = await resolveVisibleModels(


### PR DESCRIPTION
## Summary

- sanitize `PORT`, `NODE_ENV`, and `NEXT_*` at both Pi Web-controlled project shell boundaries
- preserve explicit project variables, SDK-managed PATH/session metadata, current shell settings, and user extension overrides
- document the host/project environment boundary and add POSIX, Windows, agent-bash, direct-bash, reload, and extension-priority coverage

## Root Cause

The Pi SDK's local shell environment copies `process.env`. Pi Web runs the SDK inside Next.js, so the web host's listen port, production mode, and Next runtime variables were inherited by project commands such as `npm install` and `vite dev`.

## Compatibility

- limits sanitization to Pi Web's built-in agent and direct shell paths
- leaves extension-owned tools and subprocesses untouched; an existing user/project `bash` override remains authoritative
- preserves command-local `PORT`/`NODE_ENV`, proxy and API-key variables, `PI_*` metadata, SDK bin PATH, shell path/prefix, streaming, cancellation, timeout, and truncation behavior

## Testing

- `PI_CODING_AGENT_DIR=/private/tmp/pi-web-test-agent npm test` — 557 passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint` — 0 errors (1 pre-existing warning in `components/ChatWindow.tsx`)
- full AgentSession smoke test confirms exactly one active `bash` tool

Closes #484