### PR TITLE
fix: keep markdown-table tokens inline in highlighted source

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1122,6 +1122,14 @@ span.linenumber {
   font-style: normal !important;
 }
 
+/* Prism marks every token inside a markdown table with a `table` class, which
+   collides with Tailwind's `.table` utility (display: table) and stacks each
+   pipe and cell on its own line (#460). Tokens must always flow inline; this
+   rule is unlayered so it wins over the layered utility. */
+span.token.table {
+  display: inline;
+}
+
 @keyframes drop-zone-in {
   from { opacity: 0; transform: scale(0.97); }
   to   { opacity: 1; transform: scale(1); }

--- a/components/CodeBlock.markdown-table.test.mjs
+++ b/components/CodeBlock.markdown-table.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import reactSyntaxHighlighter from "react-syntax-highlighter";
+
+// Rendered directly (not through CodeBlock/TextFileViewer) so the assertion
+// holds without providers; both components share this exact highlighter.
+const { Prism: SyntaxHighlighter } = reactSyntaxHighlighter;
+
+const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+
+const markdownTable = "| Name | Desc |\n| --- | --- |\n| A | first |";
+
+test("Prism tags every markdown-table token with a `table` class", () => {
+  // This class collides with Tailwind's `.table` display utility. If Prism
+  // ever stops emitting it, the globals.css override below can be dropped.
+  const html = renderToStaticMarkup(
+    React.createElement(SyntaxHighlighter, { language: "markdown" }, markdownTable),
+  );
+  assert.match(html, /class="token table[ "]/);
+});
+
+test("globals.css keeps `table`-classed tokens inline despite Tailwind's utility", () => {
+  // Without this override the utility's `display: table` stacks every pipe
+  // and cell of a highlighted markdown table on its own line (#460).
+  assert.match(cssSource, /span\.token\.table \{[^}]*display: inline;/);
+});


### PR DESCRIPTION
## Summary

Fixes #460.

The file panel's Source view rendered markdown tables split across many visual lines: every `|` and every cell landed on its own line, so a 4-line table sprawled into dozens of lines. Preview mode was unaffected. The same corruption applied to ```markdown code fences in chat messages.

## Root cause

Prism's markdown grammar tags every token inside a table with a class list that includes `table` (e.g. `token table table-header-row punctuation`). The app's stylesheet is built with Tailwind v4, and the compiled CSS ships the `.table` utility (`display: table`). That utility unintentionally restyles the highlighter's token spans, turning each pipe/cell token into a table-level box that stacks vertically.

Both `react-syntax-highlighter` consumers are affected — `TextFileViewer` (`components/FileViewer.tsx`, the reported surface) and `CodeBlock` (`components/MermaidBlock.tsx`, chat code fences) — since the collision lives in the global stylesheet, not in either component.

## What changed

- Added an unlayered `span.token.table { display: inline }` rule to `app/globals.css`, next to the existing syntax-highlighter overrides. Tailwind v4 emits utilities inside `@layer utilities`, and unlayered author CSS always beats layered rules, so the override is robust without `!important` regardless of source order.
- Added `components/CodeBlock.markdown-table.test.mjs`:
  - a canary asserting Prism still tags markdown-table tokens with the `table` class (if the tokenizer ever stops, the override can be dropped);
  - an assertion that the globals.css override keeps those tokens inline.

The only other single-word Prism/Tailwind collision in the compiled CSS is `.italic` (`font-style: italic`), which merely italicizes markdown emphasis tokens and is left alone.

## Validation

- `npm test` — both new tests pass; suite totals on my machine are 515 pass / 33 fail, and all 33 failures are pre-existing on a clean checkout of `main` on Windows (jiti module-identity issue that breaks render-based tests under mixed path separators, unrelated to this change)
- `npm run lint` — 0 errors; only the pre-existing `ChatWindow.tsx` warning remains
- `tsc --noEmit` — passed
- Reproduced the bug and verified the fix against a running dev server on Windows (issue's repro steps: open a `.md` file with a table in the file panel, switch to Source)

Before / after, rendered with the app's actual compiled stylesheet and the exact Source-view markup:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/alooshxl/pi-web/pr-460-assets/source-view-before.png) | ![after](https://raw.githubusercontent.com/alooshxl/pi-web/pr-460-assets/source-view-after.png) |

<details>
<summary>Bug as reproduced in the live app before the fix</summary>

![live app before](https://raw.githubusercontent.com/alooshxl/pi-web/pr-460-assets/live-app-before.png)

</details>

## AI assistance

An AI coding agent (Cursor) was used to investigate, implement, and verify this change; the validation commands above were run locally and the live repro was captured from a real dev server session.

