### PR TITLE
fix: forward wrapper shutdown signals to Next child

### DIFF
--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -17,6 +17,8 @@ const path = require("path");
 const fs = require("fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { parseLaunchOptions } = require("./pi-web-options");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { wireChildProcessLifecycle } = require("./process-lifecycle");
 
 const pkgDir = path.join(__dirname, "..");
 const nextDir = path.join(pkgDir, ".next");
@@ -67,6 +69,7 @@ const child = spawn(process.execPath, [nextBin, ...nextArgs], {
   stdio: ["inherit", "pipe", "inherit"],
   env: { ...process.env, PI_WEB_HOSTNAME: hostname },
 });
+wireChildProcessLifecycle(child);
 
 let browserOpened = false;
 const url = `http://${hostname}:${port}`;
@@ -110,5 +113,3 @@ child.stdout.on("data", (chunk) => {
     opener.unref();
   }
 });
-
-child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/process-lifecycle.js
+++ b/bin/process-lifecycle.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const signalExitCodes = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+function wireChildProcessLifecycle(child, parentProcess = process) {
+  const signalHandlers = new Map();
+
+  for (const signal of Object.keys(signalExitCodes)) {
+    const handler = () => child.kill(signal);
+    signalHandlers.set(signal, handler);
+    parentProcess.on(signal, handler);
+  }
+
+  child.once("exit", (code, signal) => {
+    for (const [forwardedSignal, handler] of signalHandlers) {
+      parentProcess.removeListener(forwardedSignal, handler);
+    }
+
+    parentProcess.exit(code ?? signalExitCodes[signal] ?? 1);
+  });
+}
+
+module.exports = { wireChildProcessLifecycle };

--- a/bin/process-lifecycle.js
+++ b/bin/process-lifecycle.js
@@ -1,25 +1,45 @@
 "use strict";
 
-const signalExitCodes = {
-  SIGINT: 130,
-  SIGTERM: 143,
-};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const os = require("node:os");
 
-function wireChildProcessLifecycle(child, parentProcess = process) {
+const forwardedSignals = ["SIGINT", "SIGTERM"];
+const shutdownTimeoutMs = 5_000;
+
+function getSignalExitCode(signal) {
+  const signalNumber = signal ? os.constants.signals[signal] : undefined;
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}
+
+function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = shutdownTimeoutMs) {
   const signalHandlers = new Map();
+  let shutdownTimer;
 
-  for (const signal of Object.keys(signalExitCodes)) {
-    const handler = () => child.kill(signal);
+  const forceKill = () => child.kill("SIGKILL");
+
+  for (const signal of forwardedSignals) {
+    const handler = () => {
+      if (shutdownTimer) {
+        forceKill();
+        return;
+      }
+
+      shutdownTimer = setTimeout(forceKill, timeoutMs);
+      shutdownTimer.unref();
+      child.kill(signal);
+    };
     signalHandlers.set(signal, handler);
     parentProcess.on(signal, handler);
   }
 
   child.once("exit", (code, signal) => {
+    if (shutdownTimer) clearTimeout(shutdownTimer);
+
     for (const [forwardedSignal, handler] of signalHandlers) {
       parentProcess.removeListener(forwardedSignal, handler);
     }
 
-    parentProcess.exit(code ?? signalExitCodes[signal] ?? 1);
+    parentProcess.exit(code ?? getSignalExitCode(signal));
   });
 }
 

--- a/lib/process-lifecycle.test.mjs
+++ b/lib/process-lifecycle.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { wireChildProcessLifecycle } from "../bin/process-lifecycle.js";
 
@@ -21,7 +22,7 @@ function createProcesses() {
   return { parent, child, forwardedSignals, exitCodes };
 }
 
-test("forwards SIGINT and SIGTERM to the child until it exits", () => {
+test("forwards the first shutdown signal and force-kills on repeated signals", () => {
   const { parent, child, forwardedSignals } = createProcesses();
 
   wireChildProcessLifecycle(child, parent);
@@ -29,33 +30,54 @@ test("forwards SIGINT and SIGTERM to the child until it exits", () => {
   parent.emit("SIGTERM");
   parent.emit("SIGINT");
 
-  assert.deepEqual(forwardedSignals, ["SIGTERM", "SIGTERM", "SIGINT"]);
+  assert.deepEqual(forwardedSignals, ["SIGTERM", "SIGKILL", "SIGKILL"]);
+  child.emit("exit", null, "SIGKILL");
 });
 
-test("propagates a child exit code and removes only its signal listeners", () => {
+test("propagates a child exit code and clears its shutdown wiring", async () => {
   const { parent, child, forwardedSignals, exitCodes } = createProcesses();
   const existingSigtermListener = () => {};
   parent.on("SIGTERM", existingSigtermListener);
 
-  wireChildProcessLifecycle(child, parent);
+  wireChildProcessLifecycle(child, parent, 10);
   assert.equal(parent.listenerCount("SIGINT"), 1);
   assert.equal(parent.listenerCount("SIGTERM"), 2);
 
+  parent.emit("SIGTERM");
   child.emit("exit", 23, null);
+  await delay(20);
 
   assert.deepEqual(exitCodes, [23]);
   assert.equal(parent.listenerCount("SIGINT"), 0);
   assert.deepEqual(parent.listeners("SIGTERM"), [existingSigtermListener]);
 
   parent.emit("SIGTERM");
-  assert.deepEqual(forwardedSignals, []);
+  assert.deepEqual(forwardedSignals, ["SIGTERM"]);
 });
 
-test("uses the conventional exit status when the child exits on a signal", () => {
-  const { parent, child, exitCodes } = createProcesses();
+test("force-kills the child when graceful shutdown times out", async () => {
+  const { parent, child, forwardedSignals } = createProcesses();
 
-  wireChildProcessLifecycle(child, parent);
-  child.emit("exit", null, "SIGTERM");
+  wireChildProcessLifecycle(child, parent, 10);
+  parent.emit("SIGINT");
+  assert.deepEqual(forwardedSignals, ["SIGINT"]);
 
-  assert.deepEqual(exitCodes, [143]);
+  await delay(20);
+
+  assert.deepEqual(forwardedSignals, ["SIGINT", "SIGKILL"]);
+  child.emit("exit", null, "SIGKILL");
+});
+
+test("uses conventional exit statuses for known child signals", () => {
+  for (const [signal, expectedExitCode] of [
+    ["SIGTERM", 143],
+    ["SIGKILL", 137],
+  ]) {
+    const { parent, child, exitCodes } = createProcesses();
+
+    wireChildProcessLifecycle(child, parent);
+    child.emit("exit", null, signal);
+
+    assert.deepEqual(exitCodes, [expectedExitCode]);
+  }
 });

--- a/lib/process-lifecycle.test.mjs
+++ b/lib/process-lifecycle.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { wireChildProcessLifecycle } from "../bin/process-lifecycle.js";
+
+function createProcesses() {
+  const parent = new EventEmitter();
+  const child = new EventEmitter();
+  const forwardedSignals = [];
+  const exitCodes = [];
+
+  child.kill = (signal) => {
+    forwardedSignals.push(signal);
+    return true;
+  };
+  parent.exit = (code) => {
+    exitCodes.push(code);
+  };
+
+  return { parent, child, forwardedSignals, exitCodes };
+}
+
+test("forwards SIGINT and SIGTERM to the child until it exits", () => {
+  const { parent, child, forwardedSignals } = createProcesses();
+
+  wireChildProcessLifecycle(child, parent);
+  parent.emit("SIGTERM");
+  parent.emit("SIGTERM");
+  parent.emit("SIGINT");
+
+  assert.deepEqual(forwardedSignals, ["SIGTERM", "SIGTERM", "SIGINT"]);
+});
+
+test("propagates a child exit code and removes only its signal listeners", () => {
+  const { parent, child, forwardedSignals, exitCodes } = createProcesses();
+  const existingSigtermListener = () => {};
+  parent.on("SIGTERM", existingSigtermListener);
+
+  wireChildProcessLifecycle(child, parent);
+  assert.equal(parent.listenerCount("SIGINT"), 1);
+  assert.equal(parent.listenerCount("SIGTERM"), 2);
+
+  child.emit("exit", 23, null);
+
+  assert.deepEqual(exitCodes, [23]);
+  assert.equal(parent.listenerCount("SIGINT"), 0);
+  assert.deepEqual(parent.listeners("SIGTERM"), [existingSigtermListener]);
+
+  parent.emit("SIGTERM");
+  assert.deepEqual(forwardedSignals, []);
+});
+
+test("uses the conventional exit status when the child exits on a signal", () => {
+  const { parent, child, exitCodes } = createProcesses();
+
+  wireChildProcessLifecycle(child, parent);
+  child.emit("exit", null, "SIGTERM");
+
+  assert.deepEqual(exitCodes, [143]);
+});


### PR DESCRIPTION
## Summary

- forward `SIGINT` and `SIGTERM` from the `pi-web` wrapper to the spawned Next.js process
- allow up to five seconds for graceful child shutdown
- force-stop the child when shutdown times out or another termination signal arrives
- preserve child exit codes and conventional exit statuses for known signals
- cover signal escalation, timeout cleanup, listener cleanup, and exit statuses with regression tests

## Validation

- Ran: `node --experimental-strip-types --test lib/process-lifecycle.test.mjs`
- Ran: `npm test` (560 tests passed)
- Ran: `npm run lint`
- Ran: `node_modules/.bin/tsc --noEmit`
- Ran: `npm run build`
- Ran: `npm pack --dry-run --json`
- Checked: a Unix `SIGTERM` smoke test exits the wrapper with status 143 and leaves no child process
- Checked: a long-lived HTTP stream is force-closed after the five-second grace period; the wrapper exits with status 137 and leaves no child process

Fixes #495