### PR TITLE
fix: report why the Next.js child stopped

### DIFF
--- a/bin/process-lifecycle.js
+++ b/bin/process-lifecycle.js
@@ -11,11 +11,30 @@ function getSignalExitCode(signal) {
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }
 
-function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = shutdownTimeoutMs) {
+function describeExit(code, signal) {
+  return signal ? `signal ${signal}` : `code ${code}`;
+}
+
+function wireChildProcessLifecycle(
+  child,
+  parentProcess = process,
+  timeoutMs = shutdownTimeoutMs,
+  log = console.error,
+) {
   const signalHandlers = new Map();
   let shutdownTimer;
+  // Set once we forward a signal, so an exit we asked for stays quiet and one
+  // we did not gets reported.
+  let shuttingDown = false;
 
   const forceKill = () => child.kill("SIGKILL");
+
+  const unwire = () => {
+    if (shutdownTimer) clearTimeout(shutdownTimer);
+    for (const [forwardedSignal, handler] of signalHandlers) {
+      parentProcess.removeListener(forwardedSignal, handler);
+    }
+  };
 
   for (const signal of forwardedSignals) {
     const handler = () => {
@@ -24,6 +43,7 @@ function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = s
         return;
       }
 
+      shuttingDown = true;
       shutdownTimer = setTimeout(forceKill, timeoutMs);
       shutdownTimer.unref();
       child.kill(signal);
@@ -32,11 +52,21 @@ function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = s
     parentProcess.on(signal, handler);
   }
 
-  child.once("exit", (code, signal) => {
-    if (shutdownTimer) clearTimeout(shutdownTimer);
+  // Without a listener an 'error' event is fatal to the wrapper itself, so a
+  // spawn failure surfaced as a bare stack trace rather than a reason.
+  child.once("error", (error) => {
+    unwire();
+    log(`[pi-web] could not run the Next.js process: ${error.message}`);
+    parentProcess.exit(1);
+  });
 
-    for (const [forwardedSignal, handler] of signalHandlers) {
-      parentProcess.removeListener(forwardedSignal, handler);
+  child.once("exit", (code, signal) => {
+    unwire();
+
+    // A shutdown the user asked for needs no explanation; anything else left
+    // the window closing with no stated reason.
+    if (!shuttingDown && (signal || (code ?? 0) !== 0)) {
+      log(`[pi-web] Next.js exited unexpectedly (${describeExit(code, signal)})`);
     }
 
     parentProcess.exit(code ?? getSignalExitCode(signal));

--- a/lib/process-lifecycle.test.mjs
+++ b/lib/process-lifecycle.test.mjs
@@ -81,3 +81,63 @@ test("uses conventional exit statuses for known child signals", () => {
     assert.deepEqual(exitCodes, [expectedExitCode]);
   }
 });
+
+test("reports a spawn failure instead of crashing on an unhandled error event", () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  // Without a listener this event is fatal to the wrapper itself.
+  child.emit("error", new Error("spawn node ENOENT"));
+
+  assert.deepEqual(exitCodes, [1]);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /could not run the Next\.js process: spawn node ENOENT/);
+  assert.equal(parent.listenerCount("SIGINT"), 0, "the signal wiring must be torn down");
+});
+
+test("names the reason when the child stops on its own", () => {
+  for (const [code, signal, expected] of [
+    [null, "SIGKILL", /signal SIGKILL/],
+    [1, null, /code 1/],
+  ]) {
+    const { parent, child, exitCodes } = createProcesses();
+    const logged = [];
+
+    wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+    child.emit("exit", code, signal);
+
+    assert.equal(logged.length, 1, `expected one line for ${describe(code, signal)}`);
+    assert.match(logged[0], expected);
+    // The exit status still carries the failure.
+    assert.notDeepEqual(exitCodes, [0]);
+  }
+});
+
+test("stays quiet for a shutdown the user asked for", async () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  parent.emit("SIGINT");
+  child.emit("exit", null, "SIGINT");
+  await delay(20);
+
+  assert.deepEqual(logged, [], "ctrl+c is not an incident");
+  assert.deepEqual(exitCodes, [130]);
+});
+
+test("a clean exit says nothing", () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  child.emit("exit", 0, null);
+
+  assert.deepEqual(logged, []);
+  assert.deepEqual(exitCodes, [0]);
+});
+
+function describe(code, signal) {
+  return signal ? `signal ${signal}` : `code ${code}`;
+}


### PR DESCRIPTION
## Summary

- handle `child.on("error")`, which had no listener at all
- name the signal or code when the child stops on its own
- stay quiet for a shutdown we forwarded, so ctrl+c does not read as an incident

Refs #506.

## What was still open

One part of #506 is already fixed on `main`: the `code ?? 0` it quotes came from `bin/pi-web.js`, and #502 moved that into `bin/process-lifecycle.js` as `code ?? getSignalExitCode(signal)`, so a signal termination reports `128 + signum` rather than success. Worth saying explicitly, since the issue is the reason someone would look.

The other two points still stand:

**No error listener.** `wireChildProcessLifecycle` wired `exit` but never `error`. An `error` event with no listener is fatal to the wrapper itself, so a spawn failure — a bad `node`, a missing Next entry — surfaced as an unhandled-event stack trace instead of a reason. It now logs and exits 1.

**No diagnostic.** An exit the user did not ask for said nothing, which is exactly the "pi-web disappears and PowerShell returns with no visible shutdown reason" case. It now prints e.g.

```
[pi-web] Next.js exited unexpectedly (signal SIGKILL)
[pi-web] Next.js exited unexpectedly (code 1)
```

Only when we did not initiate it. Once we forward SIGINT/SIGTERM the exit is expected, so ctrl+c stays silent and a clean exit prints nothing — otherwise every ordinary shutdown would announce itself and the message would stop meaning anything.

`log` is injectable (defaults to `console.error`) so the tests assert on it rather than capturing global stderr.

## Test plan

- Ran: `node --experimental-strip-types --test lib/process-lifecycle.test.mjs` (8 passed, 4 new: spawn failure, signal exit, non-zero exit, forwarded shutdown, clean exit)
- Ran: `npm run lint`
- Checked: removing the `error` listener again fails the new spawn-failure case
- Checked: `npm test` failure count unchanged from a clean `2a6e537` on this Windows checkout
