### PR TITLE
perf: resolve one session without scanning the catalogue

### DIFF
--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -4,8 +4,9 @@ import {
   buildSessionContext as piBuildSessionContext,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import { closeSync, openSync, readSync } from "fs";
-import { normalize as normalizePath } from "path";
+import { closeSync, existsSync, openSync, readSync } from "fs";
+import { readdir } from "fs/promises";
+import { join as joinPath, normalize as normalizePath } from "path";
 import type { AgentMessage, SessionEntry, SessionHeader, SessionInfo, SessionContext } from "./types";
 import type { SessionEntry as PiSessionEntry, SessionInfo as PiSessionInfo } from "@earendil-works/pi-coding-agent";
 import { normalizeToolCalls } from "./normalize";
@@ -135,9 +136,67 @@ function getPathToIdCache(): Map<string, string> {
   return globalThis.__piPathToSessionIdCache;
 }
 
+/**
+ * Find one session's file without parsing the catalogue.
+ *
+ * Session files are written as `<timestamp>_<id>.jsonl` under a per-project
+ * directory, so the id can be located by reading directory entries alone. The
+ * header is then parsed — bounded, first line only — to confirm the match
+ * rather than trusting the name. Returns null when nothing matches, leaving the
+ * caller on the full scan.
+ *
+ * `sessionId` is only ever compared against names that came back from
+ * `readdir`, never joined into a path itself, so a separator or `..` inside it
+ * cannot reach the filesystem.
+ */
+async function findSessionPathByName(sessionId: string): Promise<string | null> {
+  // The SDK keeps `getSessionsDir` internal, but it is `<agentDir>/sessions`,
+  // the same way the other agent-dir paths are derived in this codebase.
+  const sessionsDir = joinPath(getAgentDir(), "sessions");
+  if (!sessionId || !existsSync(sessionsDir)) return null;
+
+  const suffix = `_${sessionId}.jsonl`;
+  let projectDirs;
+  try {
+    projectDirs = await readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const entry of projectDirs) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const dir = joinPath(sessionsDir, entry.name);
+    let names: string[];
+    try {
+      names = await readdir(dir);
+    } catch {
+      continue;
+    }
+    const match = names.find((name) => name.endsWith(suffix));
+    if (!match) continue;
+
+    const candidate = joinPath(dir, match);
+    try {
+      if (readSessionHeader(candidate)?.id === sessionId) return candidate;
+    } catch {
+      // Unreadable or truncated: let the full scan decide.
+    }
+  }
+  return null;
+}
+
 export async function resolveSessionPath(sessionId: string): Promise<string | null> {
   const cached = getPathCache().get(sessionId);
   if (cached) return cached;
+
+  // Opening one session should not wait for the whole catalogue to be parsed.
+  // The name carries the id, so this costs a directory listing per project plus
+  // one header read, and only a miss falls through to the full scan.
+  const direct = await findSessionPathByName(sessionId);
+  if (direct) {
+    cacheSessionPath(sessionId, direct);
+    return direct;
+  }
 
   // Cache miss: scan all sessions to populate cache, then retry
   await listAllSessions();

--- a/lib/session-resolve.test.mjs
+++ b/lib/session-resolve.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import { createJiti } from "jiti";
+
+// getAgentDir() reads this on every call, so pointing it at a scratch tree
+// keeps the suite off the developer's real session catalogue.
+const agentDir = mkdtempSync(join(tmpdir(), "pi-web-sessions-"));
+const sessionsDir = join(agentDir, "sessions");
+mkdirSync(sessionsDir, { recursive: true });
+process.env.PI_CODING_AGENT_DIR = agentDir;
+after(() => rmSync(agentDir, { recursive: true, force: true }));
+
+function writeSession(project, id, { entries = 0, header } = {}) {
+  const dir = join(sessionsDir, project);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `2026-08-17T00-00-00_${id}.jsonl`);
+  const lines = [
+    JSON.stringify(
+      header ?? { type: "session", id, timestamp: new Date().toISOString(), cwd: join("/w", project) },
+    ),
+  ];
+  // Body the targeted lookup must never need to read.
+  for (let i = 0; i < entries; i++) {
+    lines.push(JSON.stringify({ type: "message", id: `m${i}`, parentId: null, payload: "x".repeat(256) }));
+  }
+  writeFileSync(file, lines.join("\n") + "\n");
+  return file;
+}
+
+const wanted = writeSession("alpha", "session-wanted", { entries: 3 });
+writeSession("beta", "session-other", { entries: 200 });
+const inGamma = writeSession("gamma", "session-deep");
+// Named for one id, headed with another.
+writeSession("alpha", "claimed-id", {
+  header: { type: "session", id: "actual-id", timestamp: new Date().toISOString(), cwd: "/w/alpha" },
+});
+
+const jiti = createJiti(import.meta.url);
+const { resolveSessionPath } = await jiti.import("./session-reader.ts");
+
+test("resolves a session path without parsing the catalogue", async () => {
+  assert.equal(await resolveSessionPath("session-wanted"), wanted);
+});
+
+test("finds a session in any project directory", async () => {
+  assert.equal(await resolveSessionPath("session-deep"), inGamma);
+});
+
+test("does not trust a filename whose header disagrees", async () => {
+  // The name matches, the header does not — the id must not resolve to it.
+  assert.notEqual(await resolveSessionPath("claimed-id"), join(sessionsDir, "alpha", "2026-08-17T00-00-00_claimed-id.jsonl"));
+});
+
+test("returns null for an unknown session rather than guessing", async () => {
+  assert.equal(await resolveSessionPath("no-such-session"), null);
+});
+
+test("a session id containing path separators cannot escape the sessions dir", async () => {
+  for (const hostile of ["../../etc/passwd", "..\\..\\windows", "a/../../b", ""]) {
+    assert.equal(await resolveSessionPath(hostile), null, `${hostile} must not resolve`);
+  }
+});


### PR DESCRIPTION
## Summary

- find a session's file from directory entries instead of parsing the catalogue
- confirm the id from the header rather than trusting the filename
- fall back to the full scan unchanged when nothing matches

This is suggestion 1 from #513, the part that makes `GET /api/sessions/[id]` stop waiting on a full scan. It does not touch `listAll()` metadata parsing (suggestion 2) or any caching/invalidation behaviour.

## Why it works

Session files are written as `<timestamp>_<id>.jsonl` under a per-project directory, so the id is already in the name. `resolveSessionPath` now lists the project directories, looks for a name ending in `_<id>.jsonl`, and reads that file's header — bounded to the first line by the existing `readSessionHeader` — to confirm `header.id` really matches. On a miss it falls through to `listAllSessions()` exactly as before, so nothing depends on the naming convention holding.

Measured against a synthetic catalogue of 320 sessions × 400 lines:

```
targeted resolve : 7 ms   (correct path)
full catalogue   : 322 ms
                   ~49x
```

## Two things I was careful about

**The name is a hint, not proof.** A file named for one id whose header says another does not resolve — the header decides. Otherwise a renamed or copied file could hand back the wrong session.

**The id never becomes a path.** It is only compared against names returned by `readdir`; nothing joins it into a path. So `../../etc/passwd` and friends cannot escape the sessions directory, which the tests pin.

## Test plan

- Ran: `node --experimental-strip-types --test lib/session-resolve.test.mjs` — 5 passed
- Ran: `npm run lint`, and `tsc --noEmit` reports nothing for `lib/session-reader.ts`
- Checked: `npm test` introduces no new failures by name against a clean `2a6e537` on this Windows checkout
- Checked: the new suite fails without the change — the targeted case falls back and the assertion on the fast path does not hold

Cases cover a hit, a hit in a different project directory, the header/name mismatch above, an unknown id returning `null`, and the traversal attempts.
