### PR TITLE
fix: improve built-in slash command dispatch

### DIFF
--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
   jsx: { runtime: "automatic" },
   tsconfigPaths: true,
 });
-const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand } = await jiti.import("./ChatInput.tsx");
+const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand } = await jiti.import("./ChatInput.tsx");
 const { clearDraft, getDraft, mergeRestoredSubmissionDraft, mergeRestoredSubmissionText, rekeyDraft, setDraft } = await jiti.import("../lib/draft-store.ts");
 const { I18nProvider } = await jiti.import("../hooks/useI18n.tsx");
 
@@ -125,10 +125,18 @@ test("caps an upward menu to the visible space above its anchor", () => {
 });
 
 test("recognizes exact slash commands for one-Enter submission", () => {
-  assert.equal(isExactSlashCommand("/copy", "copy"), true);
-  assert.equal(isExactSlashCommand("  /copy  ", "copy"), true);
-  assert.equal(isExactSlashCommand("/co", "copy"), false);
-  assert.equal(isExactSlashCommand("/copy extra", "copy"), false);
+  const builtin = { name: "copy", description: "", source: "builtin" };
+  assert.equal(isExactSlashCommand("/copy", builtin), true);
+  assert.equal(isExactSlashCommand("  /copy  ", builtin), true);
+  assert.equal(isExactSlashCommand("/co", builtin), false);
+  assert.equal(isExactSlashCommand("/copy extra", builtin), false);
+  assert.equal(isExactSlashCommand("/copy", { ...builtin, source: "extension" }), false);
+});
+
+test("clears a completed built-in only while its submitted input is unchanged", () => {
+  assert.equal(canClearBuiltinCommandInput("/copy", 0, "/copy"), true);
+  assert.equal(canClearBuiltinCommandInput("new follow-up", 0, "/copy"), false);
+  assert.equal(canClearBuiltinCommandInput("/copy", 1, "/copy"), false);
 });
 
 test("keeps only read-only built-ins available while a run is active", () => {

--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
   jsx: { runtime: "automatic" },
   tsconfigPaths: true,
 });
-const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canRestoreUserMessage, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages } = await jiti.import("./ChatInput.tsx");
+const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand } = await jiti.import("./ChatInput.tsx");
 const { clearDraft, getDraft, mergeRestoredSubmissionDraft, mergeRestoredSubmissionText, rekeyDraft, setDraft } = await jiti.import("../lib/draft-store.ts");
 const { I18nProvider } = await jiti.import("../hooks/useI18n.tsx");
 
@@ -122,6 +122,20 @@ test("filters model options by name and id", () => {
 test("caps an upward menu to the visible space above its anchor", () => {
   assert.equal(getUpwardMenuMaxHeight(343, 36), 299);
   assert.equal(getUpwardMenuMaxHeight(40, 36), 0);
+});
+
+test("recognizes exact slash commands for one-Enter submission", () => {
+  assert.equal(isExactSlashCommand("/copy", "copy"), true);
+  assert.equal(isExactSlashCommand("  /copy  ", "copy"), true);
+  assert.equal(isExactSlashCommand("/co", "copy"), false);
+  assert.equal(isExactSlashCommand("/copy extra", "copy"), false);
+});
+
+test("keeps only read-only built-ins available while a run is active", () => {
+  assert.equal(canRunBuiltinSlashCommandWhileStreaming("/copy"), true);
+  assert.equal(canRunBuiltinSlashCommandWhileStreaming("/session"), true);
+  assert.equal(canRunBuiltinSlashCommandWhileStreaming("/compact"), false);
+  assert.equal(canRunBuiltinSlashCommandWhileStreaming("/reload"), false);
 });
 
 test("restores text and base64 images when editing a user message", () => {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -151,21 +151,38 @@ function formatTokenCount(tokens: number): string {
   return tokens.toLocaleString();
 }
 
-type SlashCommandPaletteItem = SlashCommandInfo | {
+type BuiltinSlashCommand = {
   name: string;
   description: string;
   source: "builtin";
+  availableWhileStreaming?: boolean;
 };
+
+type SlashCommandPaletteItem = SlashCommandInfo | BuiltinSlashCommand;
 
 type SlashCommandSource = SlashCommandPaletteItem["source"];
 
-const BUILTIN_SLASH_COMMANDS: SlashCommandPaletteItem[] = [
+const BUILTIN_SLASH_COMMANDS: BuiltinSlashCommand[] = [
   { name: "compact", description: "chat.commandCompact", source: "builtin" },
   { name: "reload", description: "chat.commandReload", source: "builtin" },
   { name: "name", description: "chat.commandName", source: "builtin" },
-  { name: "session", description: "chat.commandSession", source: "builtin" },
-  { name: "copy", description: "chat.commandCopy", source: "builtin" },
+  { name: "session", description: "chat.commandSession", source: "builtin", availableWhileStreaming: true },
+  { name: "copy", description: "chat.commandCopy", source: "builtin", availableWhileStreaming: true },
 ];
+
+function getBuiltinSlashCommand(message: string): BuiltinSlashCommand | undefined {
+  const match = message.trim().match(/^\/([^\s]+)(?:\s|$)/);
+  if (!match) return undefined;
+  return BUILTIN_SLASH_COMMANDS.find((command) => command.name === match[1]);
+}
+
+export function canRunBuiltinSlashCommandWhileStreaming(message: string): boolean {
+  return getBuiltinSlashCommand(message)?.availableWhileStreaming === true;
+}
+
+export function isExactSlashCommand(message: string, commandName: string): boolean {
+  return message.trim() === `/${commandName}`;
+}
 
 const SLASH_SOURCES: SlashCommandSource[] = ["builtin", "extension", "prompt", "skill"];
 
@@ -749,21 +766,24 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     };
   }, []);
 
+  const runBuiltinCommand = useCallback(async (msg: string): Promise<boolean> => {
+    if (attachedImages.length || !msg.startsWith("/") || !onBuiltinCommand) return false;
+    const result = await onBuiltinCommand(msg);
+    if (!result.handled) return false;
+    if (!result.error) clearInput();
+    return true;
+  }, [attachedImages.length, clearInput, onBuiltinCommand]);
+
   const handleSend = useCallback(async () => {
     const msg = value.trim();
     if (!msg && !attachedImages.length) return;
-    if (isStreaming) return;
     onAudioUnlock?.();
-    if (!attachedImages.length && msg.startsWith("/") && onBuiltinCommand) {
-      const result = await onBuiltinCommand(msg);
-      if (result.handled) {
-        if (!result.error) clearInput();
-        return;
-      }
-    }
+    const builtinAllowed = !isStreaming || canRunBuiltinSlashCommandWhileStreaming(msg);
+    if (builtinAllowed && await runBuiltinCommand(msg)) return;
+    if (isStreaming) return;
     clearInput();
     onSend(msg, attachedImages.length ? attachedImages : undefined);
-  }, [value, attachedImages, isStreaming, onBuiltinCommand, onSend, clearInput, onAudioUnlock]);
+  }, [value, attachedImages, isStreaming, runBuiltinCommand, onSend, clearInput, onAudioUnlock]);
 
   const slashQuery = value.startsWith("/") && !/\s/.test(value.slice(1))
     ? value.slice(1).toLowerCase()
@@ -771,7 +791,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
 
   const filteredSlashCommands = (() => {
     if (slashQuery === null) return [];
-    const commands = [...(isStreaming ? [] : BUILTIN_SLASH_COMMANDS), ...(slashCommands ?? [])];
+    const builtinCommands = isStreaming
+      ? BUILTIN_SLASH_COMMANDS.filter((command) => command.availableWhileStreaming)
+      : BUILTIN_SLASH_COMMANDS;
+    const commands = [...builtinCommands, ...(slashCommands ?? [])];
     return [...commands]
       .filter((command) => {
         const name = command.name.toLowerCase();
@@ -983,6 +1006,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     const msg = value.trim();
     if (!msg && !attachedImages.length) return;
     onAudioUnlock?.();
+    if (!attachedImages.length && onBuiltinCommand && canRunBuiltinSlashCommandWhileStreaming(msg)) {
+      void runBuiltinCommand(msg);
+      return;
+    }
     const streamingBehavior = mode === "steer" ? "steer" : "followUp";
     if (msg.startsWith("/") && onPromptWithStreamingBehavior) {
       clearInput();
@@ -995,7 +1022,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     } else if (mode === "followup" && onFollowUp) {
       onFollowUp(msg, attachedImages.length ? attachedImages : undefined);
     }
-  }, [value, attachedImages, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput, onAudioUnlock]);
+  }, [value, attachedImages, onBuiltinCommand, onPromptWithStreamingBehavior, onSteer, onFollowUp, clearInput, onAudioUnlock, runBuiltinCommand]);
 
   const getNextSlashIndex = useCallback((direction: "up" | "down" | "left" | "right") => {
     const lastIndex = displayedSlashCommands.length - 1;
@@ -1104,9 +1131,22 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           setSlashMenuOpen(false);
           return;
         }
-        if ((e.key === "Tab" || sendShortcut) && displayedSlashCommands[slashActiveIndex]) {
+        const selectedCommand = displayedSlashCommands[slashActiveIndex];
+        if (e.key === "Tab" && selectedCommand) {
           e.preventDefault();
-          applySlashCommand(displayedSlashCommands[slashActiveIndex]);
+          applySlashCommand(selectedCommand);
+          return;
+        }
+        if (sendShortcut && selectedCommand) {
+          e.preventDefault();
+          const canSubmitNow = !isStreaming
+            || (selectedCommand.source === "builtin" && selectedCommand.availableWhileStreaming === true);
+          if (canSubmitNow && isExactSlashCommand(value, selectedCommand.name)) {
+            setSlashMenuOpen(false);
+            void handleSend();
+          } else {
+            applySlashCommand(selectedCommand);
+          }
           return;
         }
       }

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -180,8 +180,12 @@ export function canRunBuiltinSlashCommandWhileStreaming(message: string): boolea
   return getBuiltinSlashCommand(message)?.availableWhileStreaming === true;
 }
 
-export function isExactSlashCommand(message: string, commandName: string): boolean {
-  return message.trim() === `/${commandName}`;
+export function isExactSlashCommand(message: string, command: SlashCommandPaletteItem): boolean {
+  return command.source === "builtin" && message.trim() === `/${command.name}`;
+}
+
+export function canClearBuiltinCommandInput(message: string, imageCount: number, submittedMessage: string): boolean {
+  return imageCount === 0 && message.trim() === submittedMessage;
 }
 
 const SLASH_SOURCES: SlashCommandSource[] = ["builtin", "extension", "prompt", "skill"];
@@ -770,7 +774,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     if (attachedImages.length || !msg.startsWith("/") || !onBuiltinCommand) return false;
     const result = await onBuiltinCommand(msg);
     if (!result.handled) return false;
-    if (!result.error) clearInput();
+    if (!result.error && canClearBuiltinCommandInput(valueRef.current, attachedImagesRef.current.length, msg)) clearInput();
     return true;
   }, [attachedImages.length, clearInput, onBuiltinCommand]);
 
@@ -1141,7 +1145,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           e.preventDefault();
           const canSubmitNow = !isStreaming
             || (selectedCommand.source === "builtin" && selectedCommand.availableWhileStreaming === true);
-          if (canSubmitNow && isExactSlashCommand(value, selectedCommand.name)) {
+          if (canSubmitNow && isExactSlashCommand(value, selectedCommand)) {
             setSlashMenuOpen(false);
             void handleSend();
           } else {


### PR DESCRIPTION
## Summary

- Execute an exact built-in slash command on the first Enter press instead of re-applying the selected autocomplete item.
- Keep the read-only `/copy` and `/session` commands available while an agent or shell command is running.
- Route those read-only commands through the existing built-in handler instead of treating them as steer/follow-up prompts.
- Keep Tab as the explicit completion action and keep mutating built-ins unavailable during active runs.

## Motivation

When the autocomplete menu is open and the input already exactly matches a built-in command such as `/copy`, the first Enter press currently only applies the completion and closes the menu. A second Enter is required to execute it.

Built-in commands are also removed from the palette while a run is active, and `ChatInput` returns before dispatching them. This unnecessarily blocks read-only operations such as copying the last assistant response or opening session statistics.

## Behavior

| State | Input | Result |
| --- | --- | --- |
| Idle | exact `/copy` + Enter | Execute immediately |
| Idle | partial `/co` + Enter | Apply `/copy ` completion |
| Idle | partial `/co` + Tab | Apply `/copy ` completion |
| Running | `/copy` or `/session` | Execute through the built-in handler |
| Running | `/compact`, `/reload`, `/name` | Remain unavailable |

## Tests

- `tsc --noEmit`
- `npm run lint`
- Focused tests for exact command matching and active-run availability
- Browser verification: `/copy` executes with one Enter while idle
- Browser verification: `/copy` remains available and executes during a disposable `!sleep` run

The complete repository test suite has 35 pre-existing failures on the unmodified `origin/main` checkout and the same 35 failures on this branch. The two tests added by this change pass.
