### PR TITLE
fix(files): serve inline SVG previews with a script-blocking CSP

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -297,12 +297,23 @@ function getContentDisposition(filePath: string, asDownload = false): string {
 }
 
 function streamFile(filePath: string, stat: fs.Stats, contentType: string, rangeHeader: string | null, asDownload = false): Response {
-  const headers = {
+  const headers: Record<string, string> = {
     "Content-Type": contentType,
     "Cache-Control": "no-cache",
     "Accept-Ranges": "bytes",
     "Content-Disposition": getContentDisposition(filePath, asDownload),
+    "X-Content-Type-Options": "nosniff",
   };
+  // SVG is the only preview type a browser executes as a document. A
+  // repo-controlled SVG navigated to directly (for example through a link in
+  // a transcript) would otherwise run script in the Pi Web origin, where it
+  // can call any /api route. These headers only affect document rendering;
+  // <img> preview embedding ignores them.
+  if (contentType === "image/svg+xml") {
+    headers["Content-Security-Policy"] =
+      "default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'";
+    headers["Referrer-Policy"] = "no-referrer";
+  }
 
   if (!rangeHeader) {
     return new Response(createFileBodyStream(filePath), {

--- a/app/api/files/stream-route.test.mjs
+++ b/app/api/files/stream-route.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./[...path]/route.ts", import.meta.url), "utf8");
+const start = source.indexOf("function streamFile");
+const end = source.indexOf("function escapeHtml", start);
+assert.notEqual(start, -1, "streamFile not found");
+assert.notEqual(end, -1, "streamFile end not found");
+const streamBlock = source.slice(start, end);
+
+test("streamed responses are not content-type sniffable", () => {
+  assert.match(streamBlock, /"X-Content-Type-Options": "nosniff"/);
+});
+
+test("inline SVG is served with a script-blocking content security policy", () => {
+  // SVG is the only inline preview type a browser executes as a document, so
+  // it must never be able to run script in the Pi Web origin.
+  assert.match(streamBlock, /contentType === "image\/svg\+xml"/);
+  assert.match(streamBlock, /Content-Security-Policy/);
+  assert.match(streamBlock, /default-src 'none'/);
+  assert.match(streamBlock, /style-src 'unsafe-inline'/);
+  assert.match(streamBlock, /frame-ancestors 'self'/);
+});
+
+test("the restrictive headers are applied to every streamFile response shape", () => {
+  // The header object is shared by the full-body, 416, and 206 paths.
+  const headerObject = streamBlock.indexOf("const headers");
+  const firstReturn = streamBlock.indexOf("createFileBodyStream", headerObject);
+  assert.ok(headerObject !== -1 && firstReturn > headerObject, "headers must be built before any response");
+});


### PR DESCRIPTION
## Problem

`GET /api/files/<path>.svg?type=read` serves `image/svg+xml` **inline** through `streamFile()`, which sets only `Content-Type` / `Cache-Control` / `Accept-Ranges` / `Content-Disposition` — no `Content-Security-Policy`, no `X-Content-Type-Options`. The DOCX preview route (`?type=preview`) already ships a restrictive CSP, but SVG is the one *repo-controlled* preview type a browser executes as a document, and it was left open.

SVG is HTML-capable, so an SVG inside a project opened in Pi Web can carry `<script>`:

```xml
<svg xmlns="http://www.w3.org/2000/svg">
  <script>fetch('/api/auth/api-key/anthropic', {method:'POST', ...})</script>
</svg>
```

Navigating to the file URL renders it as a **same-origin document** (`http://127.0.0.1:30141/api/files/...`), where the script runs with full access to every `/api/*` route — including routes that read/write provider credentials — and with the user's Basic Auth credentials attached automatically when `PI_WEB_PASSWORD` is set. A realistic entry point: the agent quotes or emits a link to an SVG asset in a transcript, and `MarkdownBody` renders non-local hrefs as `target="_blank"` links; one click executes. This matters precisely for the "open a repo you don't fully trust" workflow the rest of the codebase (path-security, request-security, DOCX CSP) is already hardened against.

## Fix

- Serve `image/svg+xml` with the same policy the DOCX preview already uses (`default-src 'none'; img-src data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'` + `Referrer-Policy: no-referrer`), so scripts can never run while legit SVGs keep inline styles and data-URI images when viewed as a document.
- Add `X-Content-Type-Options: nosniff` to every `streamFile()` response.
- In-app previews are unaffected: CSP response headers are ignored for `<img>` embedding, so the file viewer renders SVGs exactly as before.

Tests: `app/api/files/stream-route.test.mjs` (source-assertion, following the existing `watch-route.test.mjs` convention) asserts the headers exist on the shared header object used by all `streamFile` responses. Full suite 590/590, `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)