### PR TITLE
fix(files): authorize downloads for wrapper apps via signed tokens

### DIFF
--- a/app/api/auth/download-token/route.ts
+++ b/app/api/auth/download-token/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "node:fs";
+import {
+ getAllowedFileRoots,
+ isExistingFilePathAllowed,
+ isFilePathAllowed,
+ normalizeSlashes,
+} from "@/lib/file-access";
+import { encodeFilePathForApi } from "@/lib/file-paths";
+import {
+ DOWNLOAD_TOKEN_TTL_MS,
+ createDownloadToken,
+ getDownloadSecret,
+} from "@/lib/download-auth";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Issue a one-time signed download token for a file.
+ *
+ * The endpoint is protected by Basic Auth (enforced in proxy.ts). Wrapper apps
+ * (e.g. Pake) replay download requests through their own HTTP client without
+ * the page's Basic credentials, so they rely on the short-lived signed token
+ * issued here to pass the proxy check.
+ *
+ * Query parameters:
+ * - path: absolute path of the target file (URL-encoded)
+ *
+ * Returns `{ token, expiresAt }` on success, or a 4xx JSON error.
+ *
+ * @param request - GET request with the `path` query parameter
+ * @returns JSON response carrying the download token
+ */
+export async function GET(request: NextRequest) {
+ const rawPath = request.nextUrl.searchParams.get("path");
+ if (!rawPath) {
+  return NextResponse.json(
+   { error: "Missing path parameter" },
+   { status: 400 },
+  );
+ }
+
+ let filePath: string;
+ try {
+  filePath = decodeURIComponent(rawPath);
+ } catch {
+  return NextResponse.json(
+   { error: "Invalid path parameter" },
+   { status: 400 },
+  );
+ }
+ filePath = normalizeSlashes(filePath);
+
+ const allowedRoots = await getAllowedFileRoots();
+ if (!isFilePathAllowed(filePath, allowedRoots)) {
+  return NextResponse.json({ error: "Access denied" }, { status: 403 });
+ }
+
+ let stat: fs.Stats;
+ try {
+  stat = fs.statSync(filePath);
+ } catch {
+  return NextResponse.json({ error: "File not found" }, { status: 404 });
+ }
+ if (!stat.isFile()) {
+  return NextResponse.json({ error: "Not a file" }, { status: 400 });
+ }
+
+ // Re-check after resolving symlinks so a link cannot escape the allowed roots.
+ if (!isExistingFilePathAllowed(filePath, allowedRoots)) {
+  return NextResponse.json({ error: "Access denied" }, { status: 403 });
+ }
+
+ const pathname = `/api/files/${encodeFilePathForApi(filePath)}`;
+ const token = createDownloadToken(getDownloadSecret(), pathname);
+ return NextResponse.json({
+  token,
+  expiresAt: Date.now() + DOWNLOAD_TOKEN_TTL_MS,
+ });
+}

--- a/components/FileExplorer.tsx
+++ b/components/FileExplorer.tsx
@@ -12,7 +12,44 @@ import {
 } from "@/lib/file-paths";
 import type { GitFileStatus, GitFileStatusKind, GitStatusResponse } from "@/lib/git-types";
 import { useI18n } from "@/hooks/useI18n";
+import { isPakeInterceptedDownload } from "@/lib/pake-download-extensions";
 type Translate = ReturnType<typeof useI18n>["t"];
+
+/**
+ * Build a download URL with a short-lived signed download token.
+ *
+ * Wrapper apps (e.g. Pake) replay download links through their own HTTP client
+ * without the page's Basic credentials, and they intercept clicks in the
+ * capture phase before React handlers run. The token therefore must be written
+ * into the href before the click happens (prefetched on hover; see the
+ * download button's onMouseEnter). Falls back to the plain link when token
+ * issuance fails (browser clients still carry credentials and download fine).
+ */
+async function buildDownloadUrl(
+  fullPath: string,
+): Promise<{ url: string; expiresAt: number }> {
+  const url = `/api/files/${encodeFilePathForApi(fullPath)}?type=download`;
+  try {
+    const response = await fetch(
+      `/api/auth/download-token?path=${encodeURIComponent(fullPath)}`,
+    );
+    if (response.ok) {
+      const { token, expiresAt } = (await response.json()) as {
+        token?: string;
+        expiresAt?: number;
+      };
+      if (token) {
+        return {
+          url: `${url}&dt=${encodeURIComponent(token)}`,
+          expiresAt: Number(expiresAt) || 0,
+        };
+      }
+    }
+  } catch {
+    // Fall back to the plain link when issuance fails.
+  }
+  return { url, expiresAt: 0 };
+}
 
 interface FileEntry {
   name: string;
@@ -394,8 +431,24 @@ function TreeNode({
         {hovered && !node.isDir && (
           <a
             href={`/api/files/${encodeFilePathForApi(node.fullPath)}?type=download`}
-            download
-            onClick={(e) => e.stopPropagation()}
+            download={
+              isPakeInterceptedDownload(node.fullPath)
+                ? getFileName(node.fullPath)
+                : undefined
+            }
+            onMouseEnter={(e) => {
+              // Pake intercepts clicks in the capture phase, so the token must
+              // be in the href before the click. Re-issue only when the armed
+              // token has expired to avoid re-fetching on every hover.
+              const current = e.currentTarget as HTMLAnchorElement;
+              const armedUntil = Number(current.dataset.dtExpires ?? 0);
+              if (armedUntil > Date.now()) return;
+              void (async () => {
+                const { url, expiresAt } = await buildDownloadUrl(node.fullPath);
+                current.setAttribute("href", url);
+                if (expiresAt > 0) current.dataset.dtExpires = String(expiresAt);
+              })();
+            }}
             title={t("files.download")}
             style={{
               position: "absolute",

--- a/lib/download-auth.test.mjs
+++ b/lib/download-auth.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+
+const { DOWNLOAD_TOKEN_TTL_MS, createDownloadToken, verifyDownloadToken } =
+  await jiti.import("./download-auth.ts");
+
+const SECRET = "test-secret-12345";
+
+test("token verifies after issuance", () => {
+  const token = createDownloadToken(
+    SECRET,
+    "/api/files/home/user/%E6%8A%A5%E8%A1%A8.xlsx",
+  );
+  assert.equal(
+    verifyDownloadToken(
+      SECRET,
+      "/api/files/home/user/%E6%8A%A5%E8%A1%A8.xlsx",
+      token,
+    ),
+    true,
+  );
+});
+
+test("token fails when the pathname is tampered with", () => {
+  const token = createDownloadToken(SECRET, "/api/files/home/user/a.docx");
+  assert.equal(
+    verifyDownloadToken(SECRET, "/api/files/home/user/b.docx", token),
+    false,
+  );
+});
+
+test("expired token fails verification", () => {
+  const now = Date.now();
+  const token = createDownloadToken(SECRET, "/api/files/home/user/a.docx", now);
+  assert.equal(
+    verifyDownloadToken(
+      SECRET,
+      "/api/files/home/user/a.docx",
+      token,
+      now + DOWNLOAD_TOKEN_TTL_MS + 1,
+    ),
+    false,
+  );
+});
+
+test("token verifies anywhere inside the TTL window", () => {
+  const now = Date.now();
+  const token = createDownloadToken(SECRET, "/api/files/home/user/a.docx", now);
+  assert.equal(
+    verifyDownloadToken(
+      SECRET,
+      "/api/files/home/user/a.docx",
+      token,
+      now + DOWNLOAD_TOKEN_TTL_MS - 1,
+    ),
+    true,
+  );
+});
+
+test("token fails with a different secret", () => {
+  const token = createDownloadToken(SECRET, "/api/files/home/user/a.docx");
+  assert.equal(
+    verifyDownloadToken("other-secret", "/api/files/home/user/a.docx", token),
+    false,
+  );
+});
+
+test("malformed tokens are rejected", () => {
+  assert.equal(
+    verifyDownloadToken(SECRET, "/api/files/home/user/a.docx", "garbage"),
+    false,
+  );
+  assert.equal(
+    verifyDownloadToken(SECRET, "/api/files/home/user/a.docx", "123.zzz"),
+    false,
+  );
+  assert.equal(
+    verifyDownloadToken(SECRET, "/api/files/home/user/a.docx", ""),
+    false,
+  );
+});
+
+test("empty pathname or empty token is rejected", () => {
+  const token = createDownloadToken(SECRET, "/api/files/home/user/a.docx");
+  assert.equal(verifyDownloadToken(SECRET, "", token), false);
+  assert.equal(
+    verifyDownloadToken(SECRET, "/api/files/home/user/a.docx", null),
+    false,
+  );
+});

--- a/lib/download-auth.ts
+++ b/lib/download-auth.ts
@@ -1,0 +1,106 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+/** Download token TTL in milliseconds. Covers the hover-to-click gap. */
+export const DOWNLOAD_TOKEN_TTL_MS = 5 * 60_000;
+
+/** Purpose string bound into every signature so a token cannot be reused elsewhere. */
+const DOWNLOAD_PURPOSE = "download";
+
+declare global {
+ var __piDownloadSecret: string | undefined;
+}
+
+/**
+ * Resolve the signing secret for download tokens.
+ *
+ * Prefers the PI_WEB_DOWNLOAD_SECRET environment variable (an explicit
+ * operator choice for cross-restart/process stability). Otherwise a random
+ * 32-byte key is generated once and cached on globalThis — issuance and
+ * verification always happen in the same process, so a random secret is
+ * sufficient, and keeping it in memory (never persisted) shrinks exposure.
+ *
+ * @returns the signing secret
+ */
+export function getDownloadSecret(): string {
+ const fromEnv = process.env.PI_WEB_DOWNLOAD_SECRET;
+ if (fromEnv) return fromEnv;
+ if (!globalThis.__piDownloadSecret) {
+  globalThis.__piDownloadSecret = randomBytes(32).toString("hex");
+ }
+ return globalThis.__piDownloadSecret;
+}
+
+/**
+ * Create a one-time download token for a download target.
+ *
+ * The token is `<expiry_epoch_ms>.<hmac-sha256 hex>` where the signature input
+ * is `pathname|exp|download`. It therefore cannot be replayed against another
+ * path or purpose, and tampering with the expiry invalidates the signature.
+ *
+ * @param secret - the signing secret (from getDownloadSecret)
+ * @param pathname - API path of the download target, e.g. `/api/files/home/user/report.xlsx` (URL-encoded form)
+ * @param now - current time in ms (injectable for tests)
+ * @returns the `<exp>.<hex>` download token
+ */
+export function createDownloadToken(
+ secret: string,
+ pathname: string,
+ now: number = Date.now(),
+): string {
+ const exp = now + DOWNLOAD_TOKEN_TTL_MS;
+ const signature = sign(secret, pathname, exp);
+ return `${exp}.${signature}`;
+}
+
+/**
+ * Verify a download token.
+ *
+ * @param secret - the signing secret (same one used at issuance)
+ * @param pathname - the API path of the current request; must exactly match the one bound at issuance
+ * @param token - the token carried by the request
+ * @param now - current time in ms (injectable for tests)
+ * @returns true when the token is valid; false for malformed, expired, or tampered tokens
+ */
+export function verifyDownloadToken(
+ secret: string,
+ pathname: string,
+ token: string | null | undefined,
+ now: number = Date.now(),
+): boolean {
+ if (typeof token !== "string" || !token) return false;
+ if (!pathname) return false;
+
+ const dotIndex = token.lastIndexOf(".");
+ if (dotIndex <= 0) return false;
+
+ const expText = token.slice(0, dotIndex);
+ const signature = token.slice(dotIndex + 1);
+ if (!/^\d+$/.test(expText)) return false;
+ if (!/^[0-9a-f]{64}$/i.test(signature)) return false;
+
+ const exp = Number(expText);
+ if (!Number.isSafeInteger(exp)) return false;
+ // Expired tokens are rejected (a longer expiry cannot be forged: tampering
+ // with exp breaks the signature).
+ if (now > exp) return false;
+
+ const expected = sign(secret, pathname, exp);
+ return timingSafeEqual(
+  Buffer.from(signature, "hex"),
+  Buffer.from(expected, "hex"),
+ );
+}
+
+/**
+ * Compute the token signature.
+ *
+ * @param secret - the signing secret
+ * @param pathname - the API path of the download target
+ * @param exp - expiry time in ms
+ * @returns HMAC-SHA256 hex digest
+ */
+function sign(secret: string, pathname: string, exp: number): string {
+ return createHmac("sha256", secret)
+  .update(`${pathname}|${exp}|${DOWNLOAD_PURPOSE}`)
+  .digest("hex");
+}

--- a/lib/pake-download-extensions.test.mjs
+++ b/lib/pake-download-extensions.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { isPakeInterceptedDownload } = await jiti.import(
+  "./pake-download-extensions.ts",
+);
+
+test("extensions in the Pake hijack set are intercepted", () => {
+  for (const name of [
+    "report.docx",
+    "sheet.xlsx",
+    "doc.pdf",
+    "archive.zip",
+    "data.csv",
+    "run.sh",
+    "font.ttf",
+    "model.psd",
+    "image.raw",
+    "setup.exe",
+  ]) {
+    assert.equal(
+      isPakeInterceptedDownload(`/home/user/project/${name}`),
+      true,
+      name,
+    );
+  }
+});
+
+test("extensions outside the Pake hijack set are not intercepted", () => {
+  for (const name of [
+    "README.md",
+    "package.json",
+    "index.html",
+    "script.js",
+    "style.css",
+    "config.yaml",
+    "notes.txt.multipart", // multi-dot names take the final segment, not in the set
+  ]) {
+    assert.equal(
+      isPakeInterceptedDownload(`/home/user/project/${name}`),
+      false,
+      name,
+    );
+  }
+});
+
+test("previewable media types are not intercepted", () => {
+  for (const name of [
+    "photo.png",
+    "pic.jpg",
+    "clip.mp4",
+    "audio.mp3",
+    "vector.svg",
+  ]) {
+    assert.equal(
+      isPakeInterceptedDownload(`/home/user/project/${name}`),
+      false,
+      name,
+    );
+  }
+});
+
+test("files without an extension are not intercepted", () => {
+  assert.equal(isPakeInterceptedDownload("/home/user/project/Makefile"), false);
+  assert.equal(isPakeInterceptedDownload(""), false);
+});

--- a/lib/pake-download-extensions.ts
+++ b/lib/pake-download-extensions.ts
@@ -1,0 +1,132 @@
+/**
+ * Downloadable-extension set aligned with the DOWNLOADABLE_FILE_EXTENSIONS
+ * list in Pake's injected script (https://github.com/tw93/Pake). Pake hijacks
+ * clicks on `<a>` elements whose extension is in this set (and not a
+ * previewable media type), replaying them through its own HTTP client; files
+ * outside the set go through the native webview download path.
+ *
+ * The FileExplorer uses this to decide whether to attach a readable `download`
+ * attribute (Pake prefers its value as the saved filename, which fixes
+ * percent-encoded Chinese filenames) — only files Pake will hijack need it.
+ *
+ * This module is used by client components, so it must not depend on node:path.
+ * Note: keep in sync when Pake updates its list.
+ */
+export const PAKE_DOWNLOADABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+ // documents
+ "pdf",
+ "doc",
+ "docx",
+ "xls",
+ "xlsx",
+ "ppt",
+ "pptx",
+ "txt",
+ "rtf",
+ "odt",
+ "ods",
+ "odp",
+ "pages",
+ "numbers",
+ "key",
+ "epub",
+ "mobi",
+ // archives
+ "zip",
+ "rar",
+ "7z",
+ "tar",
+ "gz",
+ "gzip",
+ "bz2",
+ "xz",
+ "lzma",
+ "deb",
+ "rpm",
+ "pkg",
+ "msi",
+ "exe",
+ "dmg",
+ "apk",
+ "ipa",
+ // data
+ "csv",
+ "sql",
+ "db",
+ "sqlite",
+ // scripts
+ "sh",
+ "bat",
+ "ps1",
+ // fonts
+ "ttf",
+ "otf",
+ "woff",
+ "woff2",
+ "eot",
+ // design
+ "ai",
+ "psd",
+ "sketch",
+ "fig",
+ "xd",
+ // system
+ "iso",
+ "img",
+ "bin",
+ "torrent",
+ "jar",
+ "war",
+ "indd",
+ "fla",
+ "swf",
+ "raw",
+]);
+
+/**
+ * Previewable media types Pake treats as native (images/audio/video) — these
+ * are never hijacked even if the extension looks downloadable.
+ */
+export const PAKE_PREVIEWABLE_MEDIA_EXTENSIONS: ReadonlySet<string> = new Set([
+ "png",
+ "jpg",
+ "jpeg",
+ "gif",
+ "webp",
+ "svg",
+ "bmp",
+ "tiff",
+ "tif",
+ "avif",
+ "heic",
+ "heif",
+ "mp4",
+ "webm",
+ "mov",
+ "m4v",
+ "mkv",
+ "avi",
+ "ogv",
+ "mp3",
+ "wav",
+ "ogg",
+ "flac",
+ "aac",
+ "m4a",
+]);
+
+/**
+ * Whether a file will be hijacked by Pake as a download (extension in the
+ * downloadable set and not a previewable media type).
+ *
+ * @param filePath - absolute file path or file name
+ * @returns true when Pake will hijack the download
+ */
+export function isPakeInterceptedDownload(filePath: string): boolean {
+ const base = (filePath.split("/").pop() ?? "").toLowerCase();
+ const dots = base.split(".");
+ const ext = dots.length > 1 ? (dots.pop() ?? "") : "";
+ if (!ext) return false;
+ if (PAKE_PREVIEWABLE_MEDIA_EXTENSIONS.has(ext)) return false;
+ return PAKE_DOWNLOADABLE_EXTENSIONS.has(ext);
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,10 +7,48 @@ import {
   isValidBasicAuthorization,
   isWebPasswordEnabled,
 } from "@/lib/web-auth";
+import { getDownloadSecret, verifyDownloadToken } from "@/lib/download-auth";
+
+/**
+ * A download request carrying a valid signed token may skip Basic auth.
+ *
+ * Wrapper apps (e.g. Pake) replay download URLs through their own HTTP client
+ * and do not carry the page's cached Basic credentials; rejecting those
+ * requests would break every file download inside the wrapper. Instead the URL
+ * carries a short-lived signed token (bound to the path, ~5 min TTL) issued by
+ * the download-token endpoint. Valid tokens pass through to the file route;
+ * missing/invalid tokens still fall through to the regular Basic check.
+ */
+function isSignedDownloadRequest(request: NextRequest): boolean {
+  const { pathname, searchParams } = request.nextUrl;
+  if (!pathname.startsWith("/api/files/")) return false;
+  if (searchParams.get("type") !== "download") return false;
+
+  const token = searchParams.get("dt");
+  if (!token) return false;
+  return verifyDownloadToken(getDownloadSecret(), pathname, token);
+}
+
+/**
+ * True when the request is a download-shaped request that carries a `dt` token
+ * which fails verification (distinguished from plain unauthenticated 401s).
+ *
+ * @param request - the current request
+ * @returns true when the request looks like a download and carries an invalid token
+ */
+function isInvalidDownloadTokenRequest(request: NextRequest): boolean {
+  const { pathname, searchParams } = request.nextUrl;
+  if (!pathname.startsWith("/api/files/")) return false;
+  if (searchParams.get("type") !== "download") return false;
+  const token = searchParams.get("dt");
+  if (!token) return false;
+  return !verifyDownloadToken(getDownloadSecret(), pathname, token);
+}
 
 export function proxy(request: NextRequest) {
-  const isApiRequest = request.nextUrl.pathname === "/api"
-    || request.nextUrl.pathname.startsWith("/api/");
+  const isApiRequest =
+    request.nextUrl.pathname === "/api" ||
+    request.nextUrl.pathname.startsWith("/api/");
   const isTrustedRequest = isApiRequest
     ? isApiRequestAllowed(request)
     : isApiRequestHostAllowed(request);
@@ -19,13 +57,31 @@ export function proxy(request: NextRequest) {
     if (!isApiRequest) {
       return new NextResponse("Untrusted request", { status: 403 });
     }
-    return NextResponse.json({ error: "Untrusted API request" }, { status: 403 });
+    return NextResponse.json(
+      { error: "Untrusted API request" },
+      { status: 403 },
+    );
+  }
+
+  // Download requests with an invalid token get an explicit 403 (vs. 401 for
+  // unauthenticated requests).
+  if (isInvalidDownloadTokenRequest(request)) {
+    return NextResponse.json(
+      { error: "Invalid download token" },
+      { status: 403 },
+    );
+  }
+
+  // Download requests with a valid signed token pass through without Basic
+  // (checked after the host/origin checks).
+  if (isSignedDownloadRequest(request)) {
+    return NextResponse.next();
   }
 
   const password = process.env.PI_WEB_PASSWORD;
   if (
-    isWebPasswordEnabled(password)
-    && !isValidBasicAuthorization(request.headers.get("authorization"), password)
+    isWebPasswordEnabled(password) &&
+    !isValidBasicAuthorization(request.headers.get("authorization"), password)
   ) {
     return new NextResponse("Authentication required", {
       status: 401,


### PR DESCRIPTION
## 目的

Pi Web 可以开启 `PI_WEB_PASSWORD`（HTTP Basic 认证）。当页面被桌面封装应用
（如 [Pake](https://github.com/tw93/Pake)）包裹时，文件浏览器的下载会持续报
`401 Unauthorized`：封装应用会用自己的 HTTP 客户端重放下载链接，而该客户端
不携带 webview 已缓存的 Basic 凭据。

## 实现方式

用一段绑定文件路径、短时有效的签名令牌，替代缺失的 Basic 凭据，仅作用于
文件下载这一个请求：

- **`app/api/auth/download-token`**（新增）：在通过常规的 allowed-roots 校验
  （并对符号链接二次校验）后，为文件签发 5 分钟的 HMAC 签名令牌。端点本身
  仍受 Basic 认证保护。
- **`proxy.ts`**：匹配 `/api/files/**?type=download` 且携带有效令牌的请求跳过
  Basic 检查；令牌无效或过期则显式返回 `403`。其余所有 `/api/*` 请求保持
  密码保护不变。
- **`components/FileExplorer.tsx`**：悬停（hover）时预取令牌并写入下载链接的
  `href`——因为封装应用在 capture 阶段拦截点击，任何 React 点击处理器都来不及
  再取令牌。仅对封装应用会接管的扩展名附加可读文件名（`download` 属性）。
- **`lib/download-auth.ts` / `lib/pake-download-extensions.ts`**（新增）及单元
  测试：覆盖签名/校验、过期、防篡改，以及镜像封装应用可下载扩展名清单的边界。

## 带来的变化

- 开启 `PI_WEB_PASSWORD` 时，封装应用内下载恢复正常。
- 非封装（浏览器）下载行为完全不变，含 `Content-Disposition` 文件名。
- 安全性：令牌绑定文件路径、5 分钟过期，且仅对 `type=download` 形态生效，
  不能用于其他 API。签名密钥为进程内随机值（不落盘），除非显式设置
  `PI_WEB_DOWNLOAD_SECRET`。

## 测试

- 单元测试：`lib/download-auth.test.mjs`（7 项）、`lib/pake-download-extensions.test.mjs`（4 项）。
- 集成验证（curl）：携带令牌下载返回 `200` 且字节数完整；缺失/无效/过期/
  篡改路径的令牌被拒绝（`401`/`403`）；Basic 认证下载回归通过。
- 已在 Pake 封装环境实测：docx/xlsx 下载成功且文件名为可读中文。