### PR TITLE
feat(cli): support Pi agent startup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,52 @@ For example:
 pi-web -p 8080 -H 0.0.0.0 --no-open
 ```
 
+### Agent startup options
+
+Pi Web also accepts the Pi options that configure `AgentSession` creation. They
+act as server-wide defaults whenever Pi Web opens an Agent runtime. An explicit
+model or thinking level selected in the browser for a new session takes
+precedence over the corresponding startup default. Launcher tool allowlists and
+suppression flags are server policy; browser presets cannot re-enable tools they
+disable, and `--exclude-tools` is always applied as a denylist.
+
+| Category | Options |
+| --- | --- |
+| Model | `--provider <name>`, `--model <pattern>`, `--thinking <level>`, `--models <patterns>`, `--api-key <key>` |
+| Tools | `--tools <names>` / `-t`, `--exclude-tools <names>` / `-xt`, `--no-builtin-tools` / `-nbt`, `--no-tools` / `-nt` |
+| Extensions | `--extension <source>` / `-e` (repeatable), `--no-extensions` |
+| Skills | `--skill <path>` (repeatable), `--no-skills` / `-ns` |
+| Prompt templates | `--prompt-template <path>` (repeatable), `--no-prompt-templates` |
+| Agent themes | `--theme <path>` (repeatable), `--no-themes` |
+| Context and prompt | `--no-context-files` / `-nc`, `--system-prompt <text>`, `--append-system-prompt <text>` (repeatable) |
+| Runtime | `--offline`, `--help` / `-h` |
+
+Comma-separate values passed to `--tools`, `--exclude-tools`, and `--models`.
+Relative resource paths are resolved from the directory where `pi-web` was
+launched, not from its npm installation directory.
+
+For a low-context server that does not discover skills or `AGENTS.md` files:
+
+```bash
+pi-web -ns -nc
+```
+
+For a read-only server with a constrained model scope:
+
+```bash
+pi-web \
+  --models 'anthropic/*:high,openai/gpt-*' \
+  --tools read,grep,find,ls \
+  --exclude-tools bash
+```
+
+Pi's TUI and one-process session flags do not map to Pi Web's long-running,
+multi-session interface. In particular, Pi Web does not accept `--print`,
+`--continue`, `--resume`, `--session`, `--fork`, or `--no-session`. The short
+`-p` option continues to mean `--port`, not Pi's `--print`.
+
+Run `pi-web --help` for the complete startup reference.
+
 ### Remote Access
 
 Binding to a non-loopback address exposes an agent that can execute high-privilege actions. On a trusted LAN, require a long random password:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,49 @@ pi-web
 pi-web -p 8080 -H 0.0.0.0 --no-open
 ```
 
+### Agent 启动参数
+
+Pi Web 也支持用于配置 `AgentSession` 创建过程的 Pi 参数。这些参数会作为
+Pi Web 每次创建 Agent runtime 时的服务端全局默认值。浏览器中为新会话明确选择的
+模型或 thinking level 优先于对应的启动默认值。启动器中的工具 allowlist 和禁用参数
+属于服务端策略，浏览器 preset 不能重新启用已禁用的工具；`--exclude-tools` 始终作为
+denylist 生效。
+
+| 分类 | 参数 |
+| --- | --- |
+| 模型 | `--provider <名称>`、`--model <模式>`、`--thinking <等级>`、`--models <模式列表>`、`--api-key <密钥>` |
+| 工具 | `--tools <名称>` / `-t`、`--exclude-tools <名称>` / `-xt`、`--no-builtin-tools` / `-nbt`、`--no-tools` / `-nt` |
+| Extensions | `--extension <来源>` / `-e`（可重复）、`--no-extensions` |
+| Skills | `--skill <路径>`（可重复）、`--no-skills` / `-ns` |
+| Prompt templates | `--prompt-template <路径>`（可重复）、`--no-prompt-templates` |
+| Agent themes | `--theme <路径>`（可重复）、`--no-themes` |
+| 上下文与 prompt | `--no-context-files` / `-nc`、`--system-prompt <文本>`、`--append-system-prompt <文本>`（可重复） |
+| 运行方式 | `--offline`、`--help` / `-h` |
+
+`--tools`、`--exclude-tools` 和 `--models` 的多个值使用逗号分隔。相对资源路径
+以启动 `pi-web` 时所在的目录为基准解析，而不是 npm 安装目录。
+
+启动一个不发现 Skills 和 `AGENTS.md` 文件的低上下文服务：
+
+```bash
+pi-web -ns -nc
+```
+
+启动只读工具、模型范围受限的服务：
+
+```bash
+pi-web \
+  --models 'anthropic/*:high,openai/gpt-*' \
+  --tools read,grep,find,ls \
+  --exclude-tools bash
+```
+
+Pi 的 TUI 参数和单进程会话参数不适用于 Pi Web 的长驻、多会话界面。因此 Pi Web
+不支持 `--print`、`--continue`、`--resume`、`--session`、`--fork` 或
+`--no-session`。短参数 `-p` 在 Pi Web 中仍表示 `--port`，而不是 Pi 的 `--print`。
+
+运行 `pi-web --help` 可查看完整启动参数。
+
 ### 远程访问
 
 监听非回环地址会暴露一个可执行高权限操作的智能体。在可信局域网中使用时，请设置足够长的随机密码：

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,6 +1,6 @@
 import { stat } from "fs/promises";
 import { resolve } from "path";
-import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionServices, getAgentDir, resolveCliModel, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import {
   loadModelsWithCache,
@@ -10,6 +10,7 @@ import {
 } from "@/lib/models-cache";
 import { resolveVisibleModels, selectInitialModelScope } from "@/lib/model-scope";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
+import { getLaunchAgentOptions, getLaunchResourceLoaderOptions } from "@/lib/launch-agent-options";
 import { projectTrustReloadOptions } from "@/lib/project-trust";
 
 export const dynamic = "force-dynamic";
@@ -37,20 +38,47 @@ async function loadModels(cwd: string): Promise<ModelsData> {
   // runs a repository's .pi/extensions factories, so honor project trust here
   // too (see lib/project-trust.ts, #236).
   const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
+  const launchAgentOptions = getLaunchAgentOptions();
   const services = await createAgentSessionServices({
     cwd,
     agentDir,
+    resourceLoaderOptions: getLaunchResourceLoaderOptions(launchAgentOptions),
     ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
   });
+  const launchModel = launchAgentOptions.model
+    ? resolveCliModel({
+      cliProvider: launchAgentOptions.provider,
+      cliModel: launchAgentOptions.model,
+      cliThinking: launchAgentOptions.thinking,
+      modelRuntime: services.modelRuntime,
+    })
+    : undefined;
+  if (launchModel?.error) throw new Error(launchModel.error);
+  if (launchAgentOptions.apiKey) {
+    if (!launchModel?.model) throw new Error("--api-key requires a resolvable --model");
+    await services.modelRuntime.setRuntimeApiKey(launchModel.model.provider, launchAgentOptions.apiKey);
+  }
   const modelError = services.modelRuntime.getError();
   const settings: SettingsManager = services.settingsManager;
   // `enabledModels` supports globs and fuzzy patterns, so resolve it the same
   // way the CLI does instead of comparing pattern strings literally (#307).
   const scope = await resolveVisibleModels(
     services.modelRuntime,
-    settings.getEnabledModels(),
+    launchAgentOptions.models ?? settings.getEnabledModels(),
   );
-  const { visible, thinkingLevelPins, warnings } = scope;
+  const visible = launchModel?.model
+    && !scope.visible.some((model) => model.provider === launchModel.model?.provider && model.id === launchModel.model.id)
+    ? [launchModel.model, ...scope.visible]
+    : scope.visible;
+  const thinkingLevelPins = { ...scope.thinkingLevelPins };
+  const launchThinking = launchAgentOptions.thinking ?? launchModel?.thinkingLevel;
+  if (launchModel?.model && launchThinking) {
+    thinkingLevelPins[`${launchModel.model.provider}/${launchModel.model.id}`] = launchThinking;
+  }
+  const warnings = [
+    ...scope.warnings,
+    ...(launchModel?.warning ? [launchModel.warning] : []),
+  ];
   modelList = visible.map((m) => ({
     id: m.id,
     name: m.name,
@@ -65,11 +93,13 @@ async function loadModels(cwd: string): Promise<ModelsData> {
 
   const defaultProvider = settings.getDefaultProvider();
   const defaultModelId = settings.getDefaultModel();
-  const initial = selectInitialModelScope(scope, {
-    ...(defaultProvider && defaultModelId
-      ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
-      : {}),
-  });
+  const initial = launchModel?.model
+    ? { model: launchModel.model }
+    : selectInitialModelScope(scope, {
+      ...(defaultProvider && defaultModelId
+        ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
+        : {}),
+    });
   if (initial.model) {
     defaultModel = { provider: initial.model.provider, modelId: initial.model.id };
   }

--- a/bin/pi-web-options.js
+++ b/bin/pi-web-options.js
@@ -2,8 +2,19 @@
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { parseArgs } = require("util");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("path");
 
 const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const REMOTE_RESOURCE_PREFIXES = ["npm:", "git:", "github:", "http:", "https:", "ssh:"];
+const LONG_SHORT_ALIASES = new Map([
+  ["-xt", "--exclude-tools"],
+  ["-nbt", "--no-builtin-tools"],
+  ["-nt", "--no-tools"],
+  ["-ns", "--no-skills"],
+  ["-nc", "--no-context-files"],
+]);
 
 function isEnabled(value) {
   return typeof value === "string" && TRUE_VALUES.has(value.trim().toLowerCase());
@@ -22,22 +33,153 @@ function normalizePort(value) {
   return String(port);
 }
 
-function parseLaunchOptions(args = process.argv.slice(2), env = process.env) {
+function expandLongShortAliases(args) {
+  return args.map((arg) => LONG_SHORT_ALIASES.get(arg) ?? arg);
+}
+
+function splitCommaSeparated(value, optionName) {
+  if (value === undefined) return undefined;
+  const values = value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  if (values.length === 0) throw new Error(`${optionName} requires at least one value.`);
+  return values;
+}
+
+function isLocalResource(value) {
+  const trimmed = value.trim();
+  return !REMOTE_RESOURCE_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+function resolveResourcePaths(values, cwd) {
+  return values?.map((value) => isLocalResource(value) ? path.resolve(cwd, value) : value);
+}
+
+function assignDefined(target, key, value) {
+  if (value !== undefined) target[key] = value;
+}
+
+function parseLaunchOptions(args = process.argv.slice(2), env = process.env, cwd = process.cwd()) {
   const { values: cliArgs } = parseArgs({
-    args,
+    args: expandLongShortAliases(args),
     options: {
-      port:      { type: "string", short: "p" },
-      hostname:  { type: "string", short: "H" },
-      "no-open": { type: "boolean" },
+      // Pi Web server options.
+      port:                    { type: "string", short: "p" },
+      hostname:                { type: "string", short: "H" },
+      "no-open":               { type: "boolean" },
+      help:                    { type: "boolean", short: "h" },
+      offline:                 { type: "boolean" },
+
+      // Pi model and tool options that are meaningful to the Web runtime.
+      provider:                { type: "string" },
+      model:                   { type: "string" },
+      thinking:                { type: "string" },
+      models:                  { type: "string" },
+      "api-key":               { type: "string" },
+      tools:                   { type: "string", short: "t" },
+      "exclude-tools":         { type: "string" },
+      "no-builtin-tools":      { type: "boolean" },
+      "no-tools":              { type: "boolean" },
+
+      // Pi resource-loader options.
+      extension:               { type: "string", short: "e", multiple: true },
+      "no-extensions":         { type: "boolean" },
+      skill:                   { type: "string", multiple: true },
+      "no-skills":             { type: "boolean" },
+      "prompt-template":       { type: "string", multiple: true },
+      "no-prompt-templates":   { type: "boolean" },
+      theme:                   { type: "string", multiple: true },
+      "no-themes":             { type: "boolean" },
+      "no-context-files":      { type: "boolean" },
+      "system-prompt":         { type: "string" },
+      "append-system-prompt":  { type: "string", multiple: true },
     },
-    strict: false,
+    strict: true,
+    allowPositionals: false,
   });
+
+  if (cliArgs.provider && !cliArgs.model) {
+    throw new Error("--provider requires --model.");
+  }
+  if (cliArgs["api-key"] && !cliArgs.model) {
+    throw new Error("--api-key requires --model.");
+  }
+  if (cliArgs.thinking && !THINKING_LEVELS.has(cliArgs.thinking)) {
+    throw new Error(`Invalid thinking level: ${cliArgs.thinking}.`);
+  }
+  if (cliArgs["no-tools"] && cliArgs["no-builtin-tools"]) {
+    throw new Error("--no-tools and --no-builtin-tools cannot be used together.");
+  }
+
+  const agentOptions = {};
+  assignDefined(agentOptions, "provider", cliArgs.provider);
+  assignDefined(agentOptions, "model", cliArgs.model);
+  assignDefined(agentOptions, "thinking", cliArgs.thinking);
+  assignDefined(agentOptions, "models", splitCommaSeparated(cliArgs.models, "--models"));
+  assignDefined(agentOptions, "apiKey", cliArgs["api-key"]);
+  assignDefined(agentOptions, "tools", splitCommaSeparated(cliArgs.tools, "--tools"));
+  assignDefined(agentOptions, "excludeTools", splitCommaSeparated(cliArgs["exclude-tools"], "--exclude-tools"));
+  if (cliArgs["no-tools"]) agentOptions.noTools = "all";
+  if (cliArgs["no-builtin-tools"]) agentOptions.noTools = "builtin";
+
+  assignDefined(agentOptions, "additionalExtensionPaths", resolveResourcePaths(cliArgs.extension, cwd));
+  assignDefined(agentOptions, "additionalSkillPaths", resolveResourcePaths(cliArgs.skill, cwd));
+  assignDefined(agentOptions, "additionalPromptTemplatePaths", resolveResourcePaths(cliArgs["prompt-template"], cwd));
+  assignDefined(agentOptions, "additionalThemePaths", resolveResourcePaths(cliArgs.theme, cwd));
+  if (cliArgs["no-extensions"]) agentOptions.noExtensions = true;
+  if (cliArgs["no-skills"]) agentOptions.noSkills = true;
+  if (cliArgs["no-prompt-templates"]) agentOptions.noPromptTemplates = true;
+  if (cliArgs["no-themes"]) agentOptions.noThemes = true;
+  if (cliArgs["no-context-files"]) agentOptions.noContextFiles = true;
+  assignDefined(agentOptions, "systemPrompt", cliArgs["system-prompt"]);
+  assignDefined(agentOptions, "appendSystemPrompt", cliArgs["append-system-prompt"]);
 
   return {
     port: normalizePort(cliArgs.port ?? env.PORT ?? "30141"),
     hostname: cliArgs.hostname ?? env.PI_WEB_HOSTNAME ?? "127.0.0.1",
     openBrowser: !cliArgs["no-open"] && !isEnabled(env.PI_WEB_NO_OPEN),
+    help: cliArgs.help ?? false,
+    offline: cliArgs.offline ?? isEnabled(env.PI_OFFLINE),
+    agentOptions,
   };
 }
 
-module.exports = { parseLaunchOptions };
+function formatHelp() {
+  return `Usage: pi-web [options]
+
+Pi Web server options:
+  -p, --port <port>               Server port (default: 30141)
+  -H, --hostname <host>           Bind hostname (default: 127.0.0.1)
+      --no-open                   Do not open a browser automatically
+  -h, --help                      Show this help
+      --offline                   Disable startup network operations
+
+Agent model options (server defaults; explicit Web selections take precedence):
+      --provider <name>           Model provider (requires --model)
+      --model <pattern>           Model ID/pattern, optionally provider/model:thinking
+      --thinking <level>          off|minimal|low|medium|high|xhigh|max
+      --models <patterns>         Comma-separated model scope patterns
+      --api-key <key>             Runtime API key for the selected model provider
+
+Agent tool options:
+  -t, --tools <names>             Comma-separated tool allowlist
+  -xt, --exclude-tools <names>    Comma-separated tool denylist
+  -nbt, --no-builtin-tools        Disable built-in tools, keep extension tools
+  -nt, --no-tools                 Disable all tools
+
+Agent resource options:
+  -e, --extension <source>        Load an extension (repeatable)
+      --no-extensions             Disable extension discovery
+      --skill <path>              Load a skill (repeatable)
+  -ns, --no-skills                Disable skill discovery
+      --prompt-template <path>    Load a prompt template (repeatable)
+      --no-prompt-templates       Disable prompt-template discovery
+      --theme <path>              Load an Agent theme resource (repeatable)
+      --no-themes                 Disable Agent theme discovery
+  -nc, --no-context-files         Disable AGENTS.md/CLAUDE.md discovery
+      --system-prompt <text>      Replace the default Agent system prompt
+      --append-system-prompt <t>  Append to the Agent system prompt (repeatable)
+
+Pi TUI/session flags such as --print, --continue, --resume, --session,
+--fork, and --no-session do not apply to Pi Web's multi-session interface.`;
+}
+
+module.exports = { formatHelp, parseLaunchOptions };

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -16,7 +16,7 @@ const path = require("path");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require("fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { parseLaunchOptions } = require("./pi-web-options");
+const { formatHelp, parseLaunchOptions } = require("./pi-web-options");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { wireChildProcessLifecycle } = require("./process-lifecycle");
 
@@ -38,7 +38,21 @@ try {
   }
 }
 
-const { port, hostname, openBrowser } = parseLaunchOptions();
+let launchOptions;
+try {
+  launchOptions = parseLaunchOptions();
+} catch (error) {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  console.error("Run pi-web --help for usage.");
+  process.exit(1);
+}
+
+const { port, hostname, openBrowser, help, offline, agentOptions } = launchOptions;
+if (help) {
+  console.log(formatHelp());
+  process.exit(0);
+}
+
 const loopbackHostnames = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 const passwordEnabled = Boolean(process.env.PI_WEB_PASSWORD);
 
@@ -62,12 +76,19 @@ if (!loopbackHostnames.has(hostname)) {
 const nextArgs = ["start", "-p", port];
 nextArgs.push("-H", hostname);
 
+const childEnv = {
+  ...process.env,
+  PI_WEB_HOSTNAME: hostname,
+  PI_WEB_AGENT_OPTIONS: JSON.stringify(agentOptions),
+  ...(offline ? { PI_OFFLINE: "1", PI_SKIP_VERSION_CHECK: "1" } : {}),
+};
+
 // Always run next's JS entry with node directly — avoids .bin symlink issues
 // and path-with-spaces problems on Windows when shell: true is used.
 const child = spawn(process.execPath, [nextBin, ...nextArgs], {
   cwd: pkgDir,
   stdio: ["inherit", "pipe", "inherit"],
-  env: { ...process.env, PI_WEB_HOSTNAME: hostname },
+  env: childEnv,
 });
 wireChildProcessLifecycle(child);
 

--- a/lib/launch-agent-options.test.mjs
+++ b/lib/launch-agent-options.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import {
+  getLaunchResourceLoaderOptions,
+  parseLaunchAgentOptions,
+} from "./launch-agent-options.ts";
+
+test("launch agent options default to an empty object", () => {
+  assert.deepEqual(parseLaunchAgentOptions(undefined), {});
+});
+
+test("launch agent options preserve validated session-construction settings", () => {
+  const options = {
+    model: "anthropic/claude-sonnet",
+    thinking: "high",
+    models: ["anthropic/*"],
+    tools: ["read", "bash"],
+    excludeTools: ["write"],
+    noSkills: true,
+    noContextFiles: true,
+    appendSystemPrompt: ["Be concise."],
+  };
+
+  assert.deepEqual(parseLaunchAgentOptions(JSON.stringify(options)), options);
+});
+
+test("no-skills and no-context-files reach Pi's DefaultResourceLoader", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pi-web-launch-options-"));
+  const cwd = join(root, "project");
+  const agentDir = join(root, "agent");
+  try {
+    await mkdir(join(agentDir, "skills", "sample"), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeFile(join(cwd, "AGENTS.md"), "# Project context\n");
+    await writeFile(
+      join(agentDir, "skills", "sample", "SKILL.md"),
+      "---\nname: sample\ndescription: sample\n---\n# Sample\n",
+    );
+
+    const launchOptions = parseLaunchAgentOptions(JSON.stringify({
+      noSkills: true,
+      noContextFiles: true,
+    }));
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      ...getLaunchResourceLoaderOptions(launchOptions),
+    });
+    await loader.reload();
+
+    assert.deepEqual(loader.getSkills().skills, []);
+    assert.deepEqual(loader.getAgentsFiles().agentsFiles, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("launch agent options reject malformed internal handoff values", () => {
+  assert.throws(() => parseLaunchAgentOptions("{"), /Invalid PI_WEB_AGENT_OPTIONS JSON/);
+  assert.throws(() => parseLaunchAgentOptions("[]"), /must contain a JSON object/);
+  assert.throws(() => parseLaunchAgentOptions('{"tools":"read"}'), /tools must be an array/);
+  assert.throws(() => parseLaunchAgentOptions('{"noSkills":"yes"}'), /noSkills must be a boolean/);
+  assert.throws(() => parseLaunchAgentOptions('{"thinking":"extreme"}'), /Invalid thinking level/);
+  assert.throws(() => parseLaunchAgentOptions('{"noTools":"sometimes"}'), /noTools must be/);
+});

--- a/lib/launch-agent-options.ts
+++ b/lib/launch-agent-options.ts
@@ -1,0 +1,141 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+
+/**
+ * Agent-level defaults forwarded by the pi-web launcher to the Next.js server.
+ *
+ * Pi Web is a long-running, multi-session host, so only options that affect
+ * AgentSession construction are represented here. Browser-provided model and
+ * thinking choices take precedence; launcher tool restrictions remain server
+ * policy.
+ */
+export interface LaunchAgentOptions {
+  additionalExtensionPaths?: string[];
+  additionalSkillPaths?: string[];
+  additionalPromptTemplatePaths?: string[];
+  additionalThemePaths?: string[];
+  noExtensions?: boolean;
+  noSkills?: boolean;
+  noPromptTemplates?: boolean;
+  noThemes?: boolean;
+  noContextFiles?: boolean;
+  systemPrompt?: string;
+  appendSystemPrompt?: string[];
+  provider?: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+  models?: string[];
+  apiKey?: string;
+  tools?: string[];
+  excludeTools?: string[];
+  noTools?: "all" | "builtin";
+}
+
+const ARRAY_KEYS = [
+  "models",
+  "tools",
+  "excludeTools",
+  "additionalExtensionPaths",
+  "additionalSkillPaths",
+  "additionalPromptTemplatePaths",
+  "additionalThemePaths",
+  "appendSystemPrompt",
+] as const;
+
+const BOOLEAN_KEYS = [
+  "noExtensions",
+  "noSkills",
+  "noPromptTemplates",
+  "noThemes",
+  "noContextFiles",
+] as const;
+
+const STRING_KEYS = [
+  "provider",
+  "model",
+  "apiKey",
+  "systemPrompt",
+] as const;
+
+const THINKING_LEVELS = new Set<ThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+function assertStringArray(value: unknown, key: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${key} must be an array of strings`);
+  }
+}
+
+/** Parse the launcher's internal environment handoff with defensive validation. */
+export function parseLaunchAgentOptions(raw: string | undefined): LaunchAgentOptions {
+  if (!raw) return {};
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid PI_WEB_AGENT_OPTIONS JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("PI_WEB_AGENT_OPTIONS must contain a JSON object");
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of ARRAY_KEYS) {
+    if (record[key] !== undefined) assertStringArray(record[key], key);
+  }
+  for (const key of BOOLEAN_KEYS) {
+    if (record[key] !== undefined && typeof record[key] !== "boolean") {
+      throw new Error(`${key} must be a boolean`);
+    }
+  }
+  for (const key of STRING_KEYS) {
+    if (record[key] !== undefined && typeof record[key] !== "string") {
+      throw new Error(`${key} must be a string`);
+    }
+  }
+  if (record.thinking !== undefined
+    && (typeof record.thinking !== "string" || !THINKING_LEVELS.has(record.thinking as ThinkingLevel))) {
+    throw new Error(`Invalid thinking level: ${String(record.thinking)}`);
+  }
+  if (record.noTools !== undefined && record.noTools !== "all" && record.noTools !== "builtin") {
+    throw new Error('noTools must be "all" or "builtin"');
+  }
+
+  return record as unknown as LaunchAgentOptions;
+}
+
+/** Select only the fields accepted by DefaultResourceLoader. */
+export function getLaunchResourceLoaderOptions(options: LaunchAgentOptions) {
+  return {
+    additionalExtensionPaths: options.additionalExtensionPaths,
+    additionalSkillPaths: options.additionalSkillPaths,
+    additionalPromptTemplatePaths: options.additionalPromptTemplatePaths,
+    additionalThemePaths: options.additionalThemePaths,
+    noExtensions: options.noExtensions,
+    noSkills: options.noSkills,
+    noPromptTemplates: options.noPromptTemplates,
+    noThemes: options.noThemes,
+    noContextFiles: options.noContextFiles,
+    systemPrompt: options.systemPrompt,
+    appendSystemPrompt: options.appendSystemPrompt,
+  };
+}
+
+let cachedRaw: string | undefined;
+let cachedOptions: LaunchAgentOptions | undefined;
+
+export function getLaunchAgentOptions(): LaunchAgentOptions {
+  const raw = process.env.PI_WEB_AGENT_OPTIONS;
+  if (cachedOptions === undefined || raw !== cachedRaw) {
+    cachedRaw = raw;
+    cachedOptions = parseLaunchAgentOptions(raw);
+  }
+  return cachedOptions;
+}

--- a/lib/pi-web-options.test.mjs
+++ b/lib/pi-web-options.test.mjs
@@ -3,13 +3,16 @@ import { createRequire } from "node:module";
 import test from "node:test";
 
 const require = createRequire(import.meta.url);
-const { parseLaunchOptions } = require("../bin/pi-web-options.js");
+const { formatHelp, parseLaunchOptions } = require("../bin/pi-web-options.js");
 
 test("opens the browser by default", () => {
   assert.deepEqual(parseLaunchOptions([], {}), {
     port: "30141",
     hostname: "127.0.0.1",
     openBrowser: true,
+    help: false,
+    offline: false,
+    agentOptions: {},
   });
 });
 
@@ -36,8 +39,87 @@ test("preserves port and hostname options", () => {
       port: "8080",
       hostname: "0.0.0.0",
       openBrowser: true,
+      help: false,
+      offline: false,
+      agentOptions: {},
     },
   );
+});
+
+test("forwards Pi model and tool options", () => {
+  const result = parseLaunchOptions([
+    "--provider", "anthropic",
+    "--model", "claude-sonnet:high",
+    "--thinking", "low",
+    "--models", "anthropic/*:high,openai/gpt-*",
+    "--api-key", "runtime-key",
+    "-t", "read,bash",
+    "-xt", "write,edit",
+  ], {});
+
+  assert.deepEqual(result.agentOptions, {
+    provider: "anthropic",
+    model: "claude-sonnet:high",
+    thinking: "low",
+    models: ["anthropic/*:high", "openai/gpt-*"],
+    apiKey: "runtime-key",
+    tools: ["read", "bash"],
+    excludeTools: ["write", "edit"],
+  });
+});
+
+test("supports Pi multi-character aliases", () => {
+  assert.deepEqual(parseLaunchOptions(["-ns", "-nc", "-nt"], {}).agentOptions, {
+    noTools: "all",
+    noSkills: true,
+    noContextFiles: true,
+  });
+  assert.equal(parseLaunchOptions(["-nbt"], {}).agentOptions.noTools, "builtin");
+});
+
+test("forwards repeatable resources and resolves local paths from the launch cwd", () => {
+  const result = parseLaunchOptions([
+    "-e", "./extensions/local.ts",
+    "--extension", "npm:@scope/tools",
+    "--skill", "./skills/review/SKILL.md",
+    "--prompt-template", "prompts/review.md",
+    "--theme", "https://example.com/theme.json",
+    "--append-system-prompt", "first",
+    "--append-system-prompt", "second",
+    "--no-extensions",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--system-prompt", "minimal",
+  ], {}, "/workspace");
+
+  assert.deepEqual(result.agentOptions, {
+    additionalExtensionPaths: ["/workspace/extensions/local.ts", "npm:@scope/tools"],
+    additionalSkillPaths: ["/workspace/skills/review/SKILL.md"],
+    additionalPromptTemplatePaths: ["/workspace/prompts/review.md"],
+    additionalThemePaths: ["https://example.com/theme.json"],
+    noExtensions: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    systemPrompt: "minimal",
+    appendSystemPrompt: ["first", "second"],
+  });
+});
+
+test("supports help and offline mode", () => {
+  const result = parseLaunchOptions(["--help", "--offline"], {});
+  assert.equal(result.help, true);
+  assert.equal(result.offline, true);
+  assert.match(formatHelp(), /--no-skills/);
+  assert.match(formatHelp(), /--no-context-files/);
+  assert.match(formatHelp(), /--exclude-tools/);
+});
+
+test("rejects invalid or unsupported options instead of silently ignoring them", () => {
+  assert.throws(() => parseLaunchOptions(["--unknown"], {}), /Unknown option/);
+  assert.throws(() => parseLaunchOptions(["--provider", "anthropic"], {}), /requires --model/);
+  assert.throws(() => parseLaunchOptions(["--thinking", "extreme"], {}), /Invalid thinking level/);
+  assert.throws(() => parseLaunchOptions(["--models", ","], {}), /requires at least one value/);
+  assert.throws(() => parseLaunchOptions(["--no-tools", "--no-builtin-tools"], {}), /cannot be used together/);
 });
 
 test("rejects port values that could inject cmd arguments", () => {

--- a/lib/project-command-env.test.mjs
+++ b/lib/project-command-env.test.mjs
@@ -24,6 +24,8 @@ const HOST_ENVIRONMENT = {
   HOME: "/home/pi",
   HTTPS_PROXY: "http://proxy.example",
   OPENROUTER_API_KEY: "secret",
+  PI_WEB_PASSWORD: "web-secret",
+  PI_WEB_AGENT_OPTIONS: '{"apiKey":"runtime-secret"}',
   PI_USER_SETTING: "preserved",
 };
 
@@ -77,6 +79,8 @@ test("agent bash removes host variables while preserving SDK and user environmen
     NODE_ENV: process.env.NODE_ENV,
     NEXT_RUNTIME: process.env.NEXT_RUNTIME,
     NEXT_PRIVATE_WORKER: process.env.NEXT_PRIVATE_WORKER,
+    PI_WEB_PASSWORD: process.env.PI_WEB_PASSWORD,
+    PI_WEB_AGENT_OPTIONS: process.env.PI_WEB_AGENT_OPTIONS,
     PI_USER_SETTING: process.env.PI_USER_SETTING,
   };
   Object.assign(process.env, {
@@ -84,6 +88,8 @@ test("agent bash removes host variables while preserving SDK and user environmen
     NODE_ENV: "production",
     NEXT_RUNTIME: "nodejs",
     NEXT_PRIVATE_WORKER: "1",
+    PI_WEB_PASSWORD: "web-secret",
+    PI_WEB_AGENT_OPTIONS: '{"apiKey":"runtime-secret"}',
     PI_USER_SETTING: "preserved",
   });
 
@@ -105,7 +111,7 @@ test("agent bash removes host variables while preserving SDK and user environmen
     const result = await registeredTool.execute(
       "issue-484",
       {
-        command: `node -e 'console.log(JSON.stringify({PORT:process.env.PORT,NODE_ENV:process.env.NODE_ENV,NEXT_RUNTIME:process.env.NEXT_RUNTIME,NEXT_PRIVATE_WORKER:process.env.NEXT_PRIVATE_WORKER,PI_USER_SETTING:process.env.PI_USER_SETTING,PI_SESSION_ID:process.env.PI_SESSION_ID,PATH:process.env.PATH}))'`,
+        command: `node -e 'console.log(JSON.stringify({PORT:process.env.PORT,NODE_ENV:process.env.NODE_ENV,NEXT_RUNTIME:process.env.NEXT_RUNTIME,NEXT_PRIVATE_WORKER:process.env.NEXT_PRIVATE_WORKER,PI_WEB_PASSWORD:process.env.PI_WEB_PASSWORD,PI_WEB_AGENT_OPTIONS:process.env.PI_WEB_AGENT_OPTIONS,PI_USER_SETTING:process.env.PI_USER_SETTING,PI_SESSION_ID:process.env.PI_SESSION_ID,PATH:process.env.PATH}))'`,
       },
       undefined,
       undefined,
@@ -124,6 +130,8 @@ test("agent bash removes host variables while preserving SDK and user environmen
     assert.equal(childEnvironment.NODE_ENV, undefined);
     assert.equal(childEnvironment.NEXT_RUNTIME, undefined);
     assert.equal(childEnvironment.NEXT_PRIVATE_WORKER, undefined);
+    assert.equal(childEnvironment.PI_WEB_PASSWORD, undefined);
+    assert.equal(childEnvironment.PI_WEB_AGENT_OPTIONS, undefined);
     assert.equal(childEnvironment.PI_USER_SETTING, "preserved");
     assert.equal(childEnvironment.PI_SESSION_ID, "session-484");
     assert.ok(childEnvironment.PATH.split(delimiter).includes(join(getAgentDir(), "bin")));

--- a/lib/project-command-env.ts
+++ b/lib/project-command-env.ts
@@ -28,7 +28,8 @@ function isHostRuntimeVariable(name: string, platform: NodeJS.Platform): boolean
   const comparableName = platform === "win32" ? name.toUpperCase() : name;
   return comparableName === "PORT"
     || comparableName === "NODE_ENV"
-    || comparableName.startsWith("NEXT_");
+    || comparableName.startsWith("NEXT_")
+    || comparableName.startsWith("PI_WEB_");
 }
 
 export function sanitizeProjectCommandEnvironment(

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -2,6 +2,28 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+test("RPC session startup applies launcher Agent options to every created runtime", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const startupSource = source.slice(source.indexOf("export async function startRpcSession"));
+
+  assert.match(startupSource, /getLaunchAgentOptions\(\)/);
+  assert.match(startupSource, /getLaunchResourceLoaderOptions\(launchAgentOptions\)/);
+  assert.match(startupSource, /resolveCliModel\(/);
+  assert.match(startupSource, /launchAgentOptions\.models \?\?/);
+  assert.match(startupSource, /excludeTools: excludeToolsOption/);
+  assert.match(startupSource, /noTools: noToolsOption/);
+  assert.match(startupSource, /const forceEmptySystemPrompt = toolsOption\?\.length === 0/);
+});
+
+test("model selector uses the same launcher model and resource options as sessions", async () => {
+  const source = await readFile(new URL("../app/api/models/route.ts", import.meta.url), "utf8");
+
+  assert.match(source, /getLaunchAgentOptions\(\)/);
+  assert.match(source, /getLaunchResourceLoaderOptions\(launchAgentOptions\)/);
+  assert.match(source, /launchAgentOptions\.models \?\? settings\.getEnabledModels\(\)/);
+  assert.match(source, /resolveCliModel\(/);
+});
+
 test("RPC session startup preloads extension-registered providers before restoring models", async () => {
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const startupSource = source.slice(source.indexOf("export async function startRpcSession"));

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,10 +1,11 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, resolveCliModel, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
 import { existsSync, realpathSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import { validateAgentImages } from "./image-attachments";
+import { getLaunchAgentOptions, getLaunchResourceLoaderOptions } from "./launch-agent-options";
 import { invalidateModelsCache } from "./models-cache";
 import { resolveVisibleModels, selectInitialModelScope } from "./model-scope";
 import {
@@ -1568,6 +1569,7 @@ export async function startRpcSession(
   options: RpcSessionStartOptions = {},
 ): Promise<{ session: AgentSessionWrapper; realSessionId: string }> {
   const { toolNames, initialModel, thinkingLevel } = options;
+  const launchAgentOptions = getLaunchAgentOptions();
   const registry = getRegistry();
   const locks = getLocks();
 
@@ -1593,8 +1595,15 @@ export async function startRpcSession(
 
     // Determine which tools to pass based on requested toolNames.
     // Since v0.68.0, session creation expects string[] tool names instead of Tool[] instances.
+    const hasLaunchToolPolicy = launchAgentOptions.tools !== undefined
+      || launchAgentOptions.noTools !== undefined;
     let toolsOption: string[] | undefined;
-    if (toolNames !== undefined) {
+    const excludeToolsOption = launchAgentOptions.excludeTools;
+    const noToolsOption = launchAgentOptions.noTools;
+    if (hasLaunchToolPolicy) {
+      // Launcher tool flags are server policy and cannot be bypassed by a browser preset.
+      toolsOption = launchAgentOptions.tools;
+    } else if (toolNames !== undefined) {
       // toolNames === [] -> "all off" (an empty allow-list disables every tool).
       // Otherwise DO NOT pass a builtin-only allow-list: passing CODING_TOOL_NAMES
       // set allowedToolNames to coding builtins only, which filtered every
@@ -1616,6 +1625,7 @@ export async function startRpcSession(
       agentDir,
       settingsManager,
       resourceLoaderOptions: {
+        ...getLaunchResourceLoaderOptions(launchAgentOptions),
         extensionFactories: [
           createProjectCommandBashExtension({
             cwd: sessionCwd,
@@ -1626,22 +1636,53 @@ export async function startRpcSession(
       },
       ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
     });
+    const launchModel = launchAgentOptions.model
+      ? resolveCliModel({
+        cliProvider: launchAgentOptions.provider,
+        cliModel: launchAgentOptions.model,
+        cliThinking: launchAgentOptions.thinking,
+        modelRuntime: services.modelRuntime,
+      })
+      : undefined;
+    if (launchModel?.warning) console.warn(`[pi-web] ${launchModel.warning}`);
+    if (launchModel?.error) throw new Error(launchModel.error);
+    if (launchAgentOptions.apiKey) {
+      if (!launchModel?.model) throw new Error("--api-key requires a resolvable --model");
+      await services.modelRuntime.setRuntimeApiKey(launchModel.model.provider, launchAgentOptions.apiKey);
+    }
+
     const scope = await resolveVisibleModels(
       services.modelRuntime,
-      services.settingsManager.getEnabledModels(),
+      launchAgentOptions.models ?? services.settingsManager.getEnabledModels(),
     );
     const defaultProvider = services.settingsManager.getDefaultProvider();
     const defaultModelId = services.settingsManager.getDefaultModel();
     const hasExistingMessages = sessionManager.getBranch().some((entry) => entry.type === "message");
+    const requestedModel = initialModel ?? (launchModel?.model
+      ? { provider: launchModel.model.provider, modelId: launchModel.model.id }
+      : undefined);
+    const requestedThinking = thinkingLevel
+      ?? launchAgentOptions.thinking
+      ?? launchModel?.thinkingLevel;
     const initial = hasExistingMessages
-      ? { scopedModels: [...scope.scopedModels] }
-      : selectInitialModelScope(scope, {
-        ...(initialModel ? { requestedModel: initialModel } : {}),
-        ...(defaultProvider && defaultModelId
-          ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
-          : {}),
-        ...(thinkingLevel ? { thinkingLevel } : {}),
-      });
+      ? {
+        ...(launchModel?.model && !initialModel ? { model: launchModel.model } : {}),
+        ...(requestedThinking ? { thinkingLevel: requestedThinking } : {}),
+        scopedModels: [...scope.scopedModels],
+      }
+      : launchModel?.model && !initialModel
+        ? {
+          model: launchModel.model,
+          ...(requestedThinking ? { thinkingLevel: requestedThinking } : {}),
+          scopedModels: [...scope.scopedModels],
+        }
+        : selectInitialModelScope(scope, {
+          ...(requestedModel ? { requestedModel } : {}),
+          ...(defaultProvider && defaultModelId
+            ? { defaultModel: { provider: defaultProvider, modelId: defaultModelId } }
+            : {}),
+          ...(requestedThinking ? { thinkingLevel: requestedThinking } : {}),
+        });
     const { session: inner } = await createAgentSessionFromServices({
       services,
       sessionManager,
@@ -1649,6 +1690,8 @@ export async function startRpcSession(
       ...(initial.thinkingLevel ? { thinkingLevel: initial.thinkingLevel } : {}),
       ...(initial.scopedModels.length > 0 ? { scopedModels: initial.scopedModels } : {}),
       ...(toolsOption !== undefined ? { tools: toolsOption } : {}),
+      ...(excludeToolsOption !== undefined ? { excludeTools: excludeToolsOption } : {}),
+      ...(noToolsOption !== undefined ? { noTools: noToolsOption } : {}),
     });
 
     const persistedPreferences = await persistExplicitStartupPreferences(
@@ -1670,15 +1713,20 @@ export async function startRpcSession(
     // If specific tool names were requested (non-empty), set the active tools to the
     // requested builtin coding tools PLUS all extension/package tools, so installed
     // extensions stay usable in Pi Web just like in the `pi` CLI.
-    if (toolNames && toolNames.length > 0) {
-      inner.setActiveToolsByName(withExtensionTools(inner, toolNames));
+    if (toolNames && toolNames.length > 0 && !hasLaunchToolPolicy) {
+      const excluded = new Set(excludeToolsOption ?? []);
+      inner.setActiveToolsByName(
+        withExtensionTools(inner, toolNames).filter((name) => !excluded.has(name)),
+      );
     }
 
+    const forceEmptySystemPrompt = toolsOption?.length === 0
+      || (toolsOption === undefined && noToolsOption === "all");
     const wrapper = new AgentSessionWrapper(inner);
     // When all tools are disabled, clear the system prompt entirely.
     // pi's buildSystemPrompt always produces a non-empty prompt even with no tools;
     // keep this forced after extension resource discovery and reloads as well.
-    if (toolNames?.length === 0) {
+    if (forceEmptySystemPrompt) {
       wrapper.setForceEmptySystemPrompt(true);
     }
     wrapper.start();
@@ -1689,7 +1737,7 @@ export async function startRpcSession(
 
     wrapper.onDestroy(() => registry.delete(realSessionId));
     registry.set(realSessionId, wrapper);
-    wrapper.beginExtensionBinding({ forceEmptySystemPrompt: toolNames?.length === 0 });
+    wrapper.beginExtensionBinding({ forceEmptySystemPrompt });
 
     return { session: wrapper, realSessionId };
   })().finally(() => {


### PR DESCRIPTION
## Summary

Pi Web currently accepts only server flags (`--port`, `--hostname`, and `--no-open`) and silently ignores Pi flags such as `-ns` and `-nc`. This makes it impossible to start Pi Web with the same resource, model, and tool constraints used by the Pi CLI.

This PR:

- adds Pi-compatible Agent startup flags for models, thinking, tools, extensions, skills, prompt templates, Agent themes, context files, and system prompts
- supports Pi's multi-character aliases, including `-ns`, `-nc`, `-nt`, `-nbt`, and `-xt`
- forwards validated options from the launcher to every in-process `AgentSession` runtime
- keeps the model selector and Agent runtime on the same model/resource configuration
- resolves relative resource paths from the directory where `pi-web` was launched
- treats launcher tool restrictions as server policy, so browser presets cannot bypass them
- rejects unknown flags instead of silently ignoring them and adds `pi-web --help`
- keeps TUI/session-only flags explicitly unsupported because Pi Web manages multiple persistent sessions itself
- strips internal `PI_WEB_*` values (including the option handoff and Web password) from Agent bash subprocesses
- documents the new behavior in English and Simplified Chinese

Example:

```bash
# Do not load skills or AGENTS.md / CLAUDE.md into Agent prompts
pi-web -ns -nc

# Read-only tools with a constrained model scope
pi-web \
  --models 'anthropic/*:high,openai/gpt-*' \
  --tools read,grep,find,ls \
  --exclude-tools bash
```

## Supported Agent flags

- Model: `--provider`, `--model`, `--thinking`, `--models`, `--api-key`
- Tools: `--tools/-t`, `--exclude-tools/-xt`, `--no-builtin-tools/-nbt`, `--no-tools/-nt`
- Resources: `--extension/-e`, `--no-extensions`, `--skill`, `--no-skills/-ns`, `--prompt-template`, `--no-prompt-templates`, `--theme`, `--no-themes`, `--no-context-files/-nc`
- Prompt: `--system-prompt`, `--append-system-prompt`
- Runtime: `--offline`, `--help/-h`

`--print`, `--continue`, `--resume`, `--session`, `--fork`, and `--no-session` remain unsupported because their single-process/TUI semantics do not map cleanly to Pi Web.

## Validation

- `npm test` — 598 tests passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `git diff --check`

A dedicated SDK integration test verifies that `noSkills` and `noContextFiles` reach Pi's `DefaultResourceLoader` and produce no loaded skills or context files.
