### PR TITLE
fix: allow LAN access to the dev server

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,31 @@ const nextConfig: NextConfig = {
     "@earendil-works/pi-ai",
     "@earendil-works/pi-tui",
   ],
-  allowedDevOrigins: ["127.0.0.1", "192.168.*.*"],
+  // Next 16 blocks cross-origin access to dev resources by default. Allow the
+  // loopback and the RFC1918 LAN ranges so the dev server stays reachable
+  // from other machines on the same LAN.
+  allowedDevOrigins: [
+    "127.0.0.1",
+    "10.*.*.*",
+    // 172.16.0.0/12
+    "172.16.*.*",
+    "172.17.*.*",
+    "172.18.*.*",
+    "172.19.*.*",
+    "172.20.*.*",
+    "172.21.*.*",
+    "172.22.*.*",
+    "172.23.*.*",
+    "172.24.*.*",
+    "172.25.*.*",
+    "172.26.*.*",
+    "172.27.*.*",
+    "172.28.*.*",
+    "172.29.*.*",
+    "172.30.*.*",
+    "172.31.*.*",
+    "192.168.*.*",
+  ],
   async headers() {
     return [
       {


### PR DESCRIPTION
## Problem

Next 16 blocks cross-origin access to dev resources by default. The previous `allowedDevOrigins` only covered `127.0.0.1` and `192.168.*.*`, so visiting the dev server from a `10.x` LAN address (e.g. `10.9.8.12`) returned **403 on every `/_next` chunk** and the HMR websocket failed, making the app unusable from other machines on the same LAN.

## Fix

Allow the loopback and all RFC1918 private ranges used by the dev server:

- `127.0.0.1`
- `10.0.0.0/8`
- `172.16.0.0/12`
- `192.168.0.0/16`

## Notes

- Config-only change, no runtime behavior impact in production builds (`allowedDevOrigins` is dev-only).
- Verified with `npm run dev` accessed from a `10.x` LAN address: chunks and HMR websocket load correctly (`eslint` clean).
