### PR TITLE
fix: avoid duplicate full-size image render in user messages

### DIFF
--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -3,6 +3,11 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createJiti } from "jiti";
+import path from "node:path";
+
+// Project root, derived from this file's location so tests never hardcode
+// machine-specific absolute paths.
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
 
 const jiti = createJiti(import.meta.url, {
   jsx: { runtime: "automatic" },
@@ -135,6 +140,41 @@ test("renders user-message images as buttons that open a larger preview", () => 
 
   assert.match(html, /<button[^>]+aria-label="Preview image"[^>]*>/);
   assert.match(html, /<img[^>]+src="data:image\/png;base64,YWJj"/);
+});
+
+test("does not re-render the markdown image reference when image blocks exist", () => {
+  const html = renderMessage({
+    role: "user",
+    content: [
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "QUJDRA==" },
+      },
+      {
+        type: "text",
+        text: "这图是什么内容\n\n![screenshot2.png](docs/screenshot2.png)",
+      },
+    ],
+    timestamp: Date.now(),
+  }, { cwd: PROJECT_ROOT });
+
+  // The image block renders the thumbnail; the text's injected Markdown
+  // image reference must not become a second full-size <img> via /api/files.
+  assert.match(html, /src="data:image\/png;base64,QUJDRA=="/);
+  assert.match(html, /这图是什么内容/);
+  assert.doesNotMatch(html, /api\/files/);
+  assert.doesNotMatch(html, /screenshot2\.png/);
+  assert.equal((html.match(/<img[^>]+src=/g) ?? []).length, 1);
+});
+
+test("still renders local markdown images when there are no image blocks", () => {
+  const html = renderMessage({
+    role: "user",
+    content: [{ type: "text", text: "look:\n\n![icon](public/icons/icon-192.png)" }],
+    timestamp: Date.now(),
+  }, { cwd: PROJECT_ROOT });
+
+  assert.match(html, /api\/files/);
 });
 
 test("renders custom-message images as buttons that open a larger preview", () => {

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -232,6 +232,20 @@ export function replaceUserMessageText(message: UserMessage, text: string): User
   return { ...message, content };
 }
 
+/**
+ * Removes Markdown image references (`![alt](url)`) from user message text.
+ * pi writes the attached image's path back into the text as such a reference;
+ * the image is already rendered separately from the message's image blocks, so
+ * keeping the reference would render the same picture twice (MarkdownBody
+ * resolves the local path and shows it at full size).
+ */
+function stripMarkdownImageLinks(text: string): string {
+  return text
+    .replace(/(?<!\\)!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/[ \t]*\n{3,}/g, "\n\n");
+}
+
+
 function haveSameRelevantToolResults(
   message: AgentMessage,
   previous: Map<string, ToolResultMessage> | undefined,
@@ -301,7 +315,12 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
-  const content =
+  const imageBlocks: ImageContent[] =
+    typeof message.content === "string"
+      ? []
+      : message.content.filter((b): b is ImageContent => b.type === "image");
+
+  const rawContent =
     typeof message.content === "string"
       ? message.content
       : message.content
@@ -309,10 +328,12 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
           .map((b) => b.text)
           .join("\n");
 
-  const imageBlocks: ImageContent[] =
-    typeof message.content === "string"
-      ? []
-      : message.content.filter((b): b is ImageContent => b.type === "image");
+  // pi writes the attached image's path back into the user text as a Markdown
+  // image reference, e.g. `![name.png](/abs/path/name.png)`. The image itself
+  // is already rendered from the image blocks above, so drop those references
+  // from the text — otherwise MarkdownBody's local-path resolver renders the
+  // same picture a second time at full size (clipped by the bubble max-height).
+  const content = imageBlocks.length > 0 ? stripMarkdownImageLinks(rawContent) : rawContent;
 
   const commandText = skillExpansionToCommand(content);
   const commandSeparator = commandText?.search(/\s/) ?? -1;


### PR DESCRIPTION
## Problem

When a user attaches an image, pi writes the attached image's path back into the user message text as a Markdown image reference (e.g. `![name.png](/abs/path/name.png)`). With image blocks present, that reference was rendered **a second time at full size** through `MarkdownBody`'s local-path resolver (`/api/files`), clipping inside the bubble's max-height — the same picture appeared twice in one user message:

1. the image-block thumbnail (clickable preview), and
2. a cropped full-size duplicate below/above the text.

## Fix

`UserMessageView` now strips Markdown image references from the text when image blocks are present (the picture is already rendered from the blocks). When there are no image blocks, local Markdown images keep working as before.

## Tests

- `does not re-render the markdown image reference when image blocks exist` — fails on the old code (asserts no second `/api/files` image), passes with the fix; red-green verified against the parent commit.
- `still renders local markdown images when there are no image blocks` — regression guard for the non-image-block path.
- Full `MessageView.test.mjs` suite: 10/10 pass; `tsc --noEmit` and `eslint` clean.

## Known trade-off

When image blocks exist, *all* Markdown image references in the text are stripped, including ones manually written by the user (a rare case: hand-written local image reference + attached image in the same message). Since base64 image blocks don't carry the original file path, a precise "only strip the injected reference" match isn't reliably possible. Happy to refine if reviewers consider it necessary.
