### PR TITLE
feat: support pasting file paths copied from file manager (fixes #529)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,3 +216,13 @@ Location: `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`
 --accent --user-bg --tool-bg
 --font-mono
 ```
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/app/api/cwd/browse/route.ts
+++ b/app/api/cwd/browse/route.ts
@@ -32,7 +32,22 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Directory does not exist" }, { status: 404 });
     }
 
-    const directoryStat = await stat(resolved);
+    let directoryStat = await stat(resolved);
+    if (!directoryStat.isDirectory()) {
+      const parent = getParentDirectory(resolved);
+      if (parent) {
+        try {
+          const parentStat = await stat(parent);
+          if (parentStat.isDirectory()) {
+            resolved = parent;
+            directoryStat = parentStat;
+          }
+        } catch {
+          // Fall back to original directory check failure
+        }
+      }
+    }
+
     if (!directoryStat.isDirectory()) {
       return NextResponse.json({ error: "Path is not a directory" }, { status: 400 });
     }

--- a/app/api/cwd/validate/route.ts
+++ b/app/api/cwd/validate/route.ts
@@ -3,12 +3,16 @@ import { statSync, type Stats } from "fs";
 import { homedir } from "os";
 import { isAbsolute, resolve } from "path";
 import { allowFileRoot } from "@/lib/file-access";
+import { convertWindowsPathToWsl } from "@/lib/paths";
 import { projectIdentityKey } from "@/lib/project-identity";
 import { resolveProject } from "@/lib/worktree";
 
 function normalizeCwd(cwd: string): string {
   if (cwd === "~") return homedir();
   if (cwd.startsWith("~/")) return resolve(homedir(), cwd.slice(2));
+  if (process.platform === "linux" && /^[a-zA-Z]:/.test(cwd)) {
+    return resolve(convertWindowsPathToWsl(cwd));
+  }
   return isAbsolute(cwd) ? cwd : resolve(cwd);
 }
 

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -26,6 +26,7 @@ import { FolderIcon, getFileIcon } from "./FileIcons";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useI18n } from "@/hooks/useI18n";
 import type { ToolPreset } from "@/lib/tool-presets";
+import { extractPathsFromClipboardData, formatPathsForInput } from "@/lib/clipboard-paths";
 
 export interface AttachedImage {
   data: string;   // base64, no prefix
@@ -1175,11 +1176,32 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
     const items = Array.from(e.clipboardData?.items ?? []);
     const imageItems = items.filter((item) => item.type.startsWith("image/"));
-    if (!imageItems.length) return;
-    e.preventDefault();
-    const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
-    processImageFiles(files);
-  }, [processImageFiles]);
+    if (imageItems.length > 0) {
+      e.preventDefault();
+      const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
+      processImageFiles(files);
+      return;
+    }
+
+    const paths = extractPathsFromClipboardData(e.clipboardData, { fallbackToFileName: true });
+    if (paths.length > 0) {
+      e.preventDefault();
+      const pastedText = formatPathsForInput(paths);
+      const ta = textareaRef.current;
+      const start = ta?.selectionStart ?? value.length;
+      const end = ta?.selectionEnd ?? value.length;
+      const nextValue = value.slice(0, start) + pastedText + value.slice(end);
+      setValue(nextValue);
+      requestAnimationFrame(() => {
+        if (ta) {
+          const nextCursor = start + pastedText.length;
+          ta.selectionStart = nextCursor;
+          ta.selectionEnd = nextCursor;
+          handleInput();
+        }
+      });
+    }
+  }, [processImageFiles, value, handleInput]);
 
   useEffect(() => {
     if (slashQuery === null) {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -24,6 +24,7 @@ import {
   restoreScrollTop,
   VISIBLE_PAGE_SIZE,
 } from "@/lib/chat-lazy-load";
+import { extractPathsFromClipboardData, formatPathsForInput } from "@/lib/clipboard-paths";
 
 interface Props {
   session: SessionInfo | null;
@@ -1282,7 +1283,8 @@ function ExtensionCustomPanel({
           }}
           onPaste={(event) => {
             event.preventDefault();
-            const text = event.clipboardData.getData("text");
+            const paths = extractPathsFromClipboardData(event.clipboardData);
+            const text = paths.length > 0 ? formatPathsForInput(paths) : event.clipboardData.getData("text");
             if (text) onInput(request, asBracketedPaste(text));
           }}
           style={{

--- a/components/DirectoryPicker.test.mjs
+++ b/components/DirectoryPicker.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { DirectoryPicker } = await jiti.import("./DirectoryPicker.tsx");
+
+test("DirectoryPicker exports a React component function", () => {
+  assert.equal(typeof DirectoryPicker, "function");
+});

--- a/components/DirectoryPicker.tsx
+++ b/components/DirectoryPicker.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useI18n } from "@/hooks/useI18n";
+import { extractPathsFromClipboardData } from "@/lib/clipboard-paths";
 
 interface DirectoryEntry {
   name: string;
@@ -151,6 +152,14 @@ export function DirectoryPicker({ onCancel, onSelect, busy = false, error }: Pro
             onChange={(event) => {
               setPathInput(event.target.value);
               setLoadError(null);
+            }}
+            onPaste={(event) => {
+              const paths = extractPathsFromClipboardData(event.clipboardData);
+              if (paths.length > 0) {
+                event.preventDefault();
+                setPathInput(paths[0]);
+                setLoadError(null);
+              }
             }}
             style={{ minWidth: 0, flex: 1, height: 36, padding: "0 10px", border: "1px solid var(--border)", borderRadius: 6, outline: "none", background: "var(--bg-panel)", color: "var(--text)", fontFamily: "var(--font-mono)", fontSize: 12 }}
           />

--- a/components/PluginsConfig.tsx
+++ b/components/PluginsConfig.tsx
@@ -5,6 +5,7 @@ import { sendAgentCommand } from "@/lib/agent-client";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import type { PluginPackageInfo, PluginsResponse } from "@/lib/api-types";
 import { useI18n } from "@/hooks/useI18n";
+import { extractPathsFromClipboardData } from "@/lib/clipboard-paths";
 
 type PluginScope = PluginPackageInfo["scope"];
 type PluginAction = "install" | "remove" | "update" | "disable" | "enable";
@@ -361,9 +362,10 @@ function AddPluginPanel({
           value={source}
           onChange={(e) => onSourceChange(e.target.value)}
           onPaste={(e) => {
-            const pasted = e.clipboardData.getData("text");
+            const paths = extractPathsFromClipboardData(e.clipboardData);
+            const pasted = paths.length > 0 ? paths[0] : e.clipboardData.getData("text");
             const normalized = normalizePluginSourceInput(pasted);
-            if (normalized === pasted) return;
+            if (normalized === pasted && paths.length === 0) return;
             e.preventDefault();
             onSourceChange(normalized);
           }}

--- a/lib/clipboard-paths.test.mjs
+++ b/lib/clipboard-paths.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+  fileUriToPath,
+  extractPathsFromClipboardData,
+  formatPathsForInput,
+} = await jiti.import("./clipboard-paths.ts");
+
+test("fileUriToPath parses Unix file URIs", () => {
+  assert.equal(fileUriToPath("file:///home/user/project/file.txt"), "/home/user/project/file.txt");
+  assert.equal(fileUriToPath("file:///Users/john/Documents"), "/Users/john/Documents");
+  assert.equal(fileUriToPath("file://localhost/Users/john/Documents"), "/Users/john/Documents");
+});
+
+test("fileUriToPath parses Windows file URIs", () => {
+  assert.equal(fileUriToPath("file:///C:/Users/user/project/file.txt"), "C:/Users/user/project/file.txt");
+  assert.equal(fileUriToPath("file:///d:/repo/subfolder"), "d:/repo/subfolder");
+  assert.equal(fileUriToPath("file://server/share/file.txt"), "//server/share/file.txt");
+});
+
+test("fileUriToPath decodes percent-encoded characters and spaces", () => {
+  assert.equal(
+    fileUriToPath("file:///home/user/my%20folder/%E6%96%87%E4%BB%B6.txt"),
+    "/home/user/my folder/文件.txt"
+  );
+  assert.equal(
+    fileUriToPath("file:///C:/Program%20Files/App/test%20file.json"),
+    "C:/Program Files/App/test file.json"
+  );
+});
+
+test("fileUriToPath returns non-file URIs as trimmed strings", () => {
+  assert.equal(fileUriToPath("  /home/user/file.txt  "), "/home/user/file.txt");
+  assert.equal(fileUriToPath("C:\\Users\\user\\file.txt"), "C:\\Users\\user\\file.txt");
+});
+
+test("extractPathsFromClipboardData extracts paths from File.path (Electron / Desktop)", () => {
+  const fakeClipboard = {
+    files: [
+      { path: "/home/user/project/a.txt", name: "a.txt" },
+      { path: "/home/user/project/b.txt", name: "b.txt" },
+    ],
+    items: [],
+    getData: () => "",
+  };
+
+  const paths = extractPathsFromClipboardData(fakeClipboard);
+  assert.deepEqual(paths, ["/home/user/project/a.txt", "/home/user/project/b.txt"]);
+});
+
+test("extractPathsFromClipboardData extracts paths from text/uri-list", () => {
+  const uriList = [
+    "# Comment line",
+    "file:///home/user/code/index.ts",
+    "file:///home/user/code/package.json",
+  ].join("\r\n");
+
+  const fakeClipboard = {
+    files: [],
+    items: [],
+    getData: (type) => (type === "text/uri-list" ? uriList : ""),
+  };
+
+  const paths = extractPathsFromClipboardData(fakeClipboard);
+  assert.deepEqual(paths, ["/home/user/code/index.ts", "/home/user/code/package.json"]);
+});
+
+test("extractPathsFromClipboardData extracts paths from Linux Nautilus/GNOME clipboard", () => {
+  const nautilusData = "copy\nfile:///home/user/photos/image.png\nfile:///home/user/photos/doc.pdf";
+
+  const fakeClipboard = {
+    files: [],
+    items: [],
+    getData: (type) => (type === "x-special/nautilus-clipboard" ? nautilusData : ""),
+  };
+
+  const paths = extractPathsFromClipboardData(fakeClipboard);
+  assert.deepEqual(paths, ["/home/user/photos/image.png", "/home/user/photos/doc.pdf"]);
+});
+
+test("extractPathsFromClipboardData extracts paths from macOS public.file-url", () => {
+  const fakeClipboard = {
+    files: [],
+    items: [],
+    getData: (type) => (type === "public.file-url" ? "file:///Users/name/Desktop/test.ts" : ""),
+  };
+
+  const paths = extractPathsFromClipboardData(fakeClipboard);
+  assert.deepEqual(paths, ["/Users/name/Desktop/test.ts"]);
+});
+
+test("extractPathsFromClipboardData extracts paths from text/plain with file:// URIs", () => {
+  const fakeClipboard = {
+    files: [],
+    items: [],
+    getData: (type) => (type === "text/plain" ? "file:///home/user/test.py" : ""),
+  };
+
+  const paths = extractPathsFromClipboardData(fakeClipboard);
+  assert.deepEqual(paths, ["/home/user/test.py"]);
+});
+
+test("extractPathsFromClipboardData handles null or empty clipboard data", () => {
+  assert.deepEqual(extractPathsFromClipboardData(null), []);
+  assert.deepEqual(
+    extractPathsFromClipboardData({
+      files: [],
+      items: [],
+      getData: () => "",
+    }),
+    []
+  );
+});
+
+test("extractPathsFromClipboardData supports fallbackToFileName", () => {
+  const fakeClipboard = {
+    files: [{ name: "myfile.zip" }],
+    items: [],
+    getData: () => "",
+  };
+
+  assert.deepEqual(extractPathsFromClipboardData(fakeClipboard, { fallbackToFileName: true }), ["myfile.zip"]);
+  assert.deepEqual(extractPathsFromClipboardData(fakeClipboard), []);
+});
+
+test("formatPathsForInput formats paths with quotes when containing spaces", () => {
+  assert.equal(formatPathsForInput([]), "");
+  assert.equal(formatPathsForInput(["/home/user/file.txt"]), "/home/user/file.txt");
+  assert.equal(
+    formatPathsForInput(["/home/user/my file.txt", "/home/user/other.txt"]),
+    '"/home/user/my file.txt" /home/user/other.txt'
+  );
+  assert.equal(
+    formatPathsForInput(['"already quoted"', "simple"]),
+    '"already quoted" simple'
+  );
+});

--- a/lib/clipboard-paths.ts
+++ b/lib/clipboard-paths.ts
@@ -1,0 +1,192 @@
+/**
+ * Helpers for extracting and formatting file paths from clipboard / drag-drop data.
+ * Supports Windows Explorer (CF_HDROP / File.path), macOS Finder (file-url / uri-list),
+ * and Linux file managers (Nautilus, Dolphin, Thunar, etc.).
+ */
+
+/**
+ * Converts a file:// URI to a local file system path.
+ * Handles Windows drive letters, Unix paths, percent-encoding, and UNC network paths.
+ */
+export function fileUriToPath(uri: string): string {
+  const trimmed = uri.trim();
+  if (!trimmed.startsWith("file://")) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    let pathname = decodeURIComponent(parsed.pathname);
+
+    // On Windows, URL pathname for file:///C:/path is "/C:/path" -> "C:/path"
+    if (/^\/[a-zA-Z]:[\\/]/.test(pathname)) {
+      pathname = pathname.slice(1);
+    } else if (parsed.host && parsed.host !== "localhost") {
+      // UNC path: file://server/share/file -> //server/share/file
+      pathname = `//${parsed.host}${pathname}`;
+    }
+
+    return pathname;
+  } catch {
+    let raw = trimmed.replace(/^file:\/\/(localhost)?/, "");
+    try {
+      raw = decodeURIComponent(raw);
+    } catch {
+      // Ignore URI decode errors and use raw string
+    }
+    if (/^\/[a-zA-Z]:[\\/]/.test(raw)) {
+      raw = raw.slice(1);
+    }
+    return raw;
+  }
+}
+
+export interface ExtractPathsOptions {
+  /**
+   * If true and no full paths or URIs could be found,
+   * fall back to returning the `name` property of clipboard File objects.
+   */
+  fallbackToFileName?: boolean;
+}
+
+const LINUX_CLIPBOARD_TYPES = [
+  "text/uri-list",
+  "x-special/nautilus-clipboard",
+  "x-special/gnome-copied-files",
+  "x-special/mate-copied-files",
+  "x-special/xfce4-copied-files",
+  "application/x-kde-cutselection",
+  "public.file-url",
+  "text/x-moz-url",
+  "application/x-moz-file",
+];
+
+function extractPathsFromText(text: string): string[] {
+  if (!text) return [];
+  const lines = text.split(/\r?\n/);
+  const paths: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || trimmed === "copy" || trimmed === "cut") {
+      continue;
+    }
+    if (trimmed.startsWith("file://")) {
+      paths.push(fileUriToPath(trimmed));
+    } else if (trimmed.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(trimmed)) {
+      paths.push(trimmed);
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Extracts file or directory paths from clipboard data or drag-and-drop DataTransfer.
+ */
+export function extractPathsFromClipboardData(
+  clipboardData: DataTransfer | null,
+  options?: ExtractPathsOptions
+): string[] {
+  if (!clipboardData) return [];
+
+  const foundPaths: string[] = [];
+
+  // 1. Check for Electron / desktop runtime `File.path` property on files
+  const files = Array.from(clipboardData.files ?? []);
+  for (const file of files) {
+    const filePath = (file as unknown as { path?: unknown }).path;
+    if (typeof filePath === "string" && filePath.trim()) {
+      foundPaths.push(filePath.trim());
+    }
+  }
+
+  if (foundPaths.length > 0) {
+    return Array.from(new Set(foundPaths));
+  }
+
+  // 2. Check DataTransferItem.getAsFile() if files didn't have path
+  const items = Array.from(clipboardData.items ?? []);
+  for (const item of items) {
+    if (item.kind === "file") {
+      const file = item.getAsFile();
+      const filePath = (file as unknown as { path?: unknown })?.path;
+      if (typeof filePath === "string" && filePath.trim()) {
+        foundPaths.push(filePath.trim());
+      }
+    }
+  }
+
+  if (foundPaths.length > 0) {
+    return Array.from(new Set(foundPaths));
+  }
+
+  // 3. Check specialized MIME types (text/uri-list, Linux file managers, macOS file-url)
+  for (const mimeType of LINUX_CLIPBOARD_TYPES) {
+    try {
+      const data = clipboardData.getData(mimeType);
+      if (data) {
+        const paths = extractPathsFromText(data);
+        if (paths.length > 0) {
+          foundPaths.push(...paths);
+        }
+      }
+    } catch {
+      // Some browsers throw when accessing unsupported custom MIME types
+    }
+  }
+
+  if (foundPaths.length > 0) {
+    return Array.from(new Set(foundPaths));
+  }
+
+  // 4. Check text/plain if it contains file:// URIs
+  try {
+    const textPlain = clipboardData.getData("text/plain") || clipboardData.getData("text");
+    if (textPlain) {
+      const lines = textPlain.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+      const fileUriLines = lines.filter((l) => l.startsWith("file://"));
+      if (fileUriLines.length > 0 && fileUriLines.length === lines.length) {
+        for (const uri of fileUriLines) {
+          foundPaths.push(fileUriToPath(uri));
+        }
+      }
+    }
+  } catch {
+    // Ignore data access error
+  }
+
+  if (foundPaths.length > 0) {
+    return Array.from(new Set(foundPaths));
+  }
+
+  // 5. Fallback to file names if enabled
+  if (options?.fallbackToFileName && files.length > 0) {
+    for (const file of files) {
+      if (file.name) {
+        foundPaths.push(file.name);
+      }
+    }
+  }
+
+  return Array.from(new Set(foundPaths));
+}
+
+/**
+ * Formats a list of paths into a string suitable for pasting into a text input or textarea.
+ * Quotes individual paths if they contain whitespace.
+ */
+export function formatPathsForInput(paths: string[], delimiter = " "): string {
+  if (!paths || paths.length === 0) return "";
+  if (paths.length === 1) return paths[0];
+
+  return paths
+    .map((p) => {
+      const trimmed = p.trim();
+      if (/\s/.test(trimmed) && !trimmed.startsWith('"') && !trimmed.startsWith("'")) {
+        return `"${trimmed}"`;
+      }
+      return trimmed;
+    })
+    .join(delimiter);
+}

--- a/lib/directory-browser.test.mjs
+++ b/lib/directory-browser.test.mjs
@@ -3,10 +3,18 @@ import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { createJiti } from "jiti";
 
-async function loadSubject() {
-  return import("./directory-browser.ts");
-}
+const jiti = createJiti(import.meta.url);
+const {
+  listDirectories,
+  getBrowseStartDirectory,
+  normalizeDirectory,
+  resolveDirectory,
+  shouldShowWindowsDrivePicker,
+  getWindowsDriveCandidates,
+  getParentDirectory,
+} = await jiti.import("./directory-browser.ts");
 
 test("lists directories and directory symlinks without returning files", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "pi-web-browse-"));
@@ -15,9 +23,7 @@ test("lists directories and directory symlinks without returning files", async (
     await writeFile(path.join(root, "notes.txt"), "test", "utf8");
     await symlink(path.join(root, "project"), path.join(root, "linked-project"));
 
-    const { listDirectories } = await loadSubject();
     const directories = await listDirectories(root);
-
     assert.deepEqual(directories.map((entry) => entry.name), ["linked-project", "project"]);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -25,12 +31,6 @@ test("lists directories and directory symlinks without returning files", async (
 });
 
 test("expands home-relative paths and rejects missing directories", async () => {
-  const {
-    getBrowseStartDirectory,
-    normalizeDirectory,
-    resolveDirectory,
-    shouldShowWindowsDrivePicker,
-  } = await loadSubject();
   assert.equal(getBrowseStartDirectory(), homedir());
   assert.equal(getBrowseStartDirectory("/project"), "/project");
   assert.equal(shouldShowWindowsDrivePicker(undefined, "win32"), true);
@@ -38,11 +38,11 @@ test("expands home-relative paths and rejects missing directories", async () => 
   assert.equal(shouldShowWindowsDrivePicker(undefined, "linux"), false);
   assert.equal(shouldShowWindowsDrivePicker("C:\\Projects", "win32"), false);
   assert.equal(normalizeDirectory("~/project"), path.join(homedir(), "project"));
+  assert.equal(normalizeDirectory("C:\\Users\\WXR\\Desktop", "linux"), "/mnt/c/Users/WXR/Desktop");
   await assert.rejects(resolveDirectory(path.join(tmpdir(), `pi-web-missing-${Date.now()}`)));
 });
 
-test("builds every Windows drive-letter candidate", async () => {
-  const { getWindowsDriveCandidates } = await loadSubject();
+test("builds every Windows drive-letter candidate", () => {
   const drives = getWindowsDriveCandidates();
 
   assert.equal(drives.length, 26);
@@ -50,11 +50,9 @@ test("builds every Windows drive-letter candidate", async () => {
   assert.deepEqual(drives.at(-1), { name: "Z:", path: "Z:\\" });
 });
 
-test("finds parent directories across POSIX and Windows paths", async () => {
-  const { getParentDirectory } = await loadSubject();
-
+test("finds parent directories across POSIX and Windows paths", () => {
   assert.equal(getParentDirectory("/Users/alex/project"), "/Users/alex");
   assert.equal(getParentDirectory("/"), null);
-  assert.equal(getParentDirectory("C:\\Users\\Alex\\project"), "C:\\Users\\Alex");
-  assert.equal(getParentDirectory("C:\\"), null);
+  assert.equal(getParentDirectory("C:\\Users\\Alex\\project", "win32"), "C:\\Users\\Alex");
+  assert.equal(getParentDirectory("C:\\", "win32"), null);
 });

--- a/lib/directory-browser.ts
+++ b/lib/directory-browser.ts
@@ -1,6 +1,7 @@
 import { readdir, realpath, stat } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
+import { convertWindowsPathToWsl } from "./paths";
 
 export interface BrowsableDirectory {
   name: string;
@@ -38,23 +39,34 @@ export async function listWindowsDrives(): Promise<BrowsableDirectory[]> {
   return candidates.filter((drive): drive is BrowsableDirectory => drive !== null);
 }
 
-export function normalizeDirectory(directory: string): string {
+export function normalizeDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (directory === "~") return homedir();
   if (directory.startsWith("~/")) return path.resolve(homedir(), directory.slice(2));
+  if (platform === "linux" && /^[a-zA-Z]:/.test(directory)) {
+    return path.resolve(convertWindowsPathToWsl(directory));
+  }
   return path.resolve(directory);
 }
 
-export function getParentDirectory(directory: string): string | null {
-  const pathApi = /^[a-zA-Z]:[\\/]/.test(directory) || directory.startsWith("\\\\")
-    ? path.win32
-    : path.posix;
+export function getParentDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const isWindows = /^[a-zA-Z]:[\\/]/.test(directory) || directory.startsWith("\\\\");
+  const pathApi = isWindows && platform === "win32" ? path.win32 : path.posix;
   const normalized = pathApi.normalize(directory);
   const parent = pathApi.dirname(normalized);
   return parent === normalized ? null : parent;
 }
 
-export async function resolveDirectory(directory: string): Promise<string> {
-  return realpath(normalizeDirectory(directory));
+export async function resolveDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string> {
+  return realpath(normalizeDirectory(directory, platform));
 }
 
 export async function listDirectories(directory: string): Promise<BrowsableDirectory[]> {

--- a/lib/paths.test.mjs
+++ b/lib/paths.test.mjs
@@ -56,3 +56,12 @@ test("isWindowsAbsolutePath recognizes drive and UNC paths", async () => {
   assert.equal(isWindowsAbsolutePath("\\\\server\\share"), true);
   assert.equal(isWindowsAbsolutePath("relative/path"), false);
 });
+
+test("convertWindowsPathToWsl converts Windows drive paths to /mnt/<drive>", async () => {
+  const { convertWindowsPathToWsl } = await loadSubject();
+  assert.equal(convertWindowsPathToWsl("C:\\Users\\WXR\\Desktop\\test.txt"), "/mnt/c/Users/WXR/Desktop/test.txt");
+  assert.equal(convertWindowsPathToWsl("d:/repo/sub"), "/mnt/d/repo/sub");
+  assert.equal(convertWindowsPathToWsl("C:"), "/mnt/c");
+  assert.equal(convertWindowsPathToWsl("C:\\"), "/mnt/c");
+  assert.equal(convertWindowsPathToWsl("/home/user"), "/home/user");
+});

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -28,6 +28,21 @@ export function isWindowsAbsolutePath(filePath: string): boolean {
 }
 
 /**
+ * Converts a Windows absolute path (e.g. C:\Users\... or C:/...) to a WSL / Linux mount path (/mnt/c/Users/...)
+ * when running on a Linux platform.
+ */
+export function convertWindowsPathToWsl(p: string): string {
+  const trimmed = p.trim();
+  const driveMatch = trimmed.match(/^([a-zA-Z]):(?:[\\/](.*))?$/);
+  if (driveMatch) {
+    const drive = driveMatch[1].toLowerCase();
+    const rest = (driveMatch[2] ?? "").replace(/\\/g, "/");
+    return rest ? `/mnt/${drive}/${rest}` : `/mnt/${drive}`;
+  }
+  return p;
+}
+
+/**
  * Convert a path to native separators. Chiefly for git output: git prints
  * POSIX-style absolute paths even on Windows (`D:/repo/sub`), which never
  * string-compares equal to the native paths Node and pi produce.


### PR DESCRIPTION
### Description

This PR resolves #529 by supporting pasting file and folder paths directly into input fields when users copy files/folders from their OS file manager (Windows Explorer, macOS Finder, Linux file managers), and adds WSL Windows drive path mapping for Linux/WSL environments.

### Changes

- **`lib/clipboard-paths.ts`**:
  - Implemented `fileUriToPath`: converts `file://` URIs to native OS paths, handling Windows drive letters (`file:///C:/...`), Unix paths, percent-encoding/spaces (`%20`, Unicode characters), and UNC paths.
  - Implemented `extractPathsFromClipboardData`: extracts file paths from `File.path` (Electron/desktop runtimes), `text/uri-list`, Linux clipboard formats (`x-special/nautilus-clipboard`, `x-special/gnome-copied-files`, `x-special/mate-copied-files`, `x-special/xfce4-copied-files`, `application/x-kde-cutselection`), macOS clipboard formats (`public.file-url`, `text/x-moz-url`), and `text/plain` file URIs.
  - Implemented `formatPathsForInput`: formats single or multiple file paths with automatic quoting for paths containing whitespace.
- **`lib/paths.ts` & `lib/directory-browser.ts` & `app/api/cwd/validate/route.ts`**:
  - Added `convertWindowsPathToWsl`: automatically converts Windows drive paths (e.g. `C:\Users\...` or `C:/...`) to WSL mount paths (`/mnt/c/Users/...`) when running on Linux/WSL.
- **`components/DirectoryPicker.tsx`**:
  - Added `onPaste` handler to directory path input box to automatically paste copied file/folder paths.
- **`components/ChatInput.tsx`**:
  - Updated `handlePaste` so non-image files copied from file manager insert their formatted file paths directly into the message textarea.
- **`components/PluginsConfig.tsx`**:
  - Updated `onPaste` on the plugin source input to support pasting folder/package file paths.
- **`components/ChatWindow.tsx`**:
  - Updated extension custom panel paste handler to handle clipboard file paths.
- **`app/api/cwd/browse/route.ts`**:
  - When browsing a path that points to a file (e.g. pasted into DirectoryPicker), automatically navigates to its parent directory rather than failing.
- **Tests**:
  - Added unit test suite `lib/clipboard-paths.test.mjs` (12 tests), updated `lib/directory-browser.test.mjs` and `lib/paths.test.mjs`, and added `components/DirectoryPicker.test.mjs`.

Fixes #529.