### PR TITLE
fix: make one-line extension widgets expandable

### DIFF
--- a/components/ExtensionWidgets.test.mjs
+++ b/components/ExtensionWidgets.test.mjs
@@ -126,9 +126,9 @@ test("compares widget lines without delimiter collisions", () => {
   assert.deepEqual(getUpdatedExtensionWidgetKeys(previous, next), ["status"]);
 });
 
-test("uses a compact key-only trigger with a placement icon", () => {
+test("keeps one-line widgets compact but expandable", () => {
   const html = renderWidgets({
-    widgets: [{ key: "long-extension-widget-key", lines: ["ready"], placement: "belowEditor" }],
+    widgets: [{ key: "single-line-widget", lines: ["ready"], placement: "belowEditor" }],
   });
 
   assert.match(html, /extension-widget-triggers/);
@@ -136,11 +136,24 @@ test("uses a compact key-only trigger with a placement icon", () => {
   assert.match(html, /data-direction="down"/);
   assert.doesNotMatch(html, /[\u2191\u2193]/);
   assert.match(html, /Below editor widget/);
-  assert.doesNotMatch(html, /aria-expanded/);
-  assert.match(html, /title="long-extension-widget-key - Below editor widget"/);
+  assert.match(html, /<button[^>]*class="extension-widget-trigger/);
+  assert.match(html, /aria-expanded="false"/);
+  assert.match(html, /title="single-line-widget - Below editor widget - Expand"/);
   assert.match(html, /extension-widget-key/);
   assert.match(html, /extension-widget-update-pulse/);
   assert.doesNotMatch(html, /extension-widget-preview/);
   assert.doesNotMatch(html, /extension-widget-line-count/);
   assert.doesNotMatch(html, />ready</);
+  assert.doesNotMatch(html, /<pre/);
+});
+
+test("keeps empty widgets non-interactive", () => {
+  const html = renderWidgets({
+    widgets: [{ key: "empty-widget", lines: [], placement: "aboveEditor" }],
+  });
+
+  assert.match(html, /<div class="extension-widget-trigger/);
+  assert.doesNotMatch(html, /<button/);
+  assert.doesNotMatch(html, /aria-expanded/);
+  assert.match(html, /title="empty-widget - Above editor widget"/);
 });

--- a/components/ExtensionWidgets.tsx
+++ b/components/ExtensionWidgets.tsx
@@ -105,7 +105,7 @@ export function ExtensionWidgets({ widgets }: { widgets: ExtensionWidgetItem[] }
 
   const expandedWidget = widgets.find((widget) => (
     widget.key === expandedWidgetKey
-    && widget.lines.length > 1
+    && widget.lines.length > 0
   ));
 
   const toggleWidget = (widget: ExtensionWidgetItem) => {
@@ -139,7 +139,7 @@ export function ExtensionWidgets({ widgets }: { widgets: ExtensionWidgetItem[] }
       )}
       <div className="extension-widget-triggers" aria-label={t("chat.extensionWidgets")}>
         {widgets.map((widget, index) => {
-          const expandable = widget.lines.length > 1;
+          const expandable = widget.lines.length > 0;
           const expanded = expandable && widget.key === expandedWidget?.key;
           const updating = updatingWidgetKeys.has(widget.key);
           const lineCountLabel = t(


### PR DESCRIPTION
## Summary

- Treat every non-empty extension widget as expandable in the compact status bar.
- Keep one-line widgets collapsed by default while preserving the existing empty-widget behavior.
- Add regression coverage for one-line and empty widgets.

## Testing

- `npm test` (`588` tests passed)
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `npm run build`

## AI assistance

OpenAI Codex was used to investigate the widget behavior, implement the fix, and run the tests. The resulting diff was independently reviewed before submission.

Closes #538
