### PR TITLE
feat(sidebar): persist user-pinned custom project paths in localStorage

### DIFF
--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -5,7 +5,8 @@ import type { SessionInfo } from "@/lib/types";
 import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
 import { dispatchSessionRowContextMenu } from "@/lib/session-row-context-menu";
 import { skillExpansionToCommand } from "@/lib/slash-display";
-import { getProjectActivity, getRecentProjects, sessionsForProject } from "@/lib/project-groups";
+import { getProjectActivity, getRecentProjects, isCustomOnlyProject, sessionsForProject } from "@/lib/project-groups";
+import { loadCustomProjects, removeCustomProject, saveCustomProject } from "@/lib/custom-projects";
 import { workspaceKeyOf } from "@/lib/workspace-memory";
 import { useI18n } from "@/hooks/useI18n";
 import { DirectoryPicker } from "./DirectoryPicker";
@@ -406,6 +407,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [customPathValue, setCustomPathValue] = useState("");
   const [customPathError, setCustomPathError] = useState<string | null>(null);
   const [customPathValidating, setCustomPathValidating] = useState(false);
+  // User-pinned custom project paths. Persisted in localStorage so the
+  // directory picker's "Custom path" branch survives a reload even when
+  // no session has been started in that project yet.
+  const [customProjects, setCustomProjects] = useState(loadCustomProjects);
   const [validatedProject, setValidatedProject] = useState<ValidatedProject | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   // Worktree switcher state
@@ -712,10 +717,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         // Session not found — notify parent so it can show the placeholder
         onInitialRestoreDone?.();
       }
-      const projects = getRecentProjects(allSessions);
+      const projects = getRecentProjects(allSessions, customProjects);
       if (projects.length > 0) setSelectedCwd(projects[0].root);
     }
-  }, [allSessions, selectedCwd, initialSessionId, skipInitialProjectSelection, onSelectSession, onInitialRestoreDone]);
+  }, [allSessions, customProjects, selectedCwd, initialSessionId, skipInitialProjectSelection, onSelectSession, onInitialRestoreDone]);
 
   // Prefer an exact UI selection while a refetch is in flight. Once the
   // response catches up, the server-resolved path handles Windows case and
@@ -751,6 +756,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         setCustomPathError(data.error ?? `HTTP ${res.status}`);
         return;
       }
+      saveCustomProject({ key: data.projectKey, root: data.projectRoot });
+      setCustomProjects(loadCustomProjects());
       setValidatedProject({
         cwd: data.cwd,
         root: data.projectRoot,
@@ -894,7 +901,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     onNewSession?.(tempId, selectedCwd);
   }, [selectedCwd, onNewSession]);
 
-  const recentProjects = getRecentProjects(allSessions);
+  const recentProjects = getRecentProjects(allSessions, customProjects);
   const showProjectFilter = recentProjects.length > 8;
   const visibleProjects = projectFilter.trim()
     ? recentProjects.filter((project) => project.root.toLowerCase().includes(projectFilter.trim().toLowerCase()))
@@ -1164,7 +1171,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 </div>
               )}
               <div style={{ maxHeight: "min(50vh, 380px)", overflowY: "auto" }}>
-                {visibleProjects.map((project) => (
+                {visibleProjects.map((project) => {
+                  const isCustomOnly = isCustomOnlyProject(project.key, allSessions, customProjects);
+                  return (
                   <button
                     key={project.key}
                     onClick={() => {
@@ -1202,9 +1211,42 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                     )}
                     {project.key !== selectedProject?.key && <span style={{ width: 10, flexShrink: 0 }} />}
                     <PathLabel text={displayCwd(project.root, homeDir)} style={{ flex: 1 }} />
+                    {isCustomOnly && (
+                      <span
+                        role="button"
+                        tabIndex={-1}
+                        aria-label={t("sidebar.removeCustomProject")}
+                        title={t("sidebar.removeCustomProject")}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeCustomProject(project.key);
+                          setCustomProjects(loadCustomProjects());
+                        }}
+                        style={{
+                          flexShrink: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          width: 16,
+                          height: 16,
+                          borderRadius: 4,
+                          color: "var(--text-dim)",
+                          cursor: "pointer",
+                          opacity: 0.7,
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.color = "#ef4444"; e.currentTarget.style.opacity = "1"; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-dim)"; e.currentTarget.style.opacity = "0.7"; }}
+                      >
+                        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+                          <line x1="2" y1="2" x2="8" y2="8" />
+                          <line x1="8" y1="2" x2="2" y2="8" />
+                        </svg>
+                      </span>
+                    )}
                     {showProjectActivity(projectActivity.get(project.key), t)}
                   </button>
-                ))}
+                  );
+                })}
                 {visibleProjects.length === 0 && projectFilter.trim() && (
                    <div style={{ padding: "8px 10px", fontSize: 11, color: "var(--text-dim)" }}>{t("sidebar.noMatchingProjects")}</div>
                 )}

--- a/lib/custom-projects.test.mjs
+++ b/lib/custom-projects.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+  loadCustomProjects,
+  removeCustomProject,
+  saveCustomProject,
+} = await jiti.import("./custom-projects.ts");
+
+function createStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    values,
+    getItem(key) { return values.get(key) ?? null; },
+    setItem(key, value) { values.set(key, value); },
+    removeItem(key) { values.delete(key); },
+  };
+}
+
+test("returns an empty list when storage has no entries", () => {
+  const storage = createStorage();
+  assert.deepEqual(loadCustomProjects(storage), []);
+});
+
+test("round-trips pinned projects through save and load", () => {
+  const storage = createStorage();
+  saveCustomProject({ key: "alpha", root: "/tmp/a" }, storage);
+  saveCustomProject({ key: "beta", root: "/tmp/b" }, storage);
+
+  const entries = loadCustomProjects(storage);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries.map((e) => e.key).sort(), ["alpha", "beta"]);
+  for (const entry of entries) {
+    assert.match(entry.addedAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(typeof entry.root, "string");
+  }
+});
+
+test("save replaces an existing entry with the same key rather than duplicating it", () => {
+  const storage = createStorage();
+  saveCustomProject({ key: "alpha", root: "/tmp/a" }, storage);
+  saveCustomProject({ key: "alpha", root: "/tmp/a-renamed" }, storage);
+
+  const entries = loadCustomProjects(storage);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].root, "/tmp/a-renamed");
+});
+
+test("remove deletes only the requested key", () => {
+  const storage = createStorage();
+  saveCustomProject({ key: "alpha", root: "/tmp/a" }, storage);
+  saveCustomProject({ key: "beta", root: "/tmp/b" }, storage);
+
+  removeCustomProject("alpha", storage);
+
+  const entries = loadCustomProjects(storage);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].key, "beta");
+});
+
+test("drops the storage key entirely when the last entry is removed", () => {
+  const storage = createStorage();
+  saveCustomProject({ key: "alpha", root: "/tmp/a" }, storage);
+  assert.ok(storage.values.has("pi-web:custom-project-paths"));
+
+  removeCustomProject("alpha", storage);
+  assert.equal(storage.values.has("pi-web:custom-project-paths"), false);
+});
+
+test("drops malformed entries without throwing", () => {
+  const storage = createStorage({
+    "pi-web:custom-project-paths": JSON.stringify([
+      { key: "ok", root: "/tmp/ok", addedAt: "2026-08-18T00:00:00.000Z" },
+      { key: "missing-root" },
+      null,
+      "string",
+      { key: 42, root: true, addedAt: [] },
+    ]),
+  });
+
+  const entries = loadCustomProjects(storage);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].key, "ok");
+});
+
+test("returns an empty list when storage raises on access", () => {
+  const blocked = {
+    getItem() { throw new Error("blocked"); },
+    setItem() { throw new Error("blocked"); },
+    removeItem() { throw new Error("blocked"); },
+  };
+  assert.deepEqual(loadCustomProjects(blocked), []);
+  assert.doesNotThrow(() => saveCustomProject({ key: "a", root: "/a" }, blocked));
+  assert.doesNotThrow(() => removeCustomProject("a", blocked));
+});
+
+test("returns an empty list when localStorage is undefined (SSR)", () => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", { configurable: true, value: undefined });
+  try {
+    assert.deepEqual(loadCustomProjects(), []);
+    assert.doesNotThrow(() => saveCustomProject({ key: "a", root: "/a" }));
+  } finally {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else delete globalThis.window;
+  }
+});

--- a/lib/custom-projects.ts
+++ b/lib/custom-projects.ts
@@ -1,0 +1,94 @@
+/**
+ * Browser-local persistence for user-pinned custom project paths.
+ *
+ * The directory picker's "Custom path" branch validates a path server-side
+ * but never wrote the choice anywhere except React state, so the path vanished
+ * on reload and was absent from the project selector. This module lets the
+ * sidebar remember those choices across reloads in `window.localStorage`.
+ *
+ * Entries only matter for projects that do not yet have a session file —
+ * session-derived projects are surfaced by `getRecentProjects` regardless.
+ * Stale entries are pruned automatically because the picker re-validates on
+ * click and `commitCustomPath` only persists on a successful response.
+ */
+
+import type { RecentProject } from "./project-groups";
+
+const STORAGE_KEY = "pi-web:custom-project-paths";
+
+export interface CustomProjectEntry extends RecentProject {
+  /** ISO timestamp recorded when the user pinned this project. */
+  addedAt: string;
+}
+
+function resolveBrowserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isValidEntry(value: unknown): value is CustomProjectEntry {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.key === "string"
+    && typeof v.root === "string"
+    && typeof v.addedAt === "string";
+}
+
+/**
+ * Load user-pinned custom project paths from browser localStorage.
+ * Returns an empty array when storage is unavailable or the payload is
+ * malformed — every consumer is expected to handle that gracefully.
+ */
+export function loadCustomProjects(storage: Storage | null = resolveBrowserStorage()): CustomProjectEntry[] {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidEntry);
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the full list. Strips the entry on empty so storage stays tidy. */
+function writeCustomProjects(entries: CustomProjectEntry[], storage: Storage | null = resolveBrowserStorage()): void {
+  if (!storage) return;
+  try {
+    if (entries.length === 0) {
+      storage.removeItem(STORAGE_KEY);
+    } else {
+      storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    }
+  } catch {
+    // Privacy mode or quota errors must not break project selection.
+  }
+}
+
+/**
+ * Pin a project path. If a previous entry exists with the same key it is
+ * replaced — useful both for re-pinning and for normalising path casing.
+ */
+export function saveCustomProject(
+  project: { key: string; root: string },
+  storage: Storage | null = resolveBrowserStorage(),
+): void {
+  const list = loadCustomProjects(storage).filter((p) => p.key !== project.key);
+  list.push({ key: project.key, root: project.root, addedAt: new Date().toISOString() });
+  writeCustomProjects(list, storage);
+}
+
+/** Forget a pinned project by its stable server-provided key. */
+export function removeCustomProject(
+  key: string,
+  storage: Storage | null = resolveBrowserStorage(),
+): void {
+  const list = loadCustomProjects(storage);
+  const next = list.filter((p) => p.key !== key);
+  if (next.length !== list.length) writeCustomProjects(next, storage);
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -80,6 +80,7 @@ export const enLocale: LocalePlugin = {
     "sidebar.noMatchingProjects": "No matching projects",
     "sidebar.useDefaultDirectory": "Use default directory",
     "sidebar.customPath": "Custom path…",
+    "sidebar.removeCustomProject": "Remove from project list",
     "directoryPicker.selectDirectory": "Select directory",
     "directoryPicker.goToParent": "Go to parent directory",
     "directoryPicker.directoryPath": "Directory path",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -80,6 +80,7 @@ export const zhCNLocale: LocalePlugin = {
     "sidebar.noMatchingProjects": "没有匹配的项目",
     "sidebar.useDefaultDirectory": "使用默认目录",
     "sidebar.customPath": "自定义路径…",
+    "sidebar.removeCustomProject": "从项目列表移除",
     "directoryPicker.selectDirectory": "选择目录",
     "directoryPicker.goToParent": "转到上级目录",
     "directoryPicker.directoryPath": "目录路径",

--- a/lib/project-groups.test.mjs
+++ b/lib/project-groups.test.mjs
@@ -7,6 +7,7 @@ const { projectIdentityKey } = await jiti.import("./project-identity.ts");
 const {
   getProjectActivity,
   getRecentProjects,
+  isCustomOnlyProject,
   sessionsForProject,
 } = await jiti.import("./project-groups.ts");
 
@@ -57,4 +58,26 @@ test("running and unread counts aggregate under the stable project identity", ()
 
   assert.deepEqual(activity.get(first.projectKey), { running: 2, unread: 1 });
   assert.equal(activity.size, 1);
+});
+
+test("pinned custom projects fill gaps and keep session roots when both reference the same project", () => {
+  const active = session("active", "/Users/alex/project", "2026-08-13T00:00:00.000Z");
+  const pinnedActive = { key: active.projectKey, root: "/Users/alex/project", addedAt: "2026-08-12T00:00:00.000Z" };
+  const pinnedNew = { key: "ghost-key", root: "/Users/alex/never-used", addedAt: "2026-08-14T00:00:00.000Z" };
+
+  const projects = getRecentProjects([active], [pinnedActive, pinnedNew]);
+  const byKey = new Map(projects.map((p) => [p.key, p.root]));
+
+  assert.equal(byKey.get(active.projectKey), active.projectRoot);
+  assert.equal(byKey.get("ghost-key"), "/Users/alex/never-used");
+  assert.equal(projects.length, 2);
+});
+
+test("isCustomOnlyProject distinguishes pinned-only projects from session-backed ones", () => {
+  const active = session("active", "/Users/alex/project", "2026-08-13T00:00:00.000Z");
+  const pinned = { key: "ghost-key", root: "/Users/alex/never-used", addedAt: "2026-08-14T00:00:00.000Z" };
+
+  assert.equal(isCustomOnlyProject(active.projectKey, [active], [pinned]), false);
+  assert.equal(isCustomOnlyProject("ghost-key", [active], [pinned]), true);
+  assert.equal(isCustomOnlyProject("missing", [active], [pinned]), false);
 });

--- a/lib/project-groups.ts
+++ b/lib/project-groups.ts
@@ -1,4 +1,5 @@
 import type { SessionInfo } from "./types";
+import type { CustomProjectEntry } from "./custom-projects";
 import { workspaceKeyOf } from "./workspace-memory";
 
 export interface RecentProject {
@@ -8,21 +9,57 @@ export interface RecentProject {
   root: string;
 }
 
-/** Projects sorted by most recent activity and deduplicated by stable key. */
-export function getRecentProjects(sessions: readonly SessionInfo[]): RecentProject[] {
-  const latestByProject = new Map<string, { root: string; modified: string }>();
+/**
+ * Projects sorted by most recent activity and deduplicated by stable key.
+ *
+ * Session-derived projects always win because they prove the directory still
+ * exists and was actually used. Pinned custom paths only fill in the gaps —
+ * if the user has never started a session in that project, the entry is still
+ * surfaced so the sidebar remembers the user's intent.
+ */
+export function getRecentProjects(
+  sessions: readonly SessionInfo[],
+  customProjects: readonly CustomProjectEntry[] = [],
+): RecentProject[] {
+  const latestByProject = new Map<string, { root: string; modified: string; fromSession: boolean }>();
   for (const session of sessions) {
     const root = session.projectRoot ?? session.cwd;
     if (!root) continue;
     const key = workspaceKeyOf(session);
     const previous = latestByProject.get(key);
     if (!previous || session.modified > previous.modified) {
-      latestByProject.set(key, { root, modified: session.modified });
+      latestByProject.set(key, { root, modified: session.modified, fromSession: true });
     }
+  }
+  for (const cp of customProjects) {
+    const existing = latestByProject.get(cp.key);
+    if (existing) {
+      // Keep the session-derived root when both refer to the same project —
+      // it has been canonicalised against the server's filesystem view.
+      if (!existing.fromSession && cp.addedAt > existing.modified) {
+        existing.modified = cp.addedAt;
+      }
+      continue;
+    }
+    latestByProject.set(cp.key, { root: cp.root, modified: cp.addedAt, fromSession: false });
   }
   return [...latestByProject.entries()]
     .sort((a, b) => b[1].modified.localeCompare(a[1].modified))
     .map(([key, { root }]) => ({ key, root }));
+}
+
+/** True when the given key only appears as a pinned custom path with no
+ *  sessions backing it. Used by the sidebar to gate the "remove" affordance. */
+export function isCustomOnlyProject(
+  key: string,
+  sessions: readonly SessionInfo[],
+  customProjects: readonly CustomProjectEntry[],
+): boolean {
+  if (!customProjects.some((cp) => cp.key === key)) return false;
+  for (const session of sessions) {
+    if (workspaceKeyOf(session) === key) return false;
+  }
+  return true;
 }
 
 export function getProjectActivity(


### PR DESCRIPTION
## Problem

The directory picker's "Custom path" branch validates a path server-side but only stores the choice in component state. The path vanishes on reload and is absent from the project selector, so users have to re-pick the same directory every time they open Pi Web.

Project list (`getRecentProjects`) is computed purely from session files on disk, so any path the user has only ever browsed (no session started) never appears in the selector.

## Fix

Pin successfully-validated custom paths in `window.localStorage["pi-web:custom-project-paths"]` and merge them into `getRecentProjects`. Session-derived projects still win on overlap because they are canonicalised against the server's filesystem view.

- New `lib/custom-projects.ts` with `loadCustomProjects` / `saveCustomProject` / `removeCustomProject` helpers. Falls back gracefully when storage is unavailable (privacy mode, SSR, denied access).
- `getRecentProjects` now accepts an optional `customProjects` list and exposes `isCustomOnlyProject` so the sidebar can show a remove button only for entries not backed by any session.
- The sidebar calls `saveCustomProject` after a successful `/api/cwd/validate` and refreshes state from storage. A small × button removes a pinned entry on hover.
- i18n: new `sidebar.removeCustomProject` key in en + zh-CN.

## Tests

- New `lib/custom-projects.test.mjs` covers round-trip, dedup-by-key, malformed entries, removal, and storage-unavailable / SSR fallback.
- New cases in `lib/project-groups.test.mjs` cover the merge logic and `isCustomOnlyProject`.
- Full suite (`npm test`): **597/597 pass**.
- `npm run lint`: clean.
- `npm run build`: clean (no new warnings).

## Screenshots

Will attach after first reply.