### PR TITLE
fix(security): tolerate Chromium stripping port from Origin header

### DIFF
--- a/lib/request-security.test.mjs
+++ b/lib/request-security.test.mjs
@@ -178,6 +178,70 @@ test("rejects missing, malformed, and unconfigured Host headers", async () => {
   })), false);
 });
 
+test("allows same-origin requests when Chromium strips the port from Origin", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Loopback IP with the port stripped from Origin (Chromium 150+ behavior).
+  const loopback = new Request("http://127.0.0.1:30141/api/agent/running", {
+    headers: {
+      host: "127.0.0.1:30141",
+      origin: "http://127.0.0.1",
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  assert.equal(isApiRequestAllowed(loopback), true);
+
+  // LAN IP with the port stripped from Origin.
+  const lan = new Request("http://192.168.32.7:30141/api/test", {
+    method: "POST",
+    headers: {
+      host: "192.168.32.7:30141",
+      origin: "http://192.168.32.7",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(lan), true);
+
+  // Loopback name with the port stripped from Origin.
+  const named = new Request("http://localhost:30141/api/test", {
+    method: "POST",
+    headers: {
+      host: "localhost:30141",
+      origin: "http://localhost",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(named), true);
+});
+
+test("still rejects when Origin hostname differs from Host even with port stripped", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Cross-loopback-name origin should not slip through just because both
+  // sides happen to be loopback addresses.
+  const crossName = new Request("http://localhost:30141/api/test", {
+    headers: {
+      host: "localhost:30141",
+      origin: "http://127.0.0.1",
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  assert.equal(isApiRequestAllowed(crossName), false);
+
+  // Attacker host matching its own Origin must still be blocked by the
+  // Host allowlist, not the Origin comparison.
+  const dnsRebind = new Request("http://localhost:30141/api/skills/install", {
+    method: "POST",
+    headers: {
+      host: "attacker.example:30141",
+      origin: "http://attacker.example",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(dnsRebind), false);
+});
+
 test("recognizes JSON request content types", async () => {
   const { hasJsonContentType } = await loadSubject();
   assert.equal(hasJsonContentType(new Request("http://localhost", {

--- a/lib/request-security.ts
+++ b/lib/request-security.ts
@@ -87,6 +87,14 @@ export function isApiRequestHostAllowed(
   );
 }
 
+function originHostname(value: string): string | null {
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return null;
+  }
+}
+
 /** Reject browser cross-site API requests while preserving non-browser clients. */
 export function isApiRequestOriginAllowed(request: Request): boolean {
   const origin = request.headers.get("origin");
@@ -94,8 +102,18 @@ export function isApiRequestOriginAllowed(request: Request): boolean {
   if (fetchSite === "cross-site") return false;
   if (!origin) return true;
 
+  // Chromium 150+ strips the port from the Origin header for same-origin
+  // requests on non-default ports. Strict canonical-origin comparison would
+  // therefore reject those legitimate requests ("http://127.0.0.1:30141"
+  // vs. the browser-sent "http://127.0.0.1"). The Host header is the
+  // authoritative source for where the request actually went, so accept any
+  // Origin whose hostname matches it. Hostnames are case-insensitive, which
+  // the URL constructor already handles for us.
   const requestOrigin = getRequestOrigin(request);
-  return requestOrigin !== null && canonicalOrigin(origin) === requestOrigin;
+  if (!requestOrigin) return false;
+  const originHost = originHostname(origin);
+  const requestHost = originHostname(requestOrigin);
+  return originHost !== null && originHost === requestHost;
 }
 
 export function shouldCheckApiRequestOrigin(request: Request): boolean {


### PR DESCRIPTION
## Summary

`isApiRequestOriginAllowed` (`lib/request-security.ts`) rejects all `/api/*`
requests with 403 on Chromium 150+, because Chrome now strips the port from
the `Origin` header for same-origin requests on non-default ports, and the
canonical-origin comparison (which includes the port) no longer matches.

pi-web defaults to port 30141, so every fresh install using a modern
Chromium-based browser is affected: the UI shows `Error: HTTP 403`, the
session sidebar appears empty, and the model config panel cannot load.

Fixes #542 

## Repro

1. `npm install && npm run dev` on a fresh checkout
2. Open `http://127.0.0.1:30141` in Chrome 150+
3. DevTools → Network → any `/api/*` request → status 403,
   response `{"error":"Untrusted API request"}`
4. Request headers show `Origin: http://127.0.0.1` (no port) vs
   `Host: 127.0.0.1:30141`

## Fix

Compare Origin hostnames instead of full canonical origins. The `Host`
header is already validated by `isApiRequestHostAllowed`, so port
differences carry no trust signal — only hostname equality does.

Add `originHostname()` helper and switch `isApiRequestOriginAllowed`
to use hostname comparison.

## Security

The Host allowlist, `sec-fetch-site`, and same-origin checks still
block DNS rebinding, cross-site fetches, opaque iframes, and cross
loopback-name origins (covered by new regression tests). The only
loosening is accepting same-hostname / different-port Origin headers,
which is the intended Chromium behavior.

## Tests

- New: `allows same-origin requests when Chromium strips the port from Origin`
  (covers loopback IP, LAN IP, loopback name)
- New: `still rejects when Origin hostname differs from Host even with port stripped`
  (covers cross-loopback-name and DNS rebind)

Existing tests continue to pass.