### PR TITLE
fix: fill the iOS standalone PWA viewport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,17 @@ html.dark {
   --bg-subtle: rgba(255,255,255,0.04);
 }
 
+/* WebKit reports dvh/innerHeight without the status-bar strip for installed
+   home-screen apps even though the layout still starts at the screen's top.
+   In standalone mode there is no browser toolbar to make vh unstable, and vh
+   includes that missing strip. The keyboard hook temporarily overrides this
+   custom property with visualViewport.height while an editor is focused. */
+@media (display-mode: standalone) {
+  :root {
+    --app-viewport-height: 100vh;
+  }
+}
+
 .catppuccin-file-icon {
   display: block;
   flex-shrink: 0;

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -13,6 +13,7 @@ test("configures iOS standalone mode to use the full screen", () => {
   assert.match(layoutSource, /statusBarStyle: "black-translucent"/);
   assert.match(layoutSource, /viewportFit: "cover"/);
   assert.match(layoutSource, /interactiveWidget: "resizes-content"/);
+  assert.match(cssSource, /@media \(display-mode: standalone\) \{[\s\S]*?--app-viewport-height: 100vh;/);
 });
 
 test("tracks the visual viewport while the software keyboard is open", () => {


### PR DESCRIPTION
## Summary

- Use the full screen height while Pi Web is running as an installed iOS standalone PWA.
- Preserve the existing `visualViewport.height` override while the software keyboard is open.
- Add a regression assertion for the standalone viewport rule.

## Problem

When Pi Web is launched from the iOS Home Screen, WebKit can report `100dvh` and `window.innerHeight` without the status-bar strip even though the page layout still starts at the top of the screen. The app shell currently falls back to `100dvh`, so its resting height is too short. The composer and bottom controls end early, leaving a visible unused area above the Home indicator.

This only reproduces in installed standalone mode; the regular browser viewport behavior should remain unchanged.

### Reproduction

1. Add Pi Web to the Home Screen on iOS.
2. Launch it from the Home Screen so it runs in standalone mode.
3. Open a chat with the software keyboard dismissed.
4. Observe that the app shell does not fill the available screen height and unused space remains below the composer.

Expected: the shell fills the screen while its content continues to respect the safe-area insets.

## Fix

Set `--app-viewport-height: 100vh` only under `@media (display-mode: standalone)`. Standalone mode has no browser toolbar, so `vh` is stable there and includes the strip omitted by `dvh`/`innerHeight` on affected iOS versions.

The existing keyboard hook still writes `visualViewport.height` as an inline custom-property value while an editor is focused. That inline value overrides this stylesheet default, so the composer remains above the keyboard. Non-standalone browser mode continues to use the existing `100dvh` fallback.

This is the upstream-based transplant of epheien/pi-web@d0168ab94f2e6967779a1666b81b24d0a9501512.

## Verification

- `node --test components/MobilePwaLayout.test.mjs hooks/useViewportHeight.test.mjs` (9 tests passed)
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`

## Screenshots

### Before

<img width="1179" height="2556" alt="Before fix: unused space below the composer in iOS standalone mode" src="https://github.com/user-attachments/assets/150a38f0-4cc8-4d26-a957-9d7c891ee56f" />

### After

<img width="1179" height="2556" alt="After fix: the composer fills the iOS standalone viewport" src="https://github.com/user-attachments/assets/01c33079-ecbc-408d-876c-e37f9e9de183" />
