### PR TITLE
feat: add maximized file panel layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1245,6 +1245,12 @@ span.token.table {
 .right-panel-overlay-backdrop {
   display: none;
 }
+.conversation-panel {
+  display: flex;
+}
+.conversation-panel.file-panel-maximized {
+  display: none;
+}
 
 /* Desktop sidebar: animate width */
 @media (min-width: 641px) {
@@ -1301,6 +1307,15 @@ span.token.table {
   .right-panel-container.right-panel-resizing > * {
     transition: none !important;
   }
+  .right-panel-container.right-panel-maximized {
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .right-panel-container.right-panel-maximized > * {
+    width: 100%;
+    min-width: 0;
+  }
 }
 
 /* Compact desktop file panel: overlay the chat instead of collapsing it. */
@@ -1344,6 +1359,16 @@ span.token.table {
   .right-panel-container > * {
     width: 100%;
     min-width: 0;
+  }
+  .right-panel-container.right-panel-maximized {
+    position: relative;
+    inset: auto;
+    z-index: auto;
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
+    box-shadow: none;
+    transform: none;
   }
 }
 

--- a/components/AppShell.file-panel-maximize.test.mjs
+++ b/components/AppShell.file-panel-maximize.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const english = await readFile(new URL("../lib/i18n/messages/en.ts", import.meta.url), "utf8");
+const chinese = await readFile(new URL("../lib/i18n/messages/zh-CN.ts", import.meta.url), "utf8");
+
+test("offers maximize and restore controls around the file panel toggle", () => {
+  assert.match(source, /data-file-panel-layout-action=\{mode\}/);
+  assert.match(source, /files\.maximizePanel/);
+  assert.match(source, /files\.restorePanel/);
+  assert.match(source, /rightPanelOpen && !rightPanelMaximized && renderFilePanelLayoutButton\("maximize"\)/);
+  assert.match(source, /rightPanelMaximized && !isMobile && renderFilePanelLayoutButton\("restore"\)/);
+  assert.match(english, /"files\.maximizePanel": "Maximize file panel"/);
+  assert.match(english, /"files\.restorePanel": "Restore file panel"/);
+  assert.match(chinese, /"files\.maximizePanel": "最大化文件面板"/);
+  assert.match(chinese, /"files\.restorePanel": "恢复文件面板"/);
+});
+
+test("maximized files replace the mounted conversation and expose the sidebar toggle", () => {
+  assert.match(source, /className={`conversation-panel\$\{rightPanelMaximized \? " file-panel-maximized" : ""\}`}/);
+  assert.match(source, /aria-hidden=\{rightPanelMaximized\}/);
+  assert.match(source, /rightPanelMaximized && !isMobile && renderSidebarToggle\("maximized-file"\)/);
+  assert.match(source, /right-panel-maximized/);
+  assert.match(css, /\.conversation-panel\.file-panel-maximized\s*\{[\s\S]*?display: none;/);
+  assert.match(css, /@media \(min-width: 960px\)[\s\S]*?\.right-panel-container\.right-panel-maximized[\s\S]*?flex: 1 1 auto;/);
+  assert.match(css, /@media \(min-width: 641px\) and \(max-width: 959px\)[\s\S]*?\.right-panel-container\.right-panel-maximized[\s\S]*?position: relative;/);
+});
+
+test("maximized layout exits at destructive and responsive boundaries", () => {
+  assert.match(source, /const handleRightPanelClose = useCallback\(\(\) => \{\s*setRightPanelMaximized\(false\);\s*setRightPanelOpen\(false\);/);
+  assert.match(source, /if \(remaining\.length === 0\) handleRightPanelClose\(\);/);
+  assert.match(source, /if \(isMobile\) \{[\s\S]*?setRightPanelMaximized\(false\);[\s\S]*?\}/);
+  assert.match(source, /const handleAttentionNeeded = useCallback[\s\S]*?setRightPanelMaximized\(false\);/);
+  assert.match(source, /setFileTabs\(\[\]\);\s*setActiveFileTabId\(null\);\s*handleRightPanelClose\(\);/);
+});
+
+test("does not show split-layout affordances while maximized", () => {
+  assert.match(source, /rightPanelOpen && !rightPanelMaximized && \(/);
+  assert.match(source, /rightPanelOpen && !rightPanelMaximized \? " is-open" : ""/);
+  assert.match(source, /right-panel-container\$\{rightPanelOpen \? " right-panel-open" : " right-panel-closed"\}\$\{rightPanelMaximized \? " right-panel-maximized" : ""\}/);
+});
+
+test("keyboard activation transfers focus between maximize and restore", () => {
+  assert.match(source, /pendingFilePanelLayoutFocusRef\.current = "restore"/);
+  assert.match(source, /pendingFilePanelLayoutFocusRef\.current = "maximize"/);
+  assert.match(source, /filePanelRestoreButtonRef\.current\?\.focus\(\)/);
+  assert.match(source, /filePanelMaximizeButtonRef\.current\?\.focus\(\)/);
+});

--- a/components/AppShell.file-panel-maximize.test.mjs
+++ b/components/AppShell.file-panel-maximize.test.mjs
@@ -7,12 +7,24 @@ const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8
 const english = await readFile(new URL("../lib/i18n/messages/en.ts", import.meta.url), "utf8");
 const chinese = await readFile(new URL("../lib/i18n/messages/zh-CN.ts", import.meta.url), "utf8");
 
-test("offers maximize and restore controls around the file panel toggle", () => {
+test("keeps maximize and restore immediately left of the file panel's own toggle", () => {
+  const conversationHeaderStart = source.indexOf("{/* Top bar with sidebar toggle */}");
+  const conversationHeaderEnd = source.indexOf("{/* Chat content */}", conversationHeaderStart);
+  const fileHeaderStart = source.indexOf("{/* Right panel tab bar */}");
+  const fileHeaderEnd = source.indexOf("{/* Only the active viewer", fileHeaderStart);
+  assert.notEqual(conversationHeaderStart, -1);
+  assert.notEqual(conversationHeaderEnd, -1);
+  assert.notEqual(fileHeaderStart, -1);
+  assert.notEqual(fileHeaderEnd, -1);
+
+  const conversationHeader = source.slice(conversationHeaderStart, conversationHeaderEnd);
+  const fileHeader = source.slice(fileHeaderStart, fileHeaderEnd);
+  const layoutControl = 'renderFilePanelLayoutButton(rightPanelMaximized ? "restore" : "maximize")';
+  assert.doesNotMatch(conversationHeader, /renderFilePanelLayoutButton/);
+  assert.ok(fileHeader.includes(layoutControl));
+  assert.ok(fileHeader.indexOf(layoutControl) < fileHeader.indexOf("onClick={handleRightPanelClose}"));
+
   assert.match(source, /data-file-panel-layout-action=\{mode\}/);
-  assert.match(source, /files\.maximizePanel/);
-  assert.match(source, /files\.restorePanel/);
-  assert.match(source, /rightPanelOpen && !rightPanelMaximized && renderFilePanelLayoutButton\("maximize"\)/);
-  assert.match(source, /rightPanelMaximized && !isMobile && renderFilePanelLayoutButton\("restore"\)/);
   assert.match(english, /"files\.maximizePanel": "Maximize file panel"/);
   assert.match(english, /"files\.restorePanel": "Restore file panel"/);
   assert.match(chinese, /"files\.maximizePanel": "最大化文件面板"/);

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1639,6 +1639,7 @@ export function AppShell() {
         aria-label={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
         data-mobile-toolbar-file={mobile ? "true" : undefined}
         style={{
+          marginLeft: !mobile && !sessionStats && !contextUsage ? "auto" : 0,
           display: "flex", alignItems: "center", justifyContent: "center",
           width: TOP_BAR_ICON_BUTTON_SIZE, height: TOP_BAR_ICON_BUTTON_SIZE, padding: 0,
           visibility: covered ? "hidden" : "visible",
@@ -1885,12 +1886,7 @@ export function AppShell() {
               {renderSessionStatsButton(false)}
             </>
           )}
-          {!isMobile && (
-            <div style={{ display: "flex", alignItems: "stretch", height: "100%", marginLeft: !sessionStats && !contextUsage ? "auto" : 0 }}>
-              {rightPanelOpen && !rightPanelMaximized && renderFilePanelLayoutButton("maximize")}
-              {renderMainFileToggle(false)}
-            </div>
-          )}
+          {!isMobile && renderMainFileToggle(false)}
           {isMobile && (
             <BranchNavigator
               tree={branchTree}
@@ -2283,7 +2279,7 @@ export function AppShell() {
               onCloseTab={handleCloseFileTab}
             />
           </div>
-          {rightPanelMaximized && !isMobile && renderFilePanelLayoutButton("restore")}
+          {rightPanelOpen && !isMobile && renderFilePanelLayoutButton(rightPanelMaximized ? "restore" : "maximize")}
           <button
             type="button"
             onClick={handleRightPanelClose}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -108,10 +108,14 @@ export function AppShell() {
   const [projectTrustError, setProjectTrustError] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [rightPanelOpen, setRightPanelOpen] = useState(false);
+  const [rightPanelMaximized, setRightPanelMaximized] = useState(false);
   const [mobileToolbarMoreOpen, setMobileToolbarMoreOpen] = useState(false);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);
   const sidebarWidthRef = useRef(SIDEBAR_DEFAULT_WIDTH);
   const rightPanelWidthRef = useRef(RIGHT_PANEL_FALLBACK_WIDTH);
+  const filePanelMaximizeButtonRef = useRef<HTMLButtonElement>(null);
+  const filePanelRestoreButtonRef = useRef<HTMLButtonElement>(null);
+  const pendingFilePanelLayoutFocusRef = useRef<"maximize" | "restore" | null>(null);
   const getResponsiveRightPanelWidth = useCallback(
     () => typeof window === "undefined"
       ? RIGHT_PANEL_FALLBACK_WIDTH
@@ -166,11 +170,25 @@ export function AppShell() {
   // On mobile the sidebar is an overlay drawer; hide it by default so the chat
   // is visible on load. Runs once the breakpoint resolves after hydration.
   useEffect(() => {
-    if (isMobile) setSidebarOpen(false);
+    if (isMobile) {
+      setSidebarOpen(false);
+      setRightPanelMaximized(false);
+    }
   }, [isMobile]);
   useEffect(() => {
     setMobileSidebarReady(true);
   }, []);
+  useEffect(() => {
+    const pendingFocus = pendingFilePanelLayoutFocusRef.current;
+    if (!pendingFocus) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      if (pendingFocus === "restore") filePanelRestoreButtonRef.current?.focus();
+      else filePanelMaximizeButtonRef.current?.focus();
+      pendingFilePanelLayoutFocusRef.current = null;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [rightPanelMaximized]);
   useEffect(() => {
     if (!rightPanelOpen) return;
     reclampSidebarWidth();
@@ -296,14 +314,31 @@ export function AppShell() {
     setMobileToolbarMoreOpen((open) => !open);
   }, []);
 
+  const handleRightPanelClose = useCallback(() => {
+    setRightPanelMaximized(false);
+    setRightPanelOpen(false);
+  }, []);
+
   const handleRightPanelToggle = useCallback(() => {
     if (isMobile) {
       setSidebarOpen(false);
       setActiveTopPanel(null);
       setMobileToolbarMoreOpen(false);
     }
+    if (rightPanelOpen) setRightPanelMaximized(false);
     setRightPanelOpen((open) => !open);
-  }, [isMobile]);
+  }, [isMobile, rightPanelOpen]);
+
+  const handleFilePanelMaximize = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.detail === 0) pendingFilePanelLayoutFocusRef.current = "restore";
+    setActiveTopPanel(null);
+    setRightPanelMaximized(true);
+  }, []);
+
+  const handleFilePanelRestore = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.detail === 0) pendingFilePanelLayoutFocusRef.current = "maximize";
+    setRightPanelMaximized(false);
+  }, []);
 
   useEffect(() => {
     if (!mobileToolbarMoreOpen) return;
@@ -545,13 +580,13 @@ export function AppShell() {
       // project must not linger. Same-project worktree switches keep them.
       setFileTabs([]);
       setActiveFileTabId(null);
-      setRightPanelOpen(false);
+      handleRightPanelClose();
       // Restore the workspace we switched to: its last open session, or keep
       // the default welcome page when none is remembered.
       restoreWorkspaceContext(newProject);
     }
     router.replace("/", { scroll: false });
-  }, [activeCwd, invalidateWorkspaceRestore, newSessionCwd, router, selectedSession, restoreWorkspaceContext]);
+  }, [activeCwd, handleRightPanelClose, invalidateWorkspaceRestore, newSessionCwd, router, selectedSession, restoreWorkspaceContext]);
 
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
     invalidateWorkspaceRestore();
@@ -691,6 +726,9 @@ export function AppShell() {
   }, [deliverSessionNotification, hydrateSelectedSession, selectedSession, translate]);
 
   const handleAttentionNeeded = useCallback((request: BlockingExtensionUiRequest) => {
+    // Blocking extension UI is rendered in the conversation. Reveal it so the
+    // user can respond instead of leaving the run stalled behind the file view.
+    setRightPanelMaximized(false);
     if (!shouldShowBrowserNotification()) return;
     if (!claimExtensionAttentionNotification(request, notifiedAttentionRequestIdsRef.current)) return;
 
@@ -811,17 +849,14 @@ export function AppShell() {
   }, [handleOpenFile, selectedSession?.id]);
 
   const handleCloseFileTab = useCallback((tabId: string) => {
-    setFileTabs((prev) => {
-      const next = prev.filter((t) => t.id !== tabId);
-      if (next.length === 0) setRightPanelOpen(false);
-      return next;
-    });
-    setActiveFileTabId((cur) => {
-      if (cur !== tabId) return cur;
-      const remaining = fileTabs.filter((t) => t.id !== tabId);
+    const remaining = fileTabs.filter((tab) => tab.id !== tabId);
+    setFileTabs(remaining);
+    if (remaining.length === 0) handleRightPanelClose();
+    setActiveFileTabId((current) => {
+      if (current !== tabId) return current;
       return remaining.length > 0 ? remaining[remaining.length - 1].id : null;
     });
-  }, [fileTabs]);
+  }, [fileTabs, handleRightPanelClose]);
 
   const handleViewFullHistory = useCallback(() => {
     if (!selectedSession) return;
@@ -989,6 +1024,36 @@ export function AppShell() {
         ))}
       </div>
     </>
+  );
+
+  const renderSidebarToggle = (location: "conversation" | "maximized-file") => (
+    <button
+      type="button"
+      onClick={handleSidebarToggle}
+      title={sidebarOpen ? translate("sidebar.hide") : translate("sidebar.show")}
+      aria-label={sidebarOpen ? translate("sidebar.hide") : translate("sidebar.show")}
+      aria-controls="session-sidebar"
+      aria-expanded={sidebarOpen}
+      data-file-panel-sidebar-toggle={location === "maximized-file" ? "true" : undefined}
+      style={{
+        display: "flex", alignItems: "center", justifyContent: "center",
+        width: TOP_BAR_ICON_BUTTON_SIZE, height: TOP_BAR_ICON_BUTTON_SIZE, padding: 0,
+        background: "none", border: "none", borderRight: "1px solid var(--border)",
+        color: "var(--text-muted)", cursor: "pointer", flexShrink: 0, transition: "color 0.12s",
+      }}
+      onMouseEnter={(event) => { event.currentTarget.style.color = "var(--text)"; }}
+      onMouseLeave={(event) => { event.currentTarget.style.color = "var(--text-muted)"; }}
+    >
+      {sidebarOpen ? (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+        </svg>
+      ) : (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      )}
+    </button>
   );
 
   const renderThemeButton = (mobile: boolean) => (
@@ -1520,6 +1585,45 @@ export function AppShell() {
     );
   };
 
+  const renderFilePanelLayoutButton = (mode: "maximize" | "restore") => {
+    const restore = mode === "restore";
+    const label = translate(restore ? "files.restorePanel" : "files.maximizePanel");
+    return (
+      <button
+        ref={restore ? filePanelRestoreButtonRef : filePanelMaximizeButtonRef}
+        type="button"
+        onClick={restore ? handleFilePanelRestore : handleFilePanelMaximize}
+        aria-controls="file-panel"
+        aria-pressed={restore}
+        title={label}
+        aria-label={label}
+        data-file-panel-layout-action={mode}
+        style={{
+          display: "flex", alignItems: "center", justifyContent: "center",
+          width: TOP_BAR_ICON_BUTTON_SIZE, height: TOP_BAR_ICON_BUTTON_SIZE, padding: 0,
+          background: restore ? "var(--bg-selected)" : "none",
+          border: "none", borderLeft: "1px solid var(--border)",
+          color: restore ? "var(--text)" : "var(--text-muted)",
+          cursor: "pointer", flexShrink: 0, transition: "color 0.12s, background 0.12s",
+        }}
+        onMouseEnter={(event) => { event.currentTarget.style.color = "var(--accent)"; }}
+        onMouseLeave={(event) => { event.currentTarget.style.color = restore ? "var(--text)" : "var(--text-muted)"; }}
+      >
+        {restore ? (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M8 3v5H3" /><path d="M16 3v5h5" />
+            <path d="M8 21v-5H3" /><path d="M16 21v-5h5" />
+          </svg>
+        ) : (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M8 3H3v5" /><path d="M16 3h5v5" />
+            <path d="M8 21H3v-5" /><path d="M16 21h5v-5" />
+          </svg>
+        )}
+      </button>
+    );
+  };
+
   const renderMainFileToggle = (mobile: boolean) => {
     const covered = mobile && mobileToolbarMoreOpen;
     return (
@@ -1535,7 +1639,6 @@ export function AppShell() {
         aria-label={rightPanelOpen ? translate("files.hidePanel") : translate("files.showPanel")}
         data-mobile-toolbar-file={mobile ? "true" : undefined}
         style={{
-          marginLeft: !mobile && !sessionStats && !contextUsage ? "auto" : 0,
           display: "flex", alignItems: "center", justifyContent: "center",
           width: TOP_BAR_ICON_BUTTON_SIZE, height: TOP_BAR_ICON_BUTTON_SIZE, padding: 0,
           visibility: covered ? "hidden" : "visible",
@@ -1694,34 +1797,16 @@ export function AppShell() {
         />
       )}
 
-      {/* Center: chat */}
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", minWidth: 0 }}>
+      {/* Center: conversation stays mounted while the file panel replaces it. */}
+      <div
+        className={`conversation-panel${rightPanelMaximized ? " file-panel-maximized" : ""}`}
+        aria-hidden={rightPanelMaximized}
+        style={{ flex: 1, flexDirection: "column", overflow: "hidden", minWidth: 0 }}
+      >
         {/* Top bar with sidebar toggle */}
         <div ref={topBarRef} style={{ flexShrink: 0, background: "var(--bg-panel)" }}>
         <div style={{ display: "flex", alignItems: "center", position: "relative", borderBottom: "1px solid var(--border)", height: "calc(36px + env(safe-area-inset-top))", paddingTop: "env(safe-area-inset-top)" }}>
-          <button
-            onClick={handleSidebarToggle}
-             title={sidebarOpen ? translate("sidebar.hide") : translate("sidebar.show")}
-             aria-label={sidebarOpen ? translate("sidebar.hide") : translate("sidebar.show")}
-            style={{
-              display: "flex", alignItems: "center", justifyContent: "center",
-              width: TOP_BAR_ICON_BUTTON_SIZE, height: TOP_BAR_ICON_BUTTON_SIZE, padding: 0,
-              background: "none", border: "none", borderRight: "1px solid var(--border)",
-              color: "var(--text-muted)", cursor: "pointer", flexShrink: 0, transition: "color 0.12s",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; }}
-          >
-            {sidebarOpen ? (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
-              </svg>
-            ) : (
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
-              </svg>
-            )}
-          </button>
+          {renderSidebarToggle("conversation")}
           {isMobile && (
             <div
               ref={mobileToolbarRef}
@@ -1800,7 +1885,12 @@ export function AppShell() {
               {renderSessionStatsButton(false)}
             </>
           )}
-          {!isMobile && renderMainFileToggle(false)}
+          {!isMobile && (
+            <div style={{ display: "flex", alignItems: "stretch", height: "100%", marginLeft: !sessionStats && !contextUsage ? "auto" : 0 }}>
+              {rightPanelOpen && !rightPanelMaximized && renderFilePanelLayoutButton("maximize")}
+              {renderMainFileToggle(false)}
+            </div>
+          )}
           {isMobile && (
             <BranchNavigator
               tree={branchTree}
@@ -2148,10 +2238,10 @@ export function AppShell() {
 
       <div
         aria-hidden="true"
-        className={`right-panel-overlay-backdrop${rightPanelOpen ? " is-open" : ""}`}
-        onClick={() => setRightPanelOpen(false)}
+        className={`right-panel-overlay-backdrop${rightPanelOpen && !rightPanelMaximized ? " is-open" : ""}`}
+        onClick={handleRightPanelClose}
       />
-      {rightPanelOpen && (
+      {rightPanelOpen && !rightPanelMaximized && (
         <div
           {...rightPanelResizer.separatorProps}
           aria-controls="file-panel"
@@ -2165,7 +2255,7 @@ export function AppShell() {
       <div
         ref={rightPanelResizer.panelRef}
         id="file-panel"
-        className={`right-panel-container${rightPanelOpen ? " right-panel-open" : " right-panel-closed"}${rightPanelResizer.isResizing ? " right-panel-resizing" : ""}`}
+        className={`right-panel-container${rightPanelOpen ? " right-panel-open" : " right-panel-closed"}${rightPanelMaximized ? " right-panel-maximized" : ""}${rightPanelResizer.isResizing ? " right-panel-resizing" : ""}`}
         style={{
           "--right-panel-width": `${rightPanelResizer.width}px`,
           display: "flex",
@@ -2184,6 +2274,7 @@ export function AppShell() {
           background: "var(--bg-panel)",
           borderBottom: "1px solid var(--border)",
         }}>
+          {rightPanelMaximized && !isMobile && renderSidebarToggle("maximized-file")}
           <div style={{ flex: 1, overflow: "hidden" }}>
             <TabBar
               tabs={fileTabs}
@@ -2192,9 +2283,10 @@ export function AppShell() {
               onCloseTab={handleCloseFileTab}
             />
           </div>
+          {rightPanelMaximized && !isMobile && renderFilePanelLayoutButton("restore")}
           <button
             type="button"
-            onClick={() => setRightPanelOpen(false)}
+            onClick={handleRightPanelClose}
             aria-controls="file-panel"
             aria-expanded={rightPanelOpen}
             title={translate("files.hidePanel")}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -68,6 +68,8 @@ export const enLocale: LocalePlugin = {
     "workspace.stepModels": "Add models via the Models button at the bottom",
     "files.hidePanel": "Hide file panel",
     "files.showPanel": "Show file panel",
+    "files.maximizePanel": "Maximize file panel",
+    "files.restorePanel": "Restore file panel",
     "files.noneOpen": "No file open",
     "layout.resizeSidebar": "Resize sidebar",
     "layout.resizeFilePanel": "Resize file panel",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -68,6 +68,8 @@ export const zhCNLocale: LocalePlugin = {
     "workspace.stepModels": "点击底部的“模型”按钮添加模型",
     "files.hidePanel": "隐藏文件面板",
     "files.showPanel": "显示文件面板",
+    "files.maximizePanel": "最大化文件面板",
+    "files.restorePanel": "恢复文件面板",
     "files.noneOpen": "没有打开的文件",
     "layout.resizeSidebar": "调整侧边栏宽度",
     "layout.resizeFilePanel": "调整文件面板宽度",


### PR DESCRIPTION
## Summary

- add a maximize/restore control to the open file panel header, immediately left of the panel visibility control
- let the file panel replace the conversation area while keeping the conversation mounted so active agent runs continue
- preserve sidebar controls, stored panel width, responsive behavior, blocking-attention recovery, and keyboard focus
- add English/Chinese labels and focused regression coverage

## Testing

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `node --test components/AppShell.file-panel-maximize.test.mjs components/AppShell.file-viewer-state.test.mjs components/AppShell.mobile-toolbar.test.mjs components/MobilePwaLayout.test.mjs` (18 passed)
- browser QA at 1264px, 800px, and 600px, including maximize/restore focus transfer and responsive layout transitions

## Full-suite note

`npm test` was run, but the current baseline has unrelated failures in component render tests that call `useI18n` without an `I18nProvider`, plus a Git Bash PATH-separator assertion in `lib/project-command-env.test.mjs`.
