### PR TITLE
chore: tighten TypeScript guards, silence stray rejections

### DIFF
--- a/app/api/models-config/test/route.ts
+++ b/app/api/models-config/test/route.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { completeSimple, type AssistantMessage } from "@earendil-works/pi-ai/compat";
+import type { TextContent } from "@earendil-works/pi-ai";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { hasJsonContentType, isApiRequestAllowed } from "@/lib/request-security";
 
@@ -20,7 +21,7 @@ function errorMessage(error: unknown): string {
 
 function getAssistantText(message: AssistantMessage): string {
   return message.content
-    .filter((block) => block.type === "text")
+    .filter((block): block is TextContent => block.type === "text")
     .map((block) => block.text)
     .join("");
 }

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, BlockingExtensionUiRequest, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage, UserMessage } from "@/lib/types";
+import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, BlockingExtensionUiRequest, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, TextContent, ToolResultMessage, UserMessage } from "@/lib/types";
 import { normalizeCustomPanelLines, parseAnsiLine } from "@/lib/ansi";
 import { asBracketedPaste, toTerminalKeyData } from "@/lib/terminal-input";
 import { countToolCallBlocks, getAssistantErrorMessage, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
@@ -92,6 +92,8 @@ function NewSessionUpdateLink({
       })
       .catch(() => {
         // Update checks are best-effort and must not interrupt a new session.
+        // Catch every error (including AbortError on cleanup) so Next 16's dev
+        // overlay doesn't surface this as unhandledRejection.
       });
     return () => controller.abort();
   }, []);
@@ -160,7 +162,7 @@ function getUserInputText(message: AgentMessage): string | null {
     return text.length > 0 ? text : null;
   }
   const text = message.content
-    .filter((block) => block.type === "text")
+    .filter((block): block is TextContent => block.type === "text")
     .map((block) => block.text)
     .join("\n")
     .trim();

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1886,9 +1886,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   // Load model list
   useEffect(() => {
     const controller = new AbortController();
-    loadModels(controller.signal).catch((e) => {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-    });
+    // loadModels swallows its own errors (network failures, JSON parse errors,
+    // AbortError on cleanup). The outer .catch is defensive — if anything ever
+    // bubbles up it must not surface as an unhandled rejection in the dev
+    // overlay. Next 16's overlay still reports the AbortError source line even
+    // when caught, so we silence every error here.
+    loadModels(controller.signal).catch(() => {});
     return () => controller.abort();
   }, [loadModels, modelsRefreshKey]);
 

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -129,7 +129,7 @@ export function useTheme() {
     };
 
     const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    const supportsVT = typeof document.startViewTransition === "function";
+    const supportsVT = typeof (document as Document & { startViewTransition?: unknown }).startViewTransition === "function";
 
     if (!supportsVT || reduceMotion) {
       apply();
@@ -143,7 +143,11 @@ export function useTheme() {
       Math.max(y, window.innerHeight - y),
     );
 
-    const transition = document.startViewTransition(apply);
+    const transition = (document as Document & { startViewTransition?: (cb: () => void) => { ready: Promise<void> } }).startViewTransition?.(apply);
+    if (!transition) {
+      apply();
+      return;
+    }
     transition.ready
       .then(() => {
         document.documentElement.animate(

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -5,6 +5,7 @@ import {
   type AgentTool,
 } from "@earendil-works/pi-agent-core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import type { TextContent } from "@earendil-works/pi-ai";
 
 const TITLE_TIMEOUT_MS = 90_000;
 const MAX_TITLE_LENGTH = 80;
@@ -144,7 +145,7 @@ function getAssistantResult(agent: Agent, historyLength: number): GeneratedSessi
       throw new Error(message.errorMessage || "The title model request failed");
     }
     const text = message.content
-      .filter((block) => block.type === "text")
+      .filter((block): block is TextContent => block.type === "text")
       .map((block) => block.text)
       .join("\n")
       .trim();


### PR DESCRIPTION
A grab bag of small changes that keep the dev experience clean under the strict TypeScript / Next 16 dev overlay:

TypeScript type guards on `AssistantMessage.content`:
- app/api/models-config/test/route.ts
- components/ChatWindow.tsx
- lib/session-title.ts

`@earendil-works/pi-ai`'s `AssistantMessage.content` is typed as `AssistantContentBlock[]`, which is a discriminated union. The naive `.filter((b) => b.type === "text")` produced a `(AssistantContentBlock | { type: 'text'; text: string })[]` that the compiler still treated as the wide type. Switching to `.filter((b): b is TextContent => ...)` narrows the result so the downstream `.map((b) => b.text)` typechecks without an `as TextContent` cast.

hooks/useTheme.ts:
- `document.startViewTransition` is not yet in the default lib types on every platform we ship to. Replace the unguarded access with a type guard, and bail to the synchronous `apply()` path when the API is missing so the theme still flips on browsers without View Transitions.
- No runtime behavior change for browsers that have the API.

hooks/useAgentSession.ts:
- `loadModels` already swallows its own errors (network failures, JSON parse failures, AbortError on cleanup). Add a defensive `.catch(() => {})` so anything that ever bubbles up is silenced — Next 16's dev overlay still reports the AbortError source line even when caught, which previously surfaced as an unhandledRejection noise.

components/ChatWindow.tsx:
- Same AbortError-catching comment near the new-session update check.
- Same TextContent guard on the user-message text extraction path.