### PR TITLE
fix(app): allow Enter to send in mobile chat input (Shift+Enter for newline)

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1043,7 +1043,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       const nativeEvent = e.nativeEvent;
-      const sendShortcut = e.key === "Enter" && !e.shiftKey && (!isMobile || e.ctrlKey || e.metaKey);
+      // Enter sends, Shift+Enter inserts a newline — same on every layout.
+      // Mobile previously required Ctrl/Meta+Enter (#472), which left
+      // hardware/Bluetooth keyboards with no way to send.
+      const sendShortcut = e.key === "Enter" && !e.shiftKey;
       const recentlyComposed = Date.now() - lastCompositionEndAtRef.current < COMPOSITION_END_ENTER_GRACE_MS;
       const isComposing =
         isComposingRef.current ||


### PR DESCRIPTION
> **Note:** This PR was written by **pi-agent** (the operator's personal AI assistant) at the operator's request, with the operator's review.

## Summary
On mobile layouts (viewport ≤ 640px), `Enter` only inserts a newline and
sending requires `Ctrl+Enter` / `Cmd+Enter` (introduced in #472). With a
physical or Bluetooth keyboard attached to a phone, plain `Enter` appears
broken and the `Ctrl/Meta+Enter` chord is awkward to discover and hit.

This makes mobile behave like desktop: **Enter sends, Shift+Enter inserts a
newline** — the convention used by WhatsApp, Telegram, iMessage, Slack, etc.

## Change
`components/ChatInput.tsx` — drop the mobile-only modifier requirement in
`handleKeyDown`:

```diff
-      const sendShortcut = e.key === "Enter" && !e.shiftKey && (!isMobile || e.ctrlKey || e.metaKey);
+      // Enter sends, Shift+Enter inserts a newline — same on every layout.
+      // Mobile previously required Ctrl/Meta+Enter (#472), which left
+      // hardware/Bluetooth keyboards with no way to send.
+      const sendShortcut = e.key === "Enter" && !e.shiftKey;
```

## Notes / tradeoffs
- #472 intentionally made `Enter` = newline on mobile for touch keyboards.
  With this change the on-screen keyboard's Return key sends (the pre-#472
  send behavior); the send button remains for touch users.
- The old `Ctrl+Enter` / `Cmd+Enter` chord still works (it satisfies
  `Enter && !shiftKey`), so nothing existing stops working.
- The CJK IME guard (`isComposing` / keyCode 229 / 100 ms composition
  grace) is untouched, so `Enter` never sends mid-composition.
- On mobile, `Enter` now also confirms highlighted slash-command / @file /
  history menu items, consistent with desktop.
- `isMobile` remains in use for layout; no other behavior changes.

## Test plan
- Mobile viewport + hardware keyboard: Enter sends; Shift+Enter newlines;
  Ctrl+Enter still sends.
- Desktop unchanged (Enter sends, Shift+Enter newlines).
- Slash / @file / history menus: Enter confirms the highlighted item on both
  layouts.
- `tsc --noEmit` clean. `npm test`: 586/587 pass locally; the single
  failure (`lib/web-auth.test.mjs`, password auth) reproduces on the clean
  tree, i.e. pre-existing and unrelated to this change.
