### PR TITLE
feat(notice): show full toast text by default, top-right position, hover-pause dismiss

### DIFF
--- a/components/ChatWindow.notices.test.mjs
+++ b/components/ChatWindow.notices.test.mjs
@@ -3,13 +3,28 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./ChatWindow.tsx", import.meta.url), "utf8");
+const hookSource = await readFile(new URL("../hooks/useAgentSession.ts", import.meta.url), "utf8");
 
-test("renders temporary notices once at the top center of the chat column", () => {
+test("renders temporary notices once at the top right of the chat column", () => {
   const noticeShelfUsages = source.match(/<NoticeShelf notices=\{notices\}/g) ?? [];
 
   assert.equal(noticeShelfUsages.length, 1);
   assert.match(
     source,
-    /position: "absolute",\s*top: 12,\s*left: 0,\s*right: isMobile \? 0 : CHAT_MINIMAP_WIDTH,[\s\S]*?justifyContent: "center",[\s\S]*?<NoticeShelf notices=\{notices\} floating \/>/,
+    /position: "absolute",\s*top: 12,\s*left: 0,\s*right: isMobile \? 0 : CHAT_MINIMAP_WIDTH,[\s\S]*?justifyContent: "flex-end",[\s\S]*?<NoticeShelf notices=\{notices\} floating onPauseChange=\{setNoticePaused\} \/>/,
   );
+});
+
+test("pauses only for a visible notice", () => {
+  assert.match(
+    hookSource,
+    /noticeState\.visible\.some\(\(notice\) => notice\.id === pausedNoticeId\)\) return/,
+  );
+});
+
+test("lets keyboard users pause and scroll long notices", () => {
+  assert.match(source, /onFocus=\{\(\) => onPauseChange\?\.\(notice\.id\)\}/);
+  assert.match(source, /onBlur=\{\(event\) => \{\s*if \(!event\.currentTarget\.matches\(":hover"\)\) onPauseChange\?\.\(null\)/);
+  assert.match(source, /onMouseLeave=\{\(event\) => \{\s*if \(!event\.currentTarget\.contains\(document\.activeElement\)\) onPauseChange\?\.\(null\)/);
+  assert.match(source, /<span\s+tabIndex=\{0\}\s+style=\{\{[^}]*overflowY: "auto"/);
 });

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -281,7 +281,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
-    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, setNoticeHover,
+    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, setNoticePaused,
     isAutoModelSelection,
     agentPhase,
     isNew,
@@ -660,7 +660,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
           pointerEvents: "none",
         }}
       >
-        <NoticeShelf notices={notices} floating onHoverChange={setNoticeHover} />
+        <NoticeShelf notices={notices} floating onPauseChange={setNoticePaused} />
       </div>
 
       {isEmptyNew ? (
@@ -947,7 +947,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
 const NOTICE_MAX_HEIGHT_PX = 500;
 const NOTICE_TEXT_MAX_HEIGHT_PX = NOTICE_MAX_HEIGHT_PX - 30;
 
-function NoticeShelf({ notices, floating = false, onHoverChange }: { notices: NoticeItem[]; floating?: boolean; onHoverChange?: (id: string | null) => void }) {
+function NoticeShelf({ notices, floating = false, onPauseChange }: { notices: NoticeItem[]; floating?: boolean; onPauseChange?: (id: string | null) => void }) {
   if (notices.length === 0) return null;
   return (
     <div
@@ -971,9 +971,14 @@ function NoticeShelf({ notices, floating = false, onHoverChange }: { notices: No
           <div
             key={notice.id}
             className="notice-shelf-item"
-            // Hover only pauses the dismiss timer (via onHoverChange); it no longer drives layout
-            onMouseEnter={() => onHoverChange?.(notice.id)}
-            onMouseLeave={() => onHoverChange?.(null)}
+            onMouseEnter={() => onPauseChange?.(notice.id)}
+            onMouseLeave={(event) => {
+              if (!event.currentTarget.contains(document.activeElement)) onPauseChange?.(null);
+            }}
+            onFocus={() => onPauseChange?.(notice.id)}
+            onBlur={(event) => {
+              if (!event.currentTarget.matches(":hover")) onPauseChange?.(null);
+            }}
             style={{
               display: "flex",
               // Top-align children so the type dot sits by the first line on multi-line toasts
@@ -1025,7 +1030,10 @@ function NoticeShelf({ notices, floating = false, onHoverChange }: { notices: No
             {/* Full text by default: pre-line preserves \n (nowrap/normal collapse
                 newlines into spaces) and long lines wrap instead of truncating;
                 content taller than the cap scrolls inside the text area */}
-            <span style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", maxHeight: NOTICE_TEXT_MAX_HEIGHT_PX, overflowY: "auto", scrollbarWidth: "thin", whiteSpace: "pre-line", wordBreak: "break-word" }}>
+            <span
+              tabIndex={0}
+              style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", maxHeight: NOTICE_TEXT_MAX_HEIGHT_PX, overflowY: "auto", scrollbarWidth: "thin", whiteSpace: "pre-line", wordBreak: "break-word" }}
+            >
               {notice.message}
             </span>
           </div>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -281,7 +281,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
-    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
+    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, setNoticeHover,
     isAutoModelSelection,
     agentPhase,
     isNew,
@@ -654,12 +654,13 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
           right: isMobile ? 0 : CHAT_MINIMAP_WIDTH,
           zIndex: 40,
           display: "flex",
-          justifyContent: "center",
+          // Toasts live in the top-right corner
+          justifyContent: "flex-end",
           padding: `0 ${CHAT_COLUMN_PADDING}px`,
           pointerEvents: "none",
         }}
       >
-        <NoticeShelf notices={notices} floating />
+        <NoticeShelf notices={notices} floating onHoverChange={setNoticeHover} />
       </div>
 
       {isEmptyNew ? (
@@ -942,14 +943,19 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
   );
 }
 
-function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; floating?: boolean }) {
+// Toast 整体高度上限；文本区高度上限 = 整体上限 - 上下 padding(14*2) - 上下边框(1*2)
+const NOTICE_MAX_HEIGHT_PX = 500;
+const NOTICE_TEXT_MAX_HEIGHT_PX = NOTICE_MAX_HEIGHT_PX - 30;
+
+function NoticeShelf({ notices, floating = false, onHoverChange }: { notices: NoticeItem[]; floating?: boolean; onHoverChange?: (id: string | null) => void }) {
   if (notices.length === 0) return null;
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
+        // Right-anchored: every toast's right edge aligns here, widths extend leftward
+        alignItems: "flex-end",
         marginBottom: floating ? 0 : 10,
       }}
     >
@@ -965,13 +971,22 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
           <div
             key={notice.id}
             className="notice-shelf-item"
+            // Hover only pauses the dismiss timer (via onHoverChange); it no longer drives layout
+            onMouseEnter={() => onHoverChange?.(notice.id)}
+            onMouseLeave={() => onHoverChange?.(null)}
             style={{
               display: "flex",
-              alignItems: "center",
+              // Top-align children so the type dot sits by the first line on multi-line toasts
+              alignItems: "flex-start",
               gap: 10,
               minHeight: 60,
-              height: 60,
-              maxHeight: 60,
+              height: "auto",
+              // 整体高度上限：超出后由文本区内部滚动承担（见下方 span 的 overflowY），
+              // 容器自身保持 hidden，小圆点固定在顶部不随文本滚动
+              maxHeight: NOTICE_MAX_HEIGHT_PX,
+              // The floating wrapper is pointerEvents:"none" (click-through by design),
+              // so the toast itself must opt back into interactivity or hover events never reach it
+              pointerEvents: "auto",
               marginBottom: index === notices.length - 1 ? 0 : 6,
               overflow: "hidden",
               borderRadius: 14,
@@ -983,12 +998,15 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
               boxShadow: floating
                 ? "0 1px 2px rgba(15,23,42,0.05), 0 10px 28px -14px rgba(15,23,42,0.24)"
                 : "0 1px 2px rgba(15,23,42,0.04), 0 8px 24px -12px rgba(15,23,42,0.10)",
-              fontSize: 18,
-              lineHeight: 1.45,
-              transformOrigin: "top center",
+              fontSize: 14,
+              lineHeight: 1.5,
+              transformOrigin: "top right",
+              // Use backwards fill for the entrance animation so height styles return to
+              // inline styles once it finishes; otherwise the keyframe's fixed 60px would
+              // stick around in fill mode and permanently clamp the expanded toast
               animation: notice.exiting
                 ? "notice-shelf-out 0.18s ease-in forwards"
-                : "notice-shelf-in 0.18s ease-out both",
+                : "notice-shelf-in 0.18s ease-out backwards",
               padding: "0 12px",
             }}
           >
@@ -999,9 +1017,15 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
                 borderRadius: "50%",
                 background: color,
                 flexShrink: 0,
+                // Align with the optical center of the first text line: 14px vertical
+                // padding + (21px line box - 7px dot) / 2
+                marginTop: 21,
               }}
             />
-            <span style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {/* Full text by default: pre-line preserves \n (nowrap/normal collapse
+                newlines into spaces) and long lines wrap instead of truncating;
+                content taller than the cap scrolls inside the text area */}
+            <span style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", maxHeight: NOTICE_TEXT_MAX_HEIGHT_PX, overflowY: "auto", scrollbarWidth: "thin", whiteSpace: "pre-line", wordBreak: "break-word" }}>
               {notice.message}
             </span>
           </div>

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1898,8 +1898,18 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     return () => clearTimeout(t);
   }, [compactResult]);
 
+  // Pause notice expiry while hovered: no countdown runs when hoveredNoticeId is set.
+  // The remainingMs/startedAt/oldestId refs implement a true pause-and-resume instead of resetting the 5s timer.
+  const [hoveredNoticeId, setHoveredNoticeId] = useState<string | null>(null);
+  const noticeRemainingMsRef = useRef(NOTICE_VISIBLE_MS);
+  const noticeTimerStartedAtRef = useRef<number | null>(null);
+  const noticeOldestIdRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (noticeState.visible.length === 0) return;
+    if (noticeState.visible.length === 0) {
+      noticeOldestIdRef.current = null;
+      return;
+    }
     const exiting = noticeState.visible.find((notice) => notice.exiting);
     if (exiting) {
       const t = setTimeout(() => {
@@ -1909,11 +1919,29 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
     const oldest = noticeState.visible[0];
     if (!oldest) return;
+    // Oldest visible notice changed; restart the countdown
+    if (noticeOldestIdRef.current !== oldest.id) {
+      noticeOldestIdRef.current = oldest.id;
+      noticeRemainingMsRef.current = NOTICE_VISIBLE_MS;
+    }
+    // Hovered: countdown paused
+    if (hoveredNoticeId !== null) return;
+    noticeTimerStartedAtRef.current = Date.now();
     const t = setTimeout(() => {
       dispatchNotice({ type: "mark_oldest_exiting" });
-    }, NOTICE_VISIBLE_MS);
-    return () => clearTimeout(t);
-  }, [noticeState.visible]);
+    }, noticeRemainingMsRef.current);
+    return () => {
+      clearTimeout(t);
+      // Accrue the elapsed time so the countdown resumes from the remaining time
+      if (noticeTimerStartedAtRef.current !== null) {
+        noticeRemainingMsRef.current = Math.max(
+          0,
+          noticeRemainingMsRef.current - (Date.now() - noticeTimerStartedAtRef.current),
+        );
+        noticeTimerStartedAtRef.current = null;
+      }
+    };
+  }, [noticeState.visible, hoveredNoticeId]);
 
   useEffect(() => {
     setSessionStatsOverride(null);
@@ -1939,6 +1967,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
     handleRecallQueue,
     handleBuiltinSlashCommand,
+    setNoticeHover: setHoveredNoticeId,
     handleToolPresetChange, handleThinkingLevelChange, loadTools, loadSlashCommands, setActiveLeafId, setData, setMessages,
     scrollToBottom, scrollUserMsgToTop,
     dispatch, setAgentRunning, setForkingEntryId,

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1898,9 +1898,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     return () => clearTimeout(t);
   }, [compactResult]);
 
-  // Pause notice expiry while hovered: no countdown runs when hoveredNoticeId is set.
+  // Pause notice expiry while hovered or focused.
   // The remainingMs/startedAt/oldestId refs implement a true pause-and-resume instead of resetting the 5s timer.
-  const [hoveredNoticeId, setHoveredNoticeId] = useState<string | null>(null);
+  const [pausedNoticeId, setPausedNoticeId] = useState<string | null>(null);
   const noticeRemainingMsRef = useRef(NOTICE_VISIBLE_MS);
   const noticeTimerStartedAtRef = useRef<number | null>(null);
   const noticeOldestIdRef = useRef<string | null>(null);
@@ -1924,8 +1924,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       noticeOldestIdRef.current = oldest.id;
       noticeRemainingMsRef.current = NOTICE_VISIBLE_MS;
     }
-    // Hovered: countdown paused
-    if (hoveredNoticeId !== null) return;
+    if (noticeState.visible.some((notice) => notice.id === pausedNoticeId)) return;
     noticeTimerStartedAtRef.current = Date.now();
     const t = setTimeout(() => {
       dispatchNotice({ type: "mark_oldest_exiting" });
@@ -1941,7 +1940,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         noticeTimerStartedAtRef.current = null;
       }
     };
-  }, [noticeState.visible, hoveredNoticeId]);
+  }, [noticeState.visible, pausedNoticeId]);
 
   useEffect(() => {
     setSessionStatsOverride(null);
@@ -1967,7 +1966,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
     handleRecallQueue,
     handleBuiltinSlashCommand,
-    setNoticeHover: setHoveredNoticeId,
+    setNoticePaused: setPausedNoticeId,
     handleToolPresetChange, handleThinkingLevelChange, loadTools, loadSlashCommands, setActiveLeafId, setData, setMessages,
     scrollToBottom, scrollUserMsgToTop,
     dispatch, setAgentRunning, setForkingEntryId,


### PR DESCRIPTION
## Problem

Extension notifications (the floating `NoticeShelf` toasts) currently:

1. **Truncate long messages** — the single-line `nowrap + ellipsis` span inside a fixed 60px / max-620px container gives users no way to read the full text (e.g. pi-fff's multi-field health report).
2. **Swallow embedded newlines** — senders like pi-fff compose multi-line messages with `lines.join("\n")`, but `white-space: nowrap/normal` folds every `\n` into a space, so structured output renders as one run-on line.
3. **Auto-dismiss after 5s** with no way to pause, so a toast can disappear before the user finishes reading.

## Changes

**Toasts show their full text by default** (`components/ChatWindow.tsx`, `NoticeShelf`):

- Message span uses `white-space: pre-line` + `word-break: break-word`: embedded `\n` are preserved and long lines wrap within the existing `max-width: min(100%, 620px)` instead of truncating. `max-height: 500` remains as a safety cap for pathological messages.
- Toasts move from top-center to the **top-right corner** (`justify-content: flex-end` on the wrapper, `align-items: flex-end` on the shelf column), so each toast's right edge stays pinned and its width extends leftward as content grows.
- `transformOrigin` follows the new anchor (`top right`).
- The type indicator dot is top-aligned with the first text line on multi-line toasts (instead of vertically centered), and the font size is reduced from 18 to 14 for a more compact look.
- Content taller than the 500px cap scrolls inside the text area (thin scrollbar); the type dot stays pinned at the top and does not scroll.

**Hover pauses the dismiss timer** (`hooks/useAgentSession.ts`):

- The hook exposes `setNoticeHover(id)`; while any notice is hovered, no expiry timer runs. Elapsed time is accrued via `remainingMs/startedAt` refs, so the countdown **resumes from the remaining time** instead of restarting at 5s. The timer resets whenever the oldest visible notice changes.

**Two latent blockers fixed along the way:**

- The floating wrapper is intentionally click-through (`pointer-events: "none"`), which meant hover events never reached the toast itself; each item now opts back in with `pointer-events: "auto"` (the rest of the overlay stays click-through).
- The `notice-shelf-in` entrance animation ran with `fill: both` and its `to` keyframe pins `height/min-height/max-height: 60px` — a completed forwards-fill animation keeps winning over inline styles and would have clamped expanded toasts forever. Fill is now `backwards` (entrance visuals unchanged).

Note: an earlier iteration of this PR implemented hover-to-expand instead. It was dropped because expanding changed the toast's width (`fit-content` shrinks once text wraps), which could eject the cursor and cause an enter/leave flicker loop. Always-expanded has a stable hover area and is simpler; hover now only controls the dismiss timer.

## Behavior

| | before | after |
|---|---|---|
| long text | truncated with `…` | full text always visible |
| embedded `\n` | folded into spaces | preserved (`pre-line`) |
| position | top-center | top-right, right edge pinned |
| 5s auto-dismiss | always | paused while hovered, resumes on leave |

## Testing

- `tsc --noEmit` clean, `npm run lint` clean.
- Verified in a real browser (Chrome via CDP against `next dev`) with pi-fff's 7-line health notice: toast renders fully expanded at the top-right by default, survives well past 5s while hovered, and the countdown resumes and completes after the mouse leaves.

Known accepted edge: when more than `MAX_NOTICES` are queued, an incoming notice can still force the oldest one out even while hovered (pre-existing queue-overflow behavior, unchanged).


