### PR TITLE
fix: prune removed models from enabled scope

### DIFF
--- a/app/api/models-config/route.ts
+++ b/app/api/models-config/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from "next/server";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { pruneRemovedEnabledModels } from "@/lib/enabled-model-pruning";
+import { invalidateModelsCache } from "@/lib/models-cache";
 import { readModelsConfig, writeModelsConfig } from "@/lib/models-config-store";
 
 export const dynamic = "force-dynamic";
@@ -10,8 +13,16 @@ export async function GET() {
 export async function PUT(req: Request) {
   try {
     const body = await req.json() as Record<string, unknown>;
-    writeModelsConfig(body);
-    return NextResponse.json({ success: true });
+    const previousConfig = readModelsConfig();
+    const nextConfig = writeModelsConfig(body);
+    const settings = SettingsManager.create(process.cwd(), getAgentDir());
+    const prunedEnabledModels = await pruneRemovedEnabledModels(
+      settings,
+      previousConfig,
+      nextConfig,
+    );
+    if (prunedEnabledModels > 0) invalidateModelsCache();
+    return NextResponse.json({ success: true, prunedEnabledModels });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
   }

--- a/lib/enabled-model-pruning.test.mjs
+++ b/lib/enabled-model-pruning.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+  pruneRemovedEnabledModelPatterns,
+  pruneRemovedEnabledModels,
+} = await jiti.import("./enabled-model-pruning.ts");
+
+const previousConfig = {
+  providers: {
+    acme: {
+      models: [
+        { id: "removed" },
+        { id: "nested/model" },
+        { id: "openrouter/model:exacto" },
+        { id: "remaining" },
+      ],
+    },
+  },
+};
+
+const nextConfig = {
+  providers: {
+    acme: {
+      models: [{ id: "remaining" }],
+    },
+  },
+};
+
+test("prunes only canonical references to models removed by the saved config", () => {
+  const patterns = [
+    "acme/removed",
+    "ACME/nested/model:high",
+    "acme/openrouter/model:exacto",
+    "acme/remaining",
+    "acme/*",
+    "removed",
+    "future/provider-model",
+    "acme/removed:not-a-thinking-level",
+  ];
+
+  assert.deepEqual(
+    pruneRemovedEnabledModelPatterns(patterns, previousConfig, nextConfig),
+    [
+      "acme/remaining",
+      "acme/*",
+      "removed",
+      "future/provider-model",
+      "acme/removed:not-a-thinking-level",
+    ],
+  );
+});
+
+test("persists a pruned global scope and reports how many entries changed", async () => {
+  const calls = [];
+  const settings = {
+    getGlobalSettings: () => ({
+      enabledModels: ["acme/removed", "acme/remaining"],
+    }),
+    setEnabledModels: (patterns) => calls.push(["set", patterns]),
+    flush: async () => calls.push(["flush"]),
+  };
+
+  assert.equal(
+    await pruneRemovedEnabledModels(settings, previousConfig, nextConfig),
+    1,
+  );
+  assert.deepEqual(calls, [
+    ["set", ["acme/remaining"]],
+    ["flush"],
+  ]);
+});
+
+test("clears enabledModels when every exact entry belonged to removed models", async () => {
+  const calls = [];
+  const settings = {
+    getGlobalSettings: () => ({ enabledModels: ["acme/removed"] }),
+    setEnabledModels: (patterns) => calls.push(["set", patterns]),
+    flush: async () => calls.push(["flush"]),
+  };
+
+  assert.equal(
+    await pruneRemovedEnabledModels(settings, previousConfig, nextConfig),
+    1,
+  );
+  assert.deepEqual(calls, [["set", undefined], ["flush"]]);
+});
+
+test("does not write settings when config changes removed no referenced model", async () => {
+  const calls = [];
+  const settings = {
+    getGlobalSettings: () => ({ enabledModels: ["acme/remaining", "acme/*"] }),
+    setEnabledModels: (patterns) => calls.push(["set", patterns]),
+    flush: async () => calls.push(["flush"]),
+  };
+
+  assert.equal(
+    await pruneRemovedEnabledModels(settings, previousConfig, nextConfig),
+    0,
+  );
+  assert.deepEqual(calls, []);
+});

--- a/lib/enabled-model-pruning.ts
+++ b/lib/enabled-model-pruning.ts
@@ -1,0 +1,88 @@
+interface EnabledModelsSettings {
+  getGlobalSettings(): { enabledModels?: string[] };
+  setEnabledModels(patterns: string[] | undefined): void;
+  flush(): Promise<void>;
+}
+
+const THINKING_LEVEL_SUFFIXES = new Set([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function configuredModelReferences(config: Record<string, unknown>): Set<string> {
+  const references = new Set<string>();
+  if (!isRecord(config.providers)) return references;
+
+  for (const [providerId, provider] of Object.entries(config.providers)) {
+    if (!isRecord(provider) || !Array.isArray(provider.models)) continue;
+    for (const model of provider.models) {
+      if (!isRecord(model) || typeof model.id !== "string") continue;
+      const modelId = model.id.trim();
+      if (!modelId) continue;
+      references.add(`${providerId}/${modelId}`.toLowerCase());
+    }
+  }
+  return references;
+}
+
+function exactCanonicalReference(pattern: string, removed: ReadonlySet<string>): string | undefined {
+  const trimmed = pattern.trim();
+  if (
+    !trimmed.includes("/")
+    || trimmed.includes("*")
+    || trimmed.includes("?")
+    || trimmed.includes("[")
+  ) return undefined;
+
+  const normalized = trimmed.toLowerCase();
+  if (removed.has(normalized)) return normalized;
+
+  const colonIndex = normalized.lastIndexOf(":");
+  if (colonIndex < 0) return undefined;
+  const suffix = normalized.slice(colonIndex + 1);
+  if (!THINKING_LEVEL_SUFFIXES.has(suffix)) return undefined;
+
+  const reference = normalized.slice(0, colonIndex);
+  return removed.has(reference) ? reference : undefined;
+}
+
+export function pruneRemovedEnabledModelPatterns(
+  patterns: readonly string[],
+  previousConfig: Record<string, unknown>,
+  nextConfig: Record<string, unknown>,
+): string[] {
+  const previous = configuredModelReferences(previousConfig);
+  const next = configuredModelReferences(nextConfig);
+  const removed = new Set([...previous].filter((reference) => !next.has(reference)));
+  if (removed.size === 0) return [...patterns];
+
+  // Preserve globs, fuzzy/bare ids, and unmatched canonical references. They may
+  // intentionally target built-in or future models that are not in models.json.
+  return patterns.filter((pattern) => !exactCanonicalReference(pattern, removed));
+}
+
+export async function pruneRemovedEnabledModels(
+  settings: EnabledModelsSettings,
+  previousConfig: Record<string, unknown>,
+  nextConfig: Record<string, unknown>,
+): Promise<number> {
+  const current = settings.getGlobalSettings().enabledModels;
+  if (!current || current.length === 0) return 0;
+
+  const pruned = pruneRemovedEnabledModelPatterns(current, previousConfig, nextConfig);
+  const removedCount = current.length - pruned.length;
+  if (removedCount === 0) return 0;
+
+  settings.setEnabledModels(pruned.length > 0 ? pruned : undefined);
+  await settings.flush();
+  return removedCount;
+}

--- a/lib/models-config-store.ts
+++ b/lib/models-config-store.ts
@@ -75,10 +75,11 @@ export function readModelsConfig(
 export function writeModelsConfig(
   data: Record<string, unknown>,
   modelsPath = getModelsConfigPath(),
-): void {
+): Record<string, unknown> {
   const dir = dirname(modelsPath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const normalized = normalizeModelsConfigCosts(sanitizeModelsConfig(data));
   writePrivateFileAtomicSync(modelsPath, JSON.stringify(normalized, null, 2));
   invalidateModelsCache();
+  return normalized;
 }


### PR DESCRIPTION
## Summary

- prune stale canonical `provider/modelId` entries from global `enabledModels` when the model dialog removes those configured models
- support exact entries with thinking-level suffixes while preserving globs, fuzzy or bare model ids, and unmatched future references
- clear `enabledModels` when every exact entry was removed
- invalidate the model-list cache after the settings update so stale warnings cannot be re-cached

## Why

Saving the model dialog updated `models.json` but never updated `settings.json`. Exact enabled-model entries for a deleted connector therefore produced a persistent “No models match pattern” warning in every later session.

The cleanup compares the normalized configuration before and after the save. It only removes a canonical entry when that exact model existed in the old config and is absent from the new one. User-authored patterns that may target built-in or future models are left untouched.

## Validation

- focused model-config and pruning tests: 8 passed
- full suite excluding the environment-dependent proxy test: 590 passed
- changed-file ESLint and `git diff --check`: passed
- the full suite’s sole failure is an HTTP proxy tunnel `502`, reproduced unchanged on `origin/main`
- TypeScript checking is currently blocked by the existing `ThemeColor` assertion in `lib/rpc-manager.ts`, also reproduced on `origin/main`

Closes #560