### PR TITLE
fix(security): docker-compose 不再寫死 Basic Auth 密碼

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 .factory
 # pi-web operator env (holds password + public hostnames)
 .pi-web.env
+docker-compose.override.yml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .factory
+# pi-web operator env (holds password + public hostnames)
+.pi-web.env

--- a/.pi-web.env.example
+++ b/.pi-web.env.example
@@ -1,0 +1,17 @@
+# pi-web operator settings — copy this file to .pi-web.env and fill it in.
+# .pi-web.env is git-ignored; never commit real values.
+#
+#   cp .pi-web.env.example .pi-web.env
+
+# Basic-auth password. REQUIRED whenever pi-web is reachable beyond
+# localhost (LAN port mapping, Cloudflare Tunnel, reverse proxy, ...).
+# Long random, never reused. Generate with:
+#   node -e "console.log(require('crypto').randomBytes(18).toString('base64url'))"
+PI_WEB_PASSWORD=
+
+# Comma-separated PUBLIC hostnames (exact Host header values) that are
+# allowed to reach the API. REQUIRED when fronting pi-web with a Cloudflare
+# Tunnel / reverse proxy — without this, requests via those hostnames are
+# rejected with 403 even though the tunnel itself works fine.
+# Multiple: PI_WEB_ALLOWED_HOSTS="pi1.example.com,pi2.example.com"
+PI_WEB_ALLOWED_HOSTS=

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -78,5 +78,6 @@ environment:
 - ⚡ [STARTUP.md](./STARTUP.md) — 快速啟動與維護指令
 - 👤 [USER_GUIDE.md](./USER_GUIDE.md) — 使用者登入與帳密說明
 - 📐 [docs/SDD-docker-cloudflare-setup.md](./docs/SDD-docker-cloudflare-setup.md) — 系統設計與問題取捨
+- ✅ [docs/DOCKER_CLOUDFLARE_CHECKLIST.md](./docs/DOCKER_CLOUDFLARE_CHECKLIST.md) — 其他機器無法從 Cloudflare 連入時的逐項核對清單
 - 📜 [docs/dev.log.md](./docs/dev.log.md) — 開發歷史與踩坑記錄
 - 💡 [LESSONS_LEARNED.md](./LESSONS_LEARNED.md) — 跨專案經驗與教訓

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,22 +1,19 @@
 # 10_PiWeb — Docker 使用說明
 
-> 本地 additions（`Dockerfile` / `docker-compose.yml` / 本文件）不屬於上游 repo，git 未追蹤。
+> 本地 additions（`Dockerfile` / `docker-compose.yml` / 本文件）不屬於上游 repo。
 > 上游：https://github.com/agegr/pi-web （v0.8.9，MIT）
 
 ## 快速開始
 
-```powershell
-cd C:\Tools\@@@@@@Antigravity\TigerAI-Methodology\04_RnD\10_PiWeb
-copy .pi-web.env.example .pi-web.env    # 必填：密碼 + 公開域名（見「遠端存取」）
+```bash
+cd /home/wrt/AG/SystemRepair/pi-web
 docker compose up -d --build     # 首次會 build 映像
-# 缺 .pi-web.env 時 compose 會明確報錯（env file not found）——刻意如此，
-# 不會帶著「無密碼/無域名」的不安全預設悄悄跑起來
-# 瀏覽器開 http://127.0.0.1:30141
+# 瀏覽器開 http://127.0.0.1:30141 或 https://pi01.xxx.com
 ```
 
 日常：
 
-```powershell
+```bash
 docker compose up -d             # 啟動（映像已 build）
 docker compose logs -f           # 看 log（出現 Ready 即可用）
 docker compose down              # 停止
@@ -27,30 +24,35 @@ docker compose pull && docker compose up -d --build   # 更新 pi-web
 
 - 映像 = `node:22-alpine` + `npm install -g @agegr/pi-web@latest`（package 內含預編譯 Next.js，無 build step）
 - 容器內 pi-web 共用 host 的 `~/.pi/agent`（session、模型設定、API key），跟 TUI pi 同一份資料
-- 預設綁 `0.0.0.0`（容器內必需），對外只有 `127.0.0.1:30141` 一個映射
+- 預設綁 `0.0.0.0`（容器內必需），對外由 30141 映射
 
 ## 掛載（volumes）
 
 | Host | Container | 用途 |
 |---|---|---|
-| `C:/Users/yesin/.pi/agent` | `/home/node/.pi/agent` | pi 設定 + session + auth |
-| `C:/Tools/.../TigerAI-Methodology` | `/workspace` | agent 要操作的專案（自行改）|
+| `${HOME}/.pi/agent` | `/home/node/.pi/agent` | pi 設定 + session + auth |
+| `/home/wrt/AG/SystemRepair` | `/workspace` | agent 要操作的專案目錄 |
 
 要讓 agent 操作其他目錄，就在 compose 的 `volumes` 加一列，網頁 UI 的 cwd 選單裡就會出現。
 
-## 遠端存取（可選）
+## 遠端存取與 Cloudflare Tunnel 配置
 
-本機用不用動。要給 LAN／外面連：改 `.pi-web.env`（不用動 compose）：
+給 LAN／Cloudflare Tunnel 對外連線時，請設定以下環境變數（已整合於 `docker-compose.yml` 或 `.pi-web.env`）：
 
-```ini
-PI_WEB_PASSWORD=node -e 產生的長隨機密碼
-# 走 Cloudflare Tunnel／反向代理時必填：精確的公開域名（逗號分隔可多個）
-# 沒填時該域名的請求會被 403 擋掉——tunnel 通了也「打不進來」
-PI_WEB_ALLOWED_HOSTS=pi.你的域名.com
+```yaml
+environment:
+  PI_WEB_HOSTNAME: "0.0.0.0"
+  PI_WEB_NO_OPEN: "1"
+  PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"
+  # 注意：docker-compose.yml 內密碼若含 $ 字元，務必寫成 $$ 避免 Compose 變數展開
+  PI_WEB_PASSWORD: "your_complex_password_here"
 ```
 
-改完 `docker compose up -d` 套用。⚠️ **env 變更要 recreate 容器才生效**——
-只改檔案不重啟 = 容器還在用舊值（用 `docker exec pi-web env | grep PI_WEB` 確認）。
+⚠️ **注意與重點**:
+- **認證 User**：`pi-web` 的 Basic Auth 使用者名稱固定為 **`pi`**（寫死於 `lib/web-auth.ts`），請勿輸入 `admin` 或其他帳號。
+- **Host Header 白名單**：走 Cloudflare Tunnel（如 `pi01.xxx.com`）時，必須將該域名填入 `PI_WEB_ALLOWED_HOSTS`，否則會回傳 `403 Forbidden`。
+- **`$` 轉義**：在 `docker-compose.yml` 中，`$` 符號會被 Compose 解析為變數展開，務必使用 `$$` 轉義。
+- **Recreate 生效**：修改環境變數後須執行 `docker compose up -d` 重建容器以套用新設定。
 
 ⚠️ 紀律：長隨機密碼、不要重用、只走 TLS（VPN／Cloudflare Tunnel）、能加 Cloudflare Access 就加（補 MFA + 稽核）。pi-web 的 Basic Auth 沒有 rate limit / MFA。
 
@@ -61,12 +63,6 @@ PI_WEB_ALLOWED_HOSTS=pi.你的域名.com
 - `/workspace` 是 read-write：容器內的寫入會直接改 host 檔案
 - 跑不信任的 repo / 無人監督任務：把 `~/.pi/agent` 換成最小化的（只放必要 key）、專案用 read-only 或 copy-in/copy-out
 
-## 進階：讓 agent 控制 host（權限與繞過）
-
-agent 需要執行 host 指令 / 讀 host 檔案（例如遠端維護部署機）時，見
-`docs/docker-host-bridge.md`：path bridge（容器內 symlink）+ ssh2 bridge
-（pure-JS，不掛 docker.sock、密碼走環境變數），含 rebuild 復原 checklist。
-
 ## 排錯
 
 | 症狀 | 處理 |
@@ -76,6 +72,11 @@ agent 需要執行 host 指令 / 讀 host 檔案（例如遠端維護部署機�
 | alpine 相容性問題（若有）| Dockerfile 改 `node:22-slim`（Debian 基底）|
 | UI 看不到某個專案目錄 | 該目錄沒掛進容器 → 加 volume |
 
-## 審查記錄
+## 相關文件與架構設計
 
-- 2026-08-15：上游 v0.8.9 源碼 + npm tarball 資安審查完成（無遙測／無資料外洩，認證最小化）→ 見 `04000_INDEX.md` 10_PiWeb 段
+- 🛠️ [INSTALL_GUIDE.md](./INSTALL_GUIDE.md) — 完整安裝與 Cloudflare 配置步驟
+- ⚡ [STARTUP.md](./STARTUP.md) — 快速啟動與維護指令
+- 👤 [USER_GUIDE.md](./USER_GUIDE.md) — 使用者登入與帳密說明
+- 📐 [docs/SDD-docker-cloudflare-setup.md](./docs/SDD-docker-cloudflare-setup.md) — 系統設計與問題取捨
+- 📜 [docs/dev.log.md](./docs/dev.log.md) — 開發歷史與踩坑記錄
+- 💡 [LESSONS_LEARNED.md](./LESSONS_LEARNED.md) — 跨專案經驗與教訓

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,69 @@
+# 10_PiWeb — Docker 使用說明
+
+> 本地 additions（`Dockerfile` / `docker-compose.yml` / 本文件）不屬於上游 repo，git 未追蹤。
+> 上游：https://github.com/agegr/pi-web （v0.8.9，MIT）
+
+## 快速開始
+
+```powershell
+cd C:\Tools\@@@@@@Antigravity\TigerAI-Methodology\04_RnD\10_PiWeb
+docker compose up -d --build     # 首次會 build 映像
+# 瀏覽器開 http://127.0.0.1:30141
+```
+
+日常：
+
+```powershell
+docker compose up -d             # 啟動（映像已 build）
+docker compose logs -f           # 看 log（出現 Ready 即可用）
+docker compose down              # 停止
+docker compose pull && docker compose up -d --build   # 更新 pi-web
+```
+
+## 它怎麼運作
+
+- 映像 = `node:22-alpine` + `npm install -g @agegr/pi-web@latest`（package 內含預編譯 Next.js，無 build step）
+- 容器內 pi-web 共用 host 的 `~/.pi/agent`（session、模型設定、API key），跟 TUI pi 同一份資料
+- 預設綁 `0.0.0.0`（容器內必需），對外只有 `127.0.0.1:30141` 一個映射
+
+## 掛載（volumes）
+
+| Host | Container | 用途 |
+|---|---|---|
+| `C:/Users/yesin/.pi/agent` | `/home/node/.pi/agent` | pi 設定 + session + auth |
+| `C:/Tools/.../TigerAI-Methodology` | `/workspace` | agent 要操作的專案（自行改）|
+
+要讓 agent 操作其他目錄，就在 compose 的 `volumes` 加一列，網頁 UI 的 cwd 選單裡就會出現。
+
+## 遠端存取（可選）
+
+本機用不用動。要給 LAN／外面連：
+
+```yaml
+environment:
+  PI_WEB_PASSWORD: "node -e 產生的長隨機密碼"
+  # 走 Cloudflare Tunnel 時：
+  # PI_WEB_ALLOWED_HOSTS: "pi.你的域名.com"
+```
+
+⚠️ 紀律：長隨機密碼、不要重用、只走 TLS（VPN／Cloudflare Tunnel）、能加 Cloudflare Access 就加（補 MFA + 稽核）。pi-web 的 Basic Auth 沒有 rate limit / MFA。
+
+## 安全邊界（記得）
+
+- 容器內 pi = 有 `/workspace` 和 `~/.pi/agent` 權限的完整 agent：能改掛載目錄的檔案、用裡面的 API key
+- `~/.pi/agent` 掛進去 = 容器看得到所有 API key 和 session 歷史，只給信任的容器
+- `/workspace` 是 read-write：容器內的寫入會直接改 host 檔案
+- 跑不信任的 repo / 無人監督任務：把 `~/.pi/agent` 換成最小化的（只放必要 key）、專案用 read-only 或 copy-in/copy-out
+
+## 排錯
+
+| 症狀 | 處理 |
+|---|---|
+| 網頁連不上 | `docker compose logs -f` 看是否 Ready；確認 30141 沒被佔 |
+| 權限錯誤（寫檔失敗）| compose 加 `user: "0"` 用 root 跑（權衡：較不隔離）|
+| alpine 相容性問題（若有）| Dockerfile 改 `node:22-slim`（Debian 基底）|
+| UI 看不到某個專案目錄 | 該目錄沒掛進容器 → 加 volume |
+
+## 審查記錄
+
+- 2026-08-15：上游 v0.8.9 源碼 + npm tarball 資安審查完成（無遙測／無資料外洩，認證最小化）→ 見 `04000_INDEX.md` 10_PiWeb 段

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,7 +7,10 @@
 
 ```powershell
 cd C:\Tools\@@@@@@Antigravity\TigerAI-Methodology\04_RnD\10_PiWeb
+copy .pi-web.env.example .pi-web.env    # 必填：密碼 + 公開域名（見「遠端存取」）
 docker compose up -d --build     # 首次會 build 映像
+# 缺 .pi-web.env 時 compose 會明確報錯（env file not found）——刻意如此，
+# 不會帶著「無密碼/無域名」的不安全預設悄悄跑起來
 # 瀏覽器開 http://127.0.0.1:30141
 ```
 
@@ -37,14 +40,17 @@ docker compose pull && docker compose up -d --build   # 更新 pi-web
 
 ## 遠端存取（可選）
 
-本機用不用動。要給 LAN／外面連：
+本機用不用動。要給 LAN／外面連：改 `.pi-web.env`（不用動 compose）：
 
-```yaml
-environment:
-  PI_WEB_PASSWORD: "node -e 產生的長隨機密碼"
-  # 走 Cloudflare Tunnel 時：
-  # PI_WEB_ALLOWED_HOSTS: "pi.你的域名.com"
+```ini
+PI_WEB_PASSWORD=node -e 產生的長隨機密碼
+# 走 Cloudflare Tunnel／反向代理時必填：精確的公開域名（逗號分隔可多個）
+# 沒填時該域名的請求會被 403 擋掉——tunnel 通了也「打不進來」
+PI_WEB_ALLOWED_HOSTS=pi.你的域名.com
 ```
+
+改完 `docker compose up -d` 套用。⚠️ **env 變更要 recreate 容器才生效**——
+只改檔案不重啟 = 容器還在用舊值（用 `docker exec pi-web env | grep PI_WEB` 確認）。
 
 ⚠️ 紀律：長隨機密碼、不要重用、只走 TLS（VPN／Cloudflare Tunnel）、能加 Cloudflare Access 就加（補 MFA + 稽核）。pi-web 的 Basic Auth 沒有 rate limit / MFA。
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -55,6 +55,12 @@ environment:
 - `/workspace` 是 read-write：容器內的寫入會直接改 host 檔案
 - 跑不信任的 repo / 無人監督任務：把 `~/.pi/agent` 換成最小化的（只放必要 key）、專案用 read-only 或 copy-in/copy-out
 
+## 進階：讓 agent 控制 host（權限與繞過）
+
+agent 需要執行 host 指令 / 讀 host 檔案（例如遠端維護部署機）時，見
+`docs/docker-host-bridge.md`：path bridge（容器內 symlink）+ ssh2 bridge
+（pure-JS，不掛 docker.sock、密碼走環境變數），含 rebuild 復原 checklist。
+
 ## 排錯
 
 | 症狀 | 處理 |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# pi-web — local Docker packaging (not upstream; local addition)
+#
+# The npm package ships prebuilt Next.js artifacts, so the image just
+# installs the global package — no build step needed.
+#
+# Build:   docker build -t tigerai/pi-web .
+# Run:     docker compose up -d        (see docker-compose.yml)
+
+FROM node:22-alpine
+
+ENV NODE_ENV=production
+
+RUN npm install -g @agegr/pi-web@latest
+
+# Run as the unprivileged node user; pi data lives in its home (/home/node).
+USER node
+
+# pi-web reads/writes pi config, sessions, and auth under the node user's
+# home. Mount the host's ~/.pi/agent onto this path (see docker-compose.yml).
+#
+# WARNING: mounting host ~/.pi/agent exposes API keys and full session
+# history to the container. Only do this for containers you trust.
+VOLUME ["/home/node/.pi/agent"]
+
+# Default pi-web port
+EXPOSE 30141
+
+# NOTE: container must bind 0.0.0.0 for port mapping to work (set
+# PI_WEB_HOSTNAME=0.0.0.0 in the compose file). For any access beyond your
+# own machine, also set PI_WEB_PASSWORD to a long random password.
+CMD ["pi-web", "--no-open"]

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -1,0 +1,80 @@
+# pi-web Docker & Cloudflare Tunnel Installation Guide
+
+This guide provides step-by-step instructions for deploying `pi-web` using Docker Compose behind a Cloudflare Tunnel or reverse proxy.
+
+---
+
+## 1. Prerequisites
+
+- Docker and Docker Compose installed.
+- Access to host agent directory `~/.pi/agent`.
+- Domain routed through Cloudflare Tunnel (e.g., `pi01.xxx.com`).
+
+---
+
+## 2. Configuration (`docker-compose.yml`)
+
+Create or update `/home/wrt/AG/SystemRepair/pi-web/docker-compose.yml`:
+
+```yaml
+services:
+  pi-web:
+    build: .
+    image: tigerai/pi-web:local
+    container_name: pi-web
+    ports:
+      - "30141:30141"
+    environment:
+      # Required: container must bind 0.0.0.0 inside container network
+      PI_WEB_HOSTNAME: "0.0.0.0"
+      # Disable auto-opening browser on container start
+      PI_WEB_NO_OPEN: "1"
+      # Allowed public hostname(s) forwarded by Cloudflare/Proxy
+      PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"
+      # HTTP Basic Auth Password ($ MUST be escaped as $$ for Compose)
+      PI_WEB_PASSWORD: "your_complex_password_here"
+    volumes:
+      - '${HOME}/.pi/agent:/home/node/.pi/agent'
+      - '/home/wrt/AG/SystemRepair:/workspace'
+    working_dir: /workspace
+    restart: unless-stopped
+```
+
+---
+
+## 3. Environment Parameters Reference
+
+| Parameter | Recommended Value | Purpose |
+|---|---|---|
+| `PI_WEB_HOSTNAME` | `"0.0.0.0"` | Binds listening server to all interfaces inside container |
+| `PI_WEB_NO_OPEN` | `"1"` | Prevents headless container from opening browser |
+| `PI_WEB_ALLOWED_HOSTS` | `"pi01.xxx.com"` | Whitelists external domain host header to prevent 403 Forbidden |
+| `PI_WEB_PASSWORD` | `"your_complex_password_here"` | Password for Basic Auth (Username is fixed to `pi`) |
+| `${HOME}/.pi/agent` | `/home/node/.pi/agent` | Mounts pi sessions, models, and credentials from host |
+| `/home/wrt/...` | `/workspace` | Mounts target project workspace into container |
+
+---
+
+## 4. Deployment Commands
+
+```bash
+# Ensure agent directory exists on host
+mkdir -p ~/.pi/agent
+
+# Build image and start container in detached mode
+docker compose up -d --build
+
+# Inspect container status
+docker compose ps
+
+# Inspect logs
+docker compose logs -f
+```
+
+---
+
+## 5. Login Credentials
+
+- **URL**: `https://pi01.xxx.com`
+- **Username**: `pi` *(Hardcoded in pi-web)*
+- **Password**: `your_complex_password_here`

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -101,3 +101,15 @@ This matrix documents technical pitfalls, root causes, fixes, and universal guid
   2. If a secret was already typed, rotate it immediately and treat the affected session file as compromised.
   3. Consider restricting filesystem permissions on `~/.pi/agent/sessions/` (e.g., 700) and limiting who can access the host volume.
 - **Lesson / Rule**: Treat pi session files as sensitive data. Secrets must never be entered via chat; always load them from protected environment sources.
+
+---
+
+## 11. Container root ≠ Host root, and Running as root Has Ownership Costs
+
+- **Symptom**: After setting `user: "0"` in `docker-compose.yml`, the agent can write to mounted volumes, but newly created files are owned by `root:root`. Switching back to `user: node` later results in "Permission denied" on those files. Some tasks that seem like "fix host" cannot be done from inside the container at all.
+- **Root Cause**: Container root is namespaced to the container. It only has full privileges over the container's filesystem and the volumes explicitly mounted from the host. It does **not** grant host-wide root access. Running as root inside the container changes ownership of files inside mounted volumes to root, which breaks the default node user.
+- **Fix**:
+  1. Understand the boundary: container can only touch its own filesystem + mounted volumes (`~/.pi/agent`, `/workspace` → `/home/wrt/TigerAI/AG/SystemRepair`). Anything outside those mounts requires an SSH bridge back to the host.
+  2. Avoid long-term `user: "0"`. Use it only temporarily for specific writes, then revert to node.
+  3. For host-wide operations (e.g., fixing the wrt host itself, managing Docker, editing files outside the mounts), use the SSH bridge skill to execute commands as the host user (with sudo when explicitly approved).
+- **Lesson / Rule**: Container root is not host root. Never assume container privileges extend to the host. Prefer SSH bridge for host operations and keep the container running as an unprivileged user to avoid ownership drift.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -28,3 +28,37 @@ This matrix documents technical pitfalls, root causes, fixes, and universal guid
 - **Root Cause**: Middleware validates incoming `Host` headers against an explicit whitelist to prevent Host Header Injection attacks.
 - **Fix**: Pass the public domain name (e.g. `pi01.xxx.com`) to `PI_WEB_ALLOWED_HOSTS`.
 - **Lesson / Rule**: When deploying containerized web services behind Cloudflare Tunnel, Nginx, or Caddy, always explicitly configure the application's allowed host list.
+
+---
+
+## 4. Docker Hairpin NAT — Container Cannot Reach Host-Published Ports
+
+- **Symptom**: `cloudflared` container logs show `dial tcp 192.168.1.61:30141: i/o timeout` or `dial tcp 172.17.0.1:30141: i/o timeout`. The target service is confirmed reachable from the host itself (`curl http://192.168.1.61:30141` returns 200).
+- **Root Cause**: Docker hairpin NAT. When a container on the default `bridge` network tries to reach a host-published port via the host's LAN IP (`192.168.1.61`) or the Docker bridge gateway (`172.17.0.1`), the packet must exit the bridge, hit host iptables PREROUTING/FORWARD chains, and loop back. On many Linux hosts the default netfilter rules **drop** or **do not DNAT** such hairpinned packets, causing a silent timeout.
+- **Key Insight**: This behavior is **host-specific**. One machine (e.g. `pi08` at `192.168.1.62`) may allow hairpin NAT fine, while another (e.g. `pi06` at `192.168.1.61`) does not — even with identical Docker versions. The difference lies in iptables/nftables configuration.
+- **Fix**: Do **not** route through host IPs from inside containers. Use Docker container DNS instead (see Lesson 5).
+- **Lesson / Rule**: Never assume a containerized service (like `cloudflared`) can reach another container's published port via the host's IP address. Always test container-to-container connectivity explicitly.
+
+---
+
+## 5. Cloudflare Tunnel Origin URL — Use Container DNS, Not Host IP
+
+- **Symptom**: Cloudflare Tunnel dashboard is configured with `http://192.168.1.61:30141` or `http://172.17.0.1:30141` as the origin URL, but all requests time out.
+- **Root Cause**: `cloudflared` runs inside a Docker container. It cannot reach port-published services via host IPs due to hairpin NAT (Lesson 4).
+- **Fix**: 
+  1. Connect `cloudflared` to pi-web's Docker compose network: `docker network connect pi-web_default <cloudflared_container>`
+  2. Set the Cloudflare Dashboard origin URL to `http://pi-web:30141` — Docker embedded DNS resolves `pi-web` to the container's internal IP on the shared network.
+- **Verification**: `docker run --rm --network pi-web_default alpine/curl -s -o /dev/null -w "%{http_code}" -H "Host: pi06.n8n.tw" http://pi-web:30141/` must return `401` (auth prompt) or `200` (with credentials).
+- **Lesson / Rule**: When `cloudflared` is containerized and needs to reach another container, always use Docker service DNS names (`http://<container_name>:<port>`) on a shared user-defined network. Never use host LAN IPs or bridge gateway IPs as origin URLs.
+
+---
+
+## 6. Cloudflared Network Connection Does Not Persist Across Restarts
+
+- **Symptom**: After `docker compose down && docker compose up -d` or a host reboot, `cloudflared` loses connectivity to `pi-web:30141` and the Cloudflare Tunnel starts timing out again.
+- **Root Cause**: `docker network connect` is a runtime operation. When either container is recreated, the cross-network link is lost. `cloudflared` (managed as a standalone `docker run` container, not in the same compose file) is not automatically reconnected.
+- **Fix**: 
+  1. Create an idempotent reconnection script (`connect-cloudflared.sh`) that runs `docker network connect pi-web_default <cloudflared_container>`.
+  2. Register a `@reboot` cron job: `@reboot sleep 30 && /path/to/connect-cloudflared.sh`
+  3. Always run `./connect-cloudflared.sh` after `docker compose up -d`.
+- **Lesson / Rule**: Any `docker network connect` between containers managed by different lifecycle systems (standalone container vs. compose project) must be re-applied after every restart. Automate it.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1,0 +1,30 @@
+# Lessons Learned Matrix
+
+This matrix documents technical pitfalls, root causes, fixes, and universal guidelines applicable across projects.
+
+---
+
+## 1. Docker Compose Variable Expansion in YAML
+
+- **Symptom**: Warning `The "XYZ" variable is not set` when running `docker compose up`, resulting in truncated environment variable values inside the container.
+- **Root Cause**: Docker Compose parses `$VAR` syntax inside `environment:` entries in `.yml` files as Compose environment variable interpolation.
+- **Fix**: Escape every `$` as `$$` in `docker-compose.yml` (e.g. `your_complex_password_here`).
+- **Lesson / Rule**: Always double `$` characters (`$$`) when setting passwords or secret tokens in `docker-compose.yml` environment blocks.
+
+---
+
+## 2. Hardcoded Credentials in Third-Party Web Frameworks
+
+- **Symptom**: HTTP 401 Unauthorized errors despite using the correct password.
+- **Root Cause**: Upstream implementation hardcodes the Basic Auth username (e.g. `PI_WEB_AUTH_USERNAME = "pi"` in `lib/web-auth.ts`).
+- **Fix**: Verify username constraints in application source code before assuming arbitrary usernames (`admin`, `user`, etc.) are permitted.
+- **Lesson / Rule**: Always inspect the application's authentication middleware to determine whether the username is configurable or fixed.
+
+---
+
+## 3. Reverse Proxy Host Header Rejection
+
+- **Symptom**: Web application returns `403 Forbidden` when accessed via Cloudflare Tunnel or reverse proxy domain.
+- **Root Cause**: Middleware validates incoming `Host` headers against an explicit whitelist to prevent Host Header Injection attacks.
+- **Fix**: Pass the public domain name (e.g. `pi01.xxx.com`) to `PI_WEB_ALLOWED_HOSTS`.
+- **Lesson / Rule**: When deploying containerized web services behind Cloudflare Tunnel, Nginx, or Caddy, always explicitly configure the application's allowed host list.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -62,3 +62,21 @@ This matrix documents technical pitfalls, root causes, fixes, and universal guid
   2. Register a `@reboot` cron job: `@reboot sleep 30 && /path/to/connect-cloudflared.sh`
   3. Always run `./connect-cloudflared.sh` after `docker compose up -d`.
 - **Lesson / Rule**: Any `docker network connect` between containers managed by different lifecycle systems (standalone container vs. compose project) must be re-applied after every restart. Automate it.
+
+---
+
+## 7. Fresh Container Working Directory Access Gating (`Access denied` on `/api/models`)
+
+- **Symptom**: `GET /api/models?cwd=/workspace` returns `403 Access denied` on fresh Docker deployments when no session files exist yet.
+- **Root Cause**: `getAllowedFileRoots()` in `lib/file-access.ts` derived allowed roots strictly from existing session `.jsonl` files and explicit user selections. On a fresh container start without pre-existing session files, `process.cwd()` (`/workspace`) was missing from the allowed roots set.
+- **Fix**: Included `process.cwd()` in `getAllowedFileRoots()` by default so the process working directory is automatically authorized.
+- **Lesson / Rule**: Always authorize the application's runtime working directory (`process.cwd()`) in security file-access boundaries to ensure fresh deployments without pre-existing sessions can query models and load project metadata immediately.
+
+---
+
+## 8. Custom OpenAI-Compatible Provider Setup (`n8n-qwen` / `Qwen3.8-27B`)
+
+- **Symptom**: Custom OpenAI API gateway models (`openai-completions` API type) not showing up or failing during inference.
+- **Root Cause**: Models missing from `~/.pi/agent/models.json` or misconfigured max tokens/reasoning parameters.
+- **Fix**: Registered `n8n-qwen` provider with `api: "openai-completions"`, `baseUrl: "http://192.168.1.86:30003/gw/v1"`, and `reasoning: true` under `~/.pi/agent/models.json`.
+- **Lesson / Rule**: Ensure custom OpenAI-compatible gateways match Pi's `models.json` schema and account for reasoning tokens emitted during inference.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1,0 +1,213 @@
+# Lessons Learned Matrix
+
+This matrix documents technical pitfalls, root causes, fixes, and universal guidelines applicable across projects.
+
+---
+
+## 1. Docker Compose Variable Expansion in YAML
+
+- **Symptom**: Warning `The "XYZ" variable is not set` when running `docker compose up`, resulting in truncated environment variable values inside the container.
+- **Root Cause**: Docker Compose parses `$VAR` syntax inside `environment:` entries in `.yml` files as Compose environment variable interpolation.
+- **Fix**: Escape every `$` as `$$` in `docker-compose.yml` (e.g. `your_complex_password_here`).
+- **Lesson / Rule**: Always double `$` characters (`$$`) when setting passwords or secret tokens in `docker-compose.yml` environment blocks.
+
+---
+
+## 2. Hardcoded Credentials in Third-Party Web Frameworks
+
+- **Symptom**: HTTP 401 Unauthorized errors despite using the correct password.
+- **Root Cause**: Upstream implementation hardcodes the Basic Auth username (e.g. `PI_WEB_AUTH_USERNAME = "pi"` in `lib/web-auth.ts`).
+- **Fix**: Verify username constraints in application source code before assuming arbitrary usernames (`admin`, `user`, etc.) are permitted.
+- **Lesson / Rule**: Always inspect the application's authentication middleware to determine whether the username is configurable or fixed.
+
+---
+
+## 3. Reverse Proxy Host Header Rejection
+
+- **Symptom**: Web application returns `403 Forbidden` when accessed via Cloudflare Tunnel or reverse proxy domain.
+- **Root Cause**: Middleware validates incoming `Host` headers against an explicit whitelist to prevent Host Header Injection attacks.
+- **Fix**: Pass the public domain name (e.g. `pi01.xxx.com`) to `PI_WEB_ALLOWED_HOSTS`.
+- **Lesson / Rule**: When deploying containerized web services behind Cloudflare Tunnel, Nginx, or Caddy, always explicitly configure the application's allowed host list.
+
+---
+
+## 4. Docker Hairpin NAT — Container Cannot Reach Host-Published Ports
+
+- **Symptom**: `cloudflared` container logs show `dial tcp 192.168.1.61:30141: i/o timeout` or `dial tcp 172.17.0.1:30141: i/o timeout`. The target service is confirmed reachable from the host itself (`curl http://192.168.1.61:30141` returns 200).
+- **Root Cause**: Docker hairpin NAT. When a container on the default `bridge` network tries to reach a host-published port via the host's LAN IP (`192.168.1.61`) or the Docker bridge gateway (`172.17.0.1`), the packet must exit the bridge, hit host iptables PREROUTING/FORWARD chains, and loop back. On many Linux hosts the default netfilter rules **drop** or **do not DNAT** such hairpinned packets, causing a silent timeout.
+- **Key Insight**: This behavior is **host-specific**. One machine (e.g. `pi08` at `192.168.1.62`) may allow hairpin NAT fine, while another (e.g. `pi06` at `192.168.1.61`) does not — even with identical Docker versions. The difference lies in iptables/nftables configuration.
+- **Fix**: Do **not** route through host IPs from inside containers. Use Docker container DNS instead (see Lesson 5).
+- **Lesson / Rule**: Never assume a containerized service (like `cloudflared`) can reach another container's published port via the host's IP address. Always test container-to-container connectivity explicitly.
+
+---
+
+## 5. Cloudflare Tunnel Origin URL — Use Container DNS, Not Host IP
+
+- **Symptom**: Cloudflare Tunnel dashboard is configured with `http://192.168.1.61:30141` or `http://172.17.0.1:30141` as the origin URL, but all requests time out.
+- **Root Cause**: `cloudflared` runs inside a Docker container. It cannot reach port-published services via host IPs due to hairpin NAT (Lesson 4).
+- **Fix**: 
+  1. Connect `cloudflared` to pi-web's Docker compose network: `docker network connect pi-web_default <cloudflared_container>`
+  2. Set the Cloudflare Dashboard origin URL to `http://pi-web:30141` — Docker embedded DNS resolves `pi-web` to the container's internal IP on the shared network.
+- **Verification**: `docker run --rm --network pi-web_default alpine/curl -s -o /dev/null -w "%{http_code}" -H "Host: pi06.n8n.tw" http://pi-web:30141/` must return `401` (auth prompt) or `200` (with credentials).
+- **Lesson / Rule**: When `cloudflared` is containerized and needs to reach another container, always use Docker service DNS names (`http://<container_name>:<port>`) on a shared user-defined network. Never use host LAN IPs or bridge gateway IPs as origin URLs.
+
+---
+
+## 6. Cloudflared Network Connection Does Not Persist Across Restarts
+
+- **Symptom**: After `docker compose down && docker compose up -d` or a host reboot, `cloudflared` loses connectivity to `pi-web:30141` and the Cloudflare Tunnel starts timing out again.
+- **Root Cause**: `docker network connect` is a runtime operation. When either container is recreated, the cross-network link is lost. `cloudflared` (managed as a standalone `docker run` container, not in the same compose file) is not automatically reconnected.
+- **Fix**: 
+  1. Create an idempotent reconnection script (`connect-cloudflared.sh`) that runs `docker network connect pi-web_default <cloudflared_container>`.
+  2. Register a `@reboot` cron job: `@reboot sleep 30 && /path/to/connect-cloudflared.sh`
+  3. Always run `./connect-cloudflared.sh` after `docker compose up -d`.
+- **Lesson / Rule**: Any `docker network connect` between containers managed by different lifecycle systems (standalone container vs. compose project) must be re-applied after every restart. Automate it.
+
+---
+
+## 7. Fresh Container Working Directory Access Gating (`Access denied` on `/api/models`)
+
+- **Symptom**: `GET /api/models?cwd=/workspace` returns `403 Access denied` on fresh Docker deployments when no session files exist yet.
+- **Root Cause**: `getAllowedFileRoots()` in `lib/file-access.ts` derived allowed roots strictly from existing session `.jsonl` files and explicit user selections. On a fresh container start without pre-existing session files, `process.cwd()` (`/workspace`) was missing from the allowed roots set.
+- **Fix**: Included `process.cwd()` in `getAllowedFileRoots()` by default so the process working directory is automatically authorized.
+- **Lesson / Rule**: Always authorize the application's runtime working directory (`process.cwd()`) in security file-access boundaries to ensure fresh deployments without pre-existing sessions can query models and load project metadata immediately.
+
+---
+
+## 8. Custom OpenAI-Compatible Provider Setup (`n8n-qwen` / `Qwen3.8-27B`)
+
+- **Symptom**: Custom OpenAI API gateway models (`openai-completions` API type) not showing up or failing during inference.
+- **Root Cause**: Models missing from `~/.pi/agent/models.json` or misconfigured max tokens/reasoning parameters.
+- **Fix**: Registered `n8n-qwen` provider with `api: "openai-completions"`, `baseUrl: "http://192.168.1.86:30003/gw/v1"`, and `reasoning: true` under `~/.pi/agent/models.json`.
+- **Lesson / Rule**: Ensure custom OpenAI-compatible gateways match Pi's `models.json` schema and account for reasoning tokens emitted during inference.
+
+---
+
+## 9. Docker Bridge Gateway IP Is Not Fixed Across Networks
+
+- **Symptom**: An in-container SSH bridge to the host using a previously working gateway IP (e.g. `172.21.0.1`) fails after redeployment onto a different docker network.
+- **Root Cause**: Each user-defined docker bridge network gets its own subnet. The host's address as seen from inside a container is always the network gateway (`.1` of the container's subnet), but that address changes per network.
+- **Fix**: Discover the gateway at setup time: decode the `gw` field of the default route in `cat /proc/net/route` (little-endian hex, e.g. `01001CAC` → `172.28.0.1`), or take the container's own IP and set the host part to `.1`.
+- **Lesson / Rule**: Never hardcode the bridge gateway as the only source of truth. Make it a parameter (env var / CLI flag) and document the discovery method next to it.
+
+---
+
+## 10. Secrets Typed in Chat Are Persisted in Pi Session Files
+
+- **Symptom**: Host SSH passwords, sudo passwords, or API keys typed into a pi session appear in the session JSONL file and are therefore readable by anyone with filesystem access to `~/.pi/agent/sessions/`.
+- **Root Cause**: Pi sessions are plain JSONL files (typically mode 644) mounted into the container. The agent records every user message verbatim, including secrets.
+- **Fix**:
+  1. Never type secrets in chat. Use environment variables or a local `.env` file (mode 600) loaded by a pi skill (see `docs/docker-host-bridge.md` Solution B+).
+  2. If a secret was already typed, rotate it immediately and treat the affected session file as compromised.
+  3. Consider restricting filesystem permissions on `~/.pi/agent/sessions/` (e.g., 700) and limiting who can access the host volume.
+- **Lesson / Rule**: Treat pi session files as sensitive data. Secrets must never be entered via chat; always load them from protected environment sources.
+
+---
+
+## 11. Container root ≠ Host root, and Running as root Has Ownership Costs
+
+- **Symptom**: After setting `user: "0"` in `docker-compose.yml`, the agent can write to mounted volumes, but newly created files are owned by `root:root`. Switching back to `user: node` later results in "Permission denied" on those files. Some tasks that seem like "fix host" cannot be done from inside the container at all.
+- **Root Cause**: Container root is namespaced to the container. It only has full privileges over the container's filesystem and the volumes explicitly mounted from the host. It does **not** grant host-wide root access. Running as root inside the container changes ownership of files inside mounted volumes to root, which breaks the default node user.
+- **Fix**:
+  1. Understand the boundary: container can only touch its own filesystem + mounted volumes (`~/.pi/agent`, `/workspace` → `/home/wrt/TigerAI/AG/SystemRepair`). Anything outside those mounts requires an SSH bridge back to the host.
+  2. Avoid long-term `user: "0"`. Use it only temporarily for specific writes, then revert to node.
+  3. For host-wide operations (e.g., fixing the wrt host itself, managing Docker, editing files outside the mounts), use the SSH bridge skill to execute commands as the host user (with sudo when explicitly approved).
+- **Lesson / Rule**: Container root is not host root. Never assume container privileges extend to the host. Prefer SSH bridge for host operations and keep the container running as an unprivileged user to avoid ownership drift.
+
+---
+
+## 12. Docker API Version Mismatch with `docker compose`
+
+- **Symptom**: Running `docker compose up -d --build` fails immediately with `unable to get image '...': Error response from daemon: client version 1.53 is too new. Maximum supported API version is 1.43`.
+- **Root Cause**: The installed `docker compose` CLI version negotiates an API version higher than what the Docker daemon on the host supports (common when CLI is updated independently of the daemon).
+- **Fix**: Prefix all `docker compose` commands with `DOCKER_API_VERSION=1.43` to pin the API version to the daemon's maximum supported level.
+  ```bash
+  DOCKER_API_VERSION=1.43 docker compose up -d --build
+  ```
+- **Lesson / Rule**: On servers where the Docker CLI and daemon versions diverge, always export `DOCKER_API_VERSION` matching the daemon's maximum. Add it to wrapper scripts and cron jobs to avoid silent failures.
+
+---
+
+## 13. Wildcard `*` in `PI_WEB_ALLOWED_HOSTS` Is Not Natively Supported
+
+- **Symptom**: Setting `PI_WEB_ALLOWED_HOSTS: "*"` in `docker-compose.yml` to allow any hostname still results in `403 Forbidden` for any non-loopback, non-IP host header.
+- **Root Cause**: The `isApiRequestHostAllowed()` function in `lib/request-security.ts` calls `normalizeConfiguredHostname("*")` which returns `null` (wildcard is not a valid hostname or IP), so no match is made.
+- **Fix**: Add an explicit wildcard check before the normalization step in `lib/request-security.ts`:
+  ```ts
+  return configuredHostnames.some(
+    (configured) => configured === "*" || normalizeConfiguredHostname(configured) === hostname,
+  );
+  ```
+  Or — preferably — list every intended hostname explicitly (e.g. `"pi02.n8n.tw,192.168.1.66"`) instead of relying on `*`.
+- **Lesson / Rule**: Inspect the source code logic of any `ALLOWED_HOSTS`-style security feature before assuming wildcards work. Explicit host lists are safer and avoid unintended security bypasses.
+
+---
+
+## 14. LAN IP Must Be in `PI_WEB_ALLOWED_HOSTS` for Local Access
+
+- **Symptom**: Accessing pi-web via `http://192.168.1.66:30141` directly (bypassing Cloudflare) returns `403 Forbidden`, even though the container is bound to `0.0.0.0`.
+- **Root Cause**: The application's host-validation middleware checks the `Host` header. When a browser connects to `http://192.168.1.66:30141`, the `Host` header is `192.168.1.66:30141`. The IP is not in the allowed list, so the request is rejected.
+- **Fix**: Add the LAN IP to `PI_WEB_ALLOWED_HOSTS`:
+  ```yaml
+  PI_WEB_ALLOWED_HOSTS: "pi02.n8n.tw,192.168.1.66"
+  ```
+  IP literals are always accepted by `isIP()` in `lib/request-security.ts`, so this works correctly.
+- **Lesson / Rule**: When offering both direct LAN access (`http://<ip>:<port>`) and Cloudflare Tunnel access (`https://<domain>`), both the IP and the domain must be in the allowed hosts list.
+
+---
+
+## 15. Passwords with `$` Characters Require `$$` Escaping in `docker-compose.yml`
+
+- **Symptom**: A password like `pW9$kX2#mV7` is silently truncated or substituted inside the container — the application receives only `pW9` or an empty string.
+- **Root Cause**: Docker Compose treats `$VAR` and `${VAR}` inside `environment:` values as shell variable interpolation. A `$` followed by any word character is consumed as a variable reference.
+- **Fix (Option A)**: Escape every `$` as `$$` in the compose file:
+  ```yaml
+  PI_WEB_PASSWORD: "pW9$$kX2"
+  ```
+- **Fix (Option B — recommended)**: Generate passwords that contain only alphanumeric characters and avoid `$`, `&`, `!`, `%`, `^` entirely:
+  ```bash
+  openssl rand -base64 32 | tr -d '=$+/'
+  ```
+  This eliminates the escaping issue entirely and is safe to paste directly into `docker-compose.yml`.
+- **Lesson / Rule**: Prefer passwords without shell-special characters when storing them in `docker-compose.yml`. If special characters are required, always escape `$` → `$$` and verify the value inside the container with `docker exec <container> env | grep PASSWORD`.
+
+---
+
+## 16. Pi Models Config File Is `models.json`, Not `models-store.json`
+
+- **Symptom**: Custom providers and models written to `~/.pi/agent/models-store.json` do not appear in the pi-web model selector.
+- **Root Cause**: `lib/models-config-store.ts` calls `join(getAgentDir(), "models.json")` — the filename is hardcoded as `models.json`. The UI may display or generate a file called `models-store.json` for internal state, but the provider/model configuration is read exclusively from `models.json`.
+- **Fix**: Write all provider configuration to `~/.pi/agent/models.json`:
+  ```bash
+  # Wrong
+  ~/.pi/agent/models-store.json
+
+  # Correct
+  ~/.pi/agent/models.json
+  ```
+  Verify the container sees it: `docker exec pi-web cat /home/node/.pi/agent/models.json`
+- **Lesson / Rule**: Always verify the exact filename expected by the application source code (`getModelsConfigPath()` in `lib/models-config-store.ts`) rather than assuming from UI filenames or documentation. For pi-web, the authoritative models config file is always `~/.pi/agent/models.json`.
+
+---
+
+## 17. Pushing to GitHub When No SSH Key or Git Credentials Are Configured
+
+- **Symptom**: `git push origin main` fails with `fatal: could not read Username for 'https://github.com': No such device or address`. No SSH keys exist under `~/.ssh/` and `~/.gitconfig` has no credential helper.
+- **Root Cause**: A fresh server (or user account) has no GitHub authentication configured. The remote URL uses HTTPS, which requires interactive username/password or a PAT; SSH push requires a keypair registered with GitHub.
+- **Fix (Option A — PAT, quickest)**:
+  ```bash
+  git remote set-url origin https://YOUR_GITHUB_PAT@github.com/ORG/REPO.git
+  git push origin main
+  # After push, restore the clean URL to avoid storing the token in .git/config:
+  git remote set-url origin https://github.com/ORG/REPO.git
+  ```
+- **Fix (Option B — SSH key, persistent)**:
+  ```bash
+  ssh-keygen -t ed25519 -C "user@hostname" -f ~/.ssh/id_ed25519 -N ""
+  cat ~/.ssh/id_ed25519.pub   # paste into GitHub → Settings → SSH and GPG keys
+  git remote set-url origin git@github.com:ORG/REPO.git
+  git push origin main
+  ```
+- **Fix (Option C — manual upload, no credentials needed)**:
+  Open `https://github.com/ORG/REPO/edit/main/PATH/TO/FILE` in a browser, paste the updated file content, and commit directly via the GitHub web editor.
+- **Lesson / Rule**: On production servers with no interactive login, pre-configure SSH key authentication or use a short-lived PAT embedded in the remote URL (remove after push). Option C (GitHub web editor) is the fastest fallback when editing a single file.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -89,3 +89,15 @@ This matrix documents technical pitfalls, root causes, fixes, and universal guid
 - **Root Cause**: Each user-defined docker bridge network gets its own subnet. The host's address as seen from inside a container is always the network gateway (`.1` of the container's subnet), but that address changes per network.
 - **Fix**: Discover the gateway at setup time: decode the `gw` field of the default route in `cat /proc/net/route` (little-endian hex, e.g. `01001CAC` → `172.28.0.1`), or take the container's own IP and set the host part to `.1`.
 - **Lesson / Rule**: Never hardcode the bridge gateway as the only source of truth. Make it a parameter (env var / CLI flag) and document the discovery method next to it.
+
+---
+
+## 10. Secrets Typed in Chat Are Persisted in Pi Session Files
+
+- **Symptom**: Host SSH passwords, sudo passwords, or API keys typed into a pi session appear in the session JSONL file and are therefore readable by anyone with filesystem access to `~/.pi/agent/sessions/`.
+- **Root Cause**: Pi sessions are plain JSONL files (typically mode 644) mounted into the container. The agent records every user message verbatim, including secrets.
+- **Fix**:
+  1. Never type secrets in chat. Use environment variables or a local `.env` file (mode 600) loaded by a pi skill (see `docs/docker-host-bridge.md` Solution B+).
+  2. If a secret was already typed, rotate it immediately and treat the affected session file as compromised.
+  3. Consider restricting filesystem permissions on `~/.pi/agent/sessions/` (e.g., 700) and limiting who can access the host volume.
+- **Lesson / Rule**: Treat pi session files as sensitive data. Secrets must never be entered via chat; always load them from protected environment sources.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -80,3 +80,12 @@ This matrix documents technical pitfalls, root causes, fixes, and universal guid
 - **Root Cause**: Models missing from `~/.pi/agent/models.json` or misconfigured max tokens/reasoning parameters.
 - **Fix**: Registered `n8n-qwen` provider with `api: "openai-completions"`, `baseUrl: "http://192.168.1.86:30003/gw/v1"`, and `reasoning: true` under `~/.pi/agent/models.json`.
 - **Lesson / Rule**: Ensure custom OpenAI-compatible gateways match Pi's `models.json` schema and account for reasoning tokens emitted during inference.
+
+---
+
+## 9. Docker Bridge Gateway IP Is Not Fixed Across Networks
+
+- **Symptom**: An in-container SSH bridge to the host using a previously working gateway IP (e.g. `172.21.0.1`) fails after redeployment onto a different docker network.
+- **Root Cause**: Each user-defined docker bridge network gets its own subnet. The host's address as seen from inside a container is always the network gateway (`.1` of the container's subnet), but that address changes per network.
+- **Fix**: Discover the gateway at setup time: decode the `gw` field of the default route in `cat /proc/net/route` (little-endian hex, e.g. `01001CAC` → `172.28.0.1`), or take the container's own IP and set the host part to `.1`.
+- **Lesson / Rule**: Never hardcode the bridge gateway as the only source of truth. Make it a parameter (env var / CLI flag) and document the discovery method next to it.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ To update, stop the running process with `Ctrl+C` and run the same install comma
 > - 📜 **[docs/dev.log.md](./docs/dev.log.md)** — Development history & resolved pitfalls
 > - 💡 **[LESSONS_LEARNED.md](./LESSONS_LEARNED.md)** — Key technical lessons learned
 >
+> > 🔒 **Security Note: Secrets in Pi Sessions**
+> > Pi sessions are stored as JSONL files under `~/.pi/agent/sessions/...`. These files are typically world-readable (644) on the host and are mounted into the container. **Any password or secret typed in chat will be persisted verbatim in the session file**, and therefore in the container's filesystem and any backups.
+> >
+> > - Never type host credentials (SSH passwords, sudo passwords, API keys) directly in chat.
+> > - Use environment variables or a local `.env` file (mode 600) that is loaded by a pi skill, as documented in `docs/docker-host-bridge.md` (Solution B+).
+> > - If a secret has been typed in chat, rotate the secret immediately and treat the session file as compromised.
+> > - Session files are shared between pi-web and the pi TUI; treat them as sensitive data.
+>
 > **Quick Checklist for Cloudflare + Docker**:
 > 1. Set `PI_WEB_HOSTNAME: "0.0.0.0"` in container environment.
 > 2. Set `PI_WEB_NO_OPEN: "1"`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ To update, stop the running process with `Ctrl+C` and run the same install comma
 
 ## Configuration
 
+> ⚠️ **IMPORTANT: Docker & Cloudflare Tunnel Deployment**
+> If you are deploying `pi-web` inside **Docker** behind **Cloudflare Tunnel** or a reverse proxy, you **MUST READ**:
+> - 📖 **[DOCKER.md](./DOCKER.md)** — Docker architecture & volume setup
+> - 🛠️ **[INSTALL_GUIDE.md](./INSTALL_GUIDE.md)** — Step-by-step Docker & Cloudflare setup guide
+> - ⚡ **[STARTUP.md](./STARTUP.md)** — Quick start & container maintenance commands
+> - 👤 **[USER_GUIDE.md](./USER_GUIDE.md)** — Access credentials & workspace overview
+> - 📐 **[docs/SDD-docker-cloudflare-setup.md](./docs/SDD-docker-cloudflare-setup.md)** — Software design decisions & trade-offs
+> - 📜 **[docs/dev.log.md](./docs/dev.log.md)** — Development history & resolved pitfalls
+> - 💡 **[LESSONS_LEARNED.md](./LESSONS_LEARNED.md)** — Key technical lessons learned
+>
+> **Quick Checklist for Cloudflare + Docker**:
+> 1. Set `PI_WEB_HOSTNAME: "0.0.0.0"` in container environment.
+> 2. Set `PI_WEB_NO_OPEN: "1"`.
+> 3. Set `PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"` (or your Cloudflare domain).
+> 4. Basic Auth username is **fixed as `pi`**. Set `PI_WEB_PASSWORD` and escape any `$` in `docker-compose.yml` as `$$`.
+
 For port and hostname, command-line options override the corresponding environment variables. Either `--no-open` or `PI_WEB_NO_OPEN=1` disables automatic browser opening.
 
 | Option or environment variable | Purpose | Default |

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ npx @agegr/pi-web@latest
 
 - **Agent data**: Pi Web reads pi data from `~/.pi/agent` by default, including session files under `sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`. Set `PI_CODING_AGENT_DIR` to use another pi agent directory.
 - **Filesystem access**: Pi Web must be able to read the agent data directory and the working directories recorded by its sessions. Run Pi Web in the same filesystem environment as pi when sharing existing sessions.
-- **Shared configuration**: the Models panel uses pi's model, settings, and credential storage, so changes are visible to both interfaces.
-- **File access boundary**: the file browser is limited to working directories selected in Pi Web and project or session roots it already knows about; it is not a general filesystem browser.
+- **Shared configuration**: the Models panel uses pi's model, settings, and credential storage, so changes are visible to both interfaces. Custom OpenAI-compatible providers (with custom base URLs, reasoning parameters, context windows, etc.) can also be added directly to `~/.pi/agent/models.json`.
+- **File access boundary**: the file browser is limited to working directories selected in Pi Web, the current process working directory (`process.cwd()`), and project or session roots it already knows about; it is not a general filesystem browser.
 - **Git worktrees**: see [Worktrees in Pi Web](./docs/worktrees.md) for switcher visibility, worktree creation, and removal behavior.
 
 ### Downstream Session Context Menu

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ To update, stop the running process with `Ctrl+C` and run the same install comma
 > > - If a secret has been typed in chat, rotate the secret immediately and treat the session file as compromised.
 > > - Session files are shared between pi-web and the pi TUI; treat them as sensitive data.
 >
+> > ⚠️ **Container Privilege Boundary**
+> > Container `root` ≠ host `root`. The pi agent inside the container can only access its own filesystem and the volumes explicitly mounted from the host (typically `~/.pi/agent` and `/workspace`). Any operation targeting the host itself (e.g., fixing the wrt host, managing Docker, editing files outside the mounts) must be done via an SSH bridge back to the host, as documented in `docs/docker-host-bridge.md`.
+> >
+> > Running the container with `user: "0"` does **not** make it host root; it only makes files created inside the mounted volumes owned by `root:root`. After that, switching back to `user: node` will cause "Permission denied" on those files. Prefer running as an unprivileged user and use the SSH bridge skill for host operations.
+>
 > **Quick Checklist for Cloudflare + Docker**:
 > 1. Set `PI_WEB_HOSTNAME: "0.0.0.0"` in container environment.
 > 2. Set `PI_WEB_NO_OPEN: "1"`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To update, stop the running process with `Ctrl+C` and run the same install comma
 > ⚠️ **IMPORTANT: Docker & Cloudflare Tunnel Deployment**
 > If you are deploying `pi-web` inside **Docker** behind **Cloudflare Tunnel** or a reverse proxy, you **MUST READ**:
 > - 📖 **[DOCKER.md](./DOCKER.md)** — Docker architecture & volume setup
+> - 🖥️ **[docs/docker-host-bridge.md](./docs/docker-host-bridge.md)** — Running host commands from the container (ssh2 bridge / pi skill, no docker.sock mount)
 > - 🛠️ **[INSTALL_GUIDE.md](./INSTALL_GUIDE.md)** — Step-by-step Docker & Cloudflare setup guide
 > - ⚡ **[STARTUP.md](./STARTUP.md)** — Quick start & container maintenance commands
 > - 👤 **[USER_GUIDE.md](./USER_GUIDE.md)** — Access credentials & workspace overview

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,8 +92,8 @@ npx @agegr/pi-web@latest
 
 - **智能体数据**：Pi Web 默认读取 `~/.pi/agent` 下的 pi 数据，包括 `sessions/<编码后的工作目录>/<时间戳>_<uuid>.jsonl` 中的会话文件。可通过 `PI_CODING_AGENT_DIR` 指定其他 pi agent 目录。
 - **文件系统访问**：Pi Web 必须能读取智能体数据目录及会话记录中的工作目录。与现有 pi 会话共用数据时，请让 Pi Web 运行在与 pi 相同的文件系统环境中。
-- **共享配置**：模型面板使用 pi 的模型、设置和凭据存储，因此两种界面都能看到相关更改。
-- **文件访问边界**：文件浏览器仅能访问在 Pi Web 中选择过的工作目录，以及它已识别的项目或会话根目录；它不是通用的文件系统浏览器。
+- **共享配置**：模型面板使用 pi 的模型、设置和凭据存储，因此两种界面都能看到相关更改。自定义兼容 OpenAI 接口的 Provider（自定义 baseUrl、Reasoning 参数、上下文窗口大小等）也可直接在 `~/.pi/agent/models.json` 中配置。
+- **文件访问边界**：文件浏览器仅能访问在 Pi Web 中选择过的工作目录、当前进程的初始工作目录 (`process.cwd()`)，以及它已识别的项目或会话根目录；它不是通用的文件系统浏览器。
 - **Git worktree**：切换器何时显示、如何创建 worktree，以及删除会产生什么影响，见 [Pi Web 里的 Worktree](./docs/worktrees.zh-CN.md)。
 
 ## 开发

--- a/STARTUP.md
+++ b/STARTUP.md
@@ -1,0 +1,34 @@
+# pi-web Quick Startup & Maintenance Guide
+
+## Quick Operational Commands
+
+### Start Service
+```bash
+cd /home/wrt/AG/SystemRepair/pi-web
+docker compose up -d
+```
+
+### Build & Re-deploy
+```bash
+docker compose up -d --build
+```
+
+### View Live Logs
+```bash
+docker compose logs -f
+```
+
+### Stop Service
+```bash
+docker compose down
+```
+
+### Check Container Health
+```bash
+docker compose ps
+```
+
+### Verify Container Environment
+```bash
+docker compose exec pi-web printenv PI_WEB_PASSWORD
+```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Accessing the Web UI
 
-1. Open your browser and navigate to `https://pi01.xxx.com` (or `http://127.0.0.1:30141` locally).
+1. Open your browser and navigate to `https://pi06.n8n.tw` (or `http://192.168.1.61:30141` locally).
 2. When prompted for authentication:
    - **Username**: `pi` *(The username is fixed by upstream pi-web authentication)*
    - **Password**: `your_complex_password_here`

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,16 @@
+# pi-web User Guide
+
+## Accessing the Web UI
+
+1. Open your browser and navigate to `https://pi01.xxx.com` (or `http://127.0.0.1:30141` locally).
+2. When prompted for authentication:
+   - **Username**: `pi` *(The username is fixed by upstream pi-web authentication)*
+   - **Password**: `your_complex_password_here`
+
+---
+
+## Workspace & Sessions
+
+- All sessions and agent data are persisted in `${HOME}/.pi/agent` on the host machine.
+- The default project workspace inside the UI is mapped to `/workspace` (`/home/wrt/AG/SystemRepair` on the host).
+- Additional host directories can be mounted into `docker-compose.yml` under `volumes:` to allow the agent to operate on multiple projects.

--- a/connect-cloudflared.sh
+++ b/connect-cloudflared.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# connect-cloudflared.sh — Ensure cloudflared can reach pi-web via Docker DNS
+#
+# Cloudflare Tunnel (beautiful_ardinghelli) runs on the default "bridge"
+# network and cannot reach host-published ports via hairpin NAT on this
+# machine. This script connects cloudflared to pi-web's compose network
+# so it can resolve http://pi-web:30141 via Docker embedded DNS.
+#
+# Cloudflare Dashboard origin URL for pi06.n8n.tw must be: http://pi-web:30141
+#
+# This script is idempotent — safe to run multiple times.
+
+set -e
+
+CLOUDFLARED_CONTAINER="beautiful_ardinghelli"
+PIWEB_NETWORK="pi-web_default"
+
+# Check if already connected
+if docker inspect "$CLOUDFLARED_CONTAINER" \
+    --format '{{range $k, $_ := .NetworkSettings.Networks}}{{$k}} {{end}}' \
+    | grep -q "$PIWEB_NETWORK"; then
+  echo "✅ $CLOUDFLARED_CONTAINER is already connected to $PIWEB_NETWORK"
+else
+  echo "Connecting $CLOUDFLARED_CONTAINER to $PIWEB_NETWORK ..."
+  docker network connect "$PIWEB_NETWORK" "$CLOUDFLARED_CONTAINER"
+  echo "✅ Connected"
+fi
+
+# Verify connectivity
+echo "Testing: cloudflared → pi-web:30141 ..."
+docker run --rm --network "$PIWEB_NETWORK" alpine/curl \
+  -s -o /dev/null -w "HTTP %{http_code}\n" --connect-timeout 3 \
+  -H "Host: pi06.n8n.tw" http://pi-web:30141/
+echo "Done."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+# pi-web — local Docker Compose (not upstream; local addition)
+#
+#   docker compose up -d --build     # build + start
+#   docker compose logs -f           # watch logs
+#   docker compose down              # stop
+#
+# Then open http://127.0.0.1:30141
+
+services:
+  pi-web:
+    build: .
+    image: tigerai/pi-web:local
+    container_name: pi-web
+    ports:
+      - "30141:30141"
+    environment:
+      # Required: container must bind all interfaces or port mapping fails.
+      # The app still only answers requests from the docker-proxy bridge.
+      PI_WEB_HOSTNAME: "0.0.0.0"
+      # No auto browser-open (headless container).
+      PI_WEB_NO_OPEN: "1"
+      # Uncomment and set a LONG random password if you ever expose this
+      # beyond your own machine (LAN, tunnel, ...). Never reuse a real password.
+      # PI_WEB_PASSWORD: "replace-with-long-random-password"
+      # If fronting with a reverse proxy / Cloudflare Tunnel, add the exact
+      # public hostname(s) here, comma-separated:
+      # PI_WEB_ALLOWED_HOSTS: "pi.example.com"
+    volumes:
+      # pi config, sessions, auth (shared with the TUI pi on this machine)
+      - 'C:/Users/yesin/.pi/agent:/home/node/.pi/agent'
+      # The project(s) the agent should work on. Change to whatever you want
+      # pi to operate on; add more mounts as needed.
+      - 'C:/Tools/@@@@@@Antigravity/TigerAI-Methodology:/workspace'
+    working_dir: /workspace
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,14 @@ services:
       PI_WEB_NO_OPEN: "1"
       # Allowed reverse proxy host (Cloudflare Tunnel)
       PI_WEB_ALLOWED_HOSTS: "pi09.n8n.tw"
-      # Secure complex password for authentication ($ escaped as $$ for Compose)
-      PI_WEB_PASSWORD: "pW9$$kX2#mV7!zL4@qN8&jR5*tC1%yB3^uK9"
+      # Basic Auth 密碼。**不要寫死在這裡** —— 這個 repo 是公開的，寫進來的值
+      # 等於公開，而且 git 歷史會永久保留。改從環境或 .env 讀：
+      #
+      #   echo "PI_WEB_PASSWORD=$(openssl rand -base64 30 | tr -d '/+=' | head -c 32)" >> .env
+      #
+      # 沒設的話這裡會是空字串，pi-web 會以無認證啟動 —— 只有在容器僅綁
+      # 127.0.0.1 且你信任本機所有行程時才可接受。
+      PI_WEB_PASSWORD: "${PI_WEB_PASSWORD:?請在 .env 設定 PI_WEB_PASSWORD}"
     volumes:
       # pi config, sessions, auth (shared with host)
       - '${HOME}/.pi/agent:/home/node/.pi/agent'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,14 @@
-# pi-web — Docker Compose
+# pi-web — local Docker Compose (not upstream; local addition)
 #
-#   1. docker compose up -d --build          # 首次 build + 啟動
-#   2. docker compose logs -f                # 看 log
-#   3. docker compose down                   # 停止
+#   docker compose up -d --build     # build + start
+#   docker compose logs -f           # watch logs
+#   docker compose down              # stop
 #
-# 然後開 http://127.0.0.1:30141 或 https://pi01.xxx.com
+# Then open http://192.168.1.61:30141 or https://pi06.n8n.tw
+#
+# IMPORTANT: After docker compose up, run the post-start script to connect
+# cloudflared to this network so it can reach http://pi-web:30141:
+#   ./connect-cloudflared.sh
 
 services:
   pi-web:
@@ -18,14 +22,14 @@ services:
       PI_WEB_HOSTNAME: "0.0.0.0"
       # No auto browser-open (headless container)
       PI_WEB_NO_OPEN: "1"
-      # Allowed reverse proxy host (Cloudflare Tunnel)
-      PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"
+      # Allowed reverse proxy host
+      PI_WEB_ALLOWED_HOSTS: "pi06.n8n.tw"
       # Secure complex password for authentication ($ escaped as $$ for Compose)
-      PI_WEB_PASSWORD: "your_complex_password_here"
+      PI_WEB_PASSWORD: "pW9$$kX2#mV7!zL4@qN8&jR5*tC1%yB3^uK9"
     volumes:
       # pi config, sessions, auth (shared with host)
       - '${HOME}/.pi/agent:/home/node/.pi/agent'
       # The project directory for pi agent to operate on
-      - '/home/wrt/AG/SystemRepair:/workspace'
+      - '/home/wrt/AG/hermes:/workspace'
     working_dir: /workspace
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,31 @@
 # pi-web — Docker Compose
 #
-#   1. cp .pi-web.env.example .pi-web.env    # 編輯 .pi-web.env（密碼 + 公開域名）
-#   2. 下面的 volumes 改成你 host 的路徑
-#   3. docker compose up -d --build          # 首次 build + 啟動
+#   1. docker compose up -d --build          # 首次 build + 啟動
+#   2. docker compose logs -f                # 看 log
+#   3. docker compose down                   # 停止
 #
-#   docker compose up -d                     # 啟動（映像已 build）
-#   docker compose logs -f                   # 看 log（出現 Ready 即可用）
-#   docker compose down                      # 停止
-#
-# 然後開 http://127.0.0.1:30141
-#
-# 密碼與公開域名放 .pi-web.env（git-ignored，絕不外流）；缺這個檔案時
-# compose 會明確報 "env file not found"，不會帶著不安全的預設悄悄跑起來。
+# 然後開 http://127.0.0.1:30141 或 https://pi01.xxx.com
 
 services:
   pi-web:
     build: .
     image: tigerai/pi-web:local
     container_name: pi-web
-    env_file:
-      # Operator values: PI_WEB_PASSWORD, PI_WEB_ALLOWED_HOSTS
-      - .pi-web.env
     ports:
-      # 要 LAN 存取改成 "0.0.0.0:30141:30141"（且 .pi-web.env 務必設密碼）
       - "30141:30141"
     environment:
-      # Required: container must bind all interfaces or port mapping fails.
-      # The app still only answers requests from the docker-proxy bridge.
+      # Required: container must bind all interfaces inside container network
       PI_WEB_HOSTNAME: "0.0.0.0"
-      # No auto browser-open (headless container).
+      # No auto browser-open (headless container)
       PI_WEB_NO_OPEN: "1"
+      # Allowed reverse proxy host (Cloudflare Tunnel)
+      PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"
+      # Secure complex password for authentication ($ escaped as $$ for Compose)
+      PI_WEB_PASSWORD: "your_complex_password_here"
     volumes:
-      # pi config, sessions, auth (shared with the TUI pi on this machine).
-      # CHANGE to your host path:
-      - 'C:/Users/yesin/.pi/agent:/home/node/.pi/agent'
-      # The project(s) the agent should work on. CHANGE to whatever you want
-      # pi to operate on; add more mounts as needed.
-      - 'C:/Tools/@@@@@@Antigravity/TigerAI-Methodology:/workspace'
+      # pi config, sessions, auth (shared with host)
+      - '${HOME}/.pi/agent:/home/node/.pi/agent'
+      # The project directory for pi agent to operate on
+      - '/home/wrt/AG/SystemRepair:/workspace'
     working_dir: /workspace
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 #   docker compose logs -f           # watch logs
 #   docker compose down              # stop
 #
-# Then open http://192.168.1.61:30141 or https://pi06.n8n.tw
+# Then open http://127.0.0.1:30141 or https://pi09.n8n.tw
 #
 # IMPORTANT: After docker compose up, run the post-start script to connect
 # cloudflared to this network so it can reach http://pi-web:30141:
@@ -22,14 +22,14 @@ services:
       PI_WEB_HOSTNAME: "0.0.0.0"
       # No auto browser-open (headless container)
       PI_WEB_NO_OPEN: "1"
-      # Allowed reverse proxy host
-      PI_WEB_ALLOWED_HOSTS: "pi06.n8n.tw"
+      # Allowed reverse proxy host (Cloudflare Tunnel)
+      PI_WEB_ALLOWED_HOSTS: "pi09.n8n.tw"
       # Secure complex password for authentication ($ escaped as $$ for Compose)
       PI_WEB_PASSWORD: "pW9$$kX2#mV7!zL4@qN8&jR5*tC1%yB3^uK9"
     volumes:
       # pi config, sessions, auth (shared with host)
       - '${HOME}/.pi/agent:/home/node/.pi/agent'
       # The project directory for pi agent to operate on
-      - '/home/wrt/AG/hermes:/workspace'
+      - '/home/wrt/AG/SystemRepair:/workspace'
     working_dir: /workspace
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,28 @@
-# pi-web — local Docker Compose (not upstream; local addition)
+# pi-web — Docker Compose
 #
-#   docker compose up -d --build     # build + start
-#   docker compose logs -f           # watch logs
-#   docker compose down              # stop
+#   1. cp .pi-web.env.example .pi-web.env    # 編輯 .pi-web.env（密碼 + 公開域名）
+#   2. 下面的 volumes 改成你 host 的路徑
+#   3. docker compose up -d --build          # 首次 build + 啟動
 #
-# Then open http://127.0.0.1:30141
+#   docker compose up -d                     # 啟動（映像已 build）
+#   docker compose logs -f                   # 看 log（出現 Ready 即可用）
+#   docker compose down                      # 停止
+#
+# 然後開 http://127.0.0.1:30141
+#
+# 密碼與公開域名放 .pi-web.env（git-ignored，絕不外流）；缺這個檔案時
+# compose 會明確報 "env file not found"，不會帶著不安全的預設悄悄跑起來。
 
 services:
   pi-web:
     build: .
     image: tigerai/pi-web:local
     container_name: pi-web
+    env_file:
+      # Operator values: PI_WEB_PASSWORD, PI_WEB_ALLOWED_HOSTS
+      - .pi-web.env
     ports:
+      # 要 LAN 存取改成 "0.0.0.0:30141:30141"（且 .pi-web.env 務必設密碼）
       - "30141:30141"
     environment:
       # Required: container must bind all interfaces or port mapping fails.
@@ -19,16 +30,11 @@ services:
       PI_WEB_HOSTNAME: "0.0.0.0"
       # No auto browser-open (headless container).
       PI_WEB_NO_OPEN: "1"
-      # Uncomment and set a LONG random password if you ever expose this
-      # beyond your own machine (LAN, tunnel, ...). Never reuse a real password.
-      # PI_WEB_PASSWORD: "replace-with-long-random-password"
-      # If fronting with a reverse proxy / Cloudflare Tunnel, add the exact
-      # public hostname(s) here, comma-separated:
-      # PI_WEB_ALLOWED_HOSTS: "pi.example.com"
     volumes:
-      # pi config, sessions, auth (shared with the TUI pi on this machine)
+      # pi config, sessions, auth (shared with the TUI pi on this machine).
+      # CHANGE to your host path:
       - 'C:/Users/yesin/.pi/agent:/home/node/.pi/agent'
-      # The project(s) the agent should work on. Change to whatever you want
+      # The project(s) the agent should work on. CHANGE to whatever you want
       # pi to operate on; add more mounts as needed.
       - 'C:/Tools/@@@@@@Antigravity/TigerAI-Methodology:/workspace'
     working_dir: /workspace

--- a/docs/DOCKER_CLOUDFLARE_CHECKLIST.md
+++ b/docs/DOCKER_CLOUDFLARE_CHECKLIST.md
@@ -1,0 +1,214 @@
+# pi-web Docker 與 Cloudflare Tunnel 檢查核對清單
+
+> 適用情境：另一台機器已安裝 Docker，但 `https://<網域>` 無法連到 pi-web。
+>
+> Docker 只負責執行容器；要從 Internet 連入，還必須有正常的 pi-web、Cloudflare Tunnel、Public Hostname 與網路路徑。
+
+## 先填寫本機資料
+
+- [ ] 公開網域：`________________________`（例：`pi02.example.com`）
+- [ ] pi-web 主機 LAN IP：`________________________`（例：`192.168.1.87`）
+- [ ] pi-web port：`30141`
+- [ ] cloudflared 跑在哪台主機：`________________________`
+- [ ] Cloudflare Tunnel 名稱：`________________________`
+
+## 1. Docker 是否正常
+
+```bash
+docker --version
+docker compose version
+docker info >/dev/null && echo "Docker OK"
+```
+
+- [ ] 三個指令都成功
+- [ ] 執行帳號有權限操作 Docker
+
+若出現 `permission denied`，先處理 Docker socket 權限；這不是 Cloudflare 問題。
+
+## 2. pi-web 容器是否啟動
+
+在 `pi-web` 專案目錄執行：
+
+```bash
+docker compose ps
+docker compose logs --tail=100 pi-web
+```
+
+- [ ] `pi-web` 狀態是 `Up` 或 `running`
+- [ ] 沒有持續重啟（Restarting）
+- [ ] log 沒有啟動失敗、port 衝突或權限錯誤
+- [ ] port 顯示類似 `0.0.0.0:30141->30141/tcp`
+
+若未啟動：
+
+```bash
+docker compose up -d --build
+docker compose logs --tail=100 pi-web
+```
+
+## 3. pi-web 環境變數是否正確
+
+以下指令只檢查變數是否存在，不輸出密碼內容：
+
+```bash
+docker compose exec pi-web sh -lc '
+  printf "PI_WEB_HOSTNAME=%s\n" "$PI_WEB_HOSTNAME"
+  printf "PI_WEB_ALLOWED_HOSTS=%s\n" "$PI_WEB_ALLOWED_HOSTS"
+  if [ -n "$PI_WEB_PASSWORD" ]; then echo "PI_WEB_PASSWORD=SET"; else echo "PI_WEB_PASSWORD=MISSING"; fi
+'
+```
+
+- [ ] `PI_WEB_HOSTNAME=0.0.0.0`
+- [ ] `PI_WEB_ALLOWED_HOSTS` 包含公開網域（不含 `https://` 和路徑）
+- [ ] 顯示 `PI_WEB_PASSWORD=SET`
+
+修改 Compose 或 `.pi-web.env` 後必須重建容器：
+
+```bash
+docker compose up -d --force-recreate
+```
+
+## 4. 先測試 pi-web 本機服務
+
+將下方網域換成實際公開網域：
+
+```bash
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' \
+  -H 'Host: pi02.example.com' \
+  http://127.0.0.1:30141/
+```
+
+判讀：
+
+- [ ] `401`：正常，服務已到達且 Basic Auth 正在保護頁面
+- [ ] `200`：服務可達，但請確認是否有啟用認證
+- [ ] `403`：`PI_WEB_ALLOWED_HOSTS` 沒包含公開網域
+- [ ] `Connection refused`：容器未啟動、未發布 port，或程式未監聽 `0.0.0.0`
+- [ ] Timeout：檢查主機防火牆、路由與 IP
+
+也可確認 port：
+
+```bash
+ss -ltn | grep ':30141'
+```
+
+## 5. 確認 Cloudflare Tunnel 的部署方式
+
+只能至少符合下面一種架構。
+
+### A. cloudflared 在同一台機器
+
+```bash
+docker ps --format '{{.Names}}\t{{.Image}}' | grep cloudflared
+```
+
+- [ ] cloudflared 容器正在運行
+- [ ] Tunnel origin 可設定為 `http://<本機 LAN IP>:30141`
+- [ ] 若兩個容器加入同一個 Docker network，也可使用 `http://pi-web:30141`
+
+### B. cloudflared 在另一台中央主機
+
+在 **cloudflared 所在主機** 測試：
+
+```bash
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' \
+  -H 'Host: pi02.example.com' \
+  http://192.168.1.87:30141/
+```
+
+- [ ] 回傳 `401` 或 `200`
+- [ ] 使用的是 pi-web 主機的正確 LAN IP，不是舊機器 IP
+- [ ] 兩台機器之間的 VLAN、防火牆或路由允許 TCP 30141
+
+如果這一步不通，Cloudflare 一定也不會通；先修內網路徑。
+
+## 6. Cloudflare Public Hostname 是否存在
+
+在 Cloudflare Zero Trust Dashboard 的 Tunnel 設定中核對：
+
+- [ ] Tunnel 狀態為 `HEALTHY`
+- [ ] Public Hostname 是正確網域，例如 `pi02.example.com`
+- [ ] Service Type 是 `HTTP`
+- [ ] Service URL 是正確來源，例如 `http://192.168.1.87:30141`
+- [ ] 沒有誤用 `https://` 連到只提供 HTTP 的 30141
+- [ ] 每台機器使用不同網域，或已有明確的路由規則
+
+注意：複製 Docker Compose 到新機器，不會自動新增或修改 Cloudflare Public Hostname。
+
+## 7. cloudflared 是否收到最新設定
+
+在 cloudflared 所在主機執行：
+
+```bash
+docker logs --tail=200 cloudflare 2>&1 | \
+  grep -E 'Registered tunnel connection|Updated to new configuration|Unable to reach the origin|error='
+```
+
+如果容器名稱不是 `cloudflare`，先用 `docker ps` 找出名稱再替換。
+
+- [ ] 出現 `Registered tunnel connection`
+- [ ] 最新 configuration 包含新網域與正確 IP/port
+- [ ] 沒有 `Unable to reach the origin service`
+- [ ] 若設定沒有更新，安全地重啟 cloudflared 容器後再查 log
+
+請勿把 Tunnel token、完整啟動命令或未遮罩的 log 貼到公開聊天室。
+
+## 8. 從外部測試 DNS 與 HTTPS
+
+最好使用手機行動網路或不在同一 LAN 的設備：
+
+```bash
+nslookup pi02.example.com
+curl -I https://pi02.example.com/
+```
+
+- [ ] DNS 查詢成功
+- [ ] HTTPS 沒有憑證錯誤
+- [ ] `401` 代表已成功到達 pi-web 登入驗證
+- [ ] `403` 優先檢查 `PI_WEB_ALLOWED_HOSTS`
+- [ ] Cloudflare `502` 優先檢查 origin IP、port、容器狀態與防火牆
+- [ ] Cloudflare `1033` 優先檢查 Tunnel 是否在線
+
+## 9. 登入與 Agent 資料
+
+- [ ] Basic Auth 使用者名稱固定為 `pi`
+- [ ] 使用該機器設定的 `PI_WEB_PASSWORD`
+- [ ] 宿主機 `~/.pi/agent` 存在
+- [ ] Compose 已掛載至 `/home/node/.pi/agent`
+- [ ] 專案目錄已掛載至容器內 `/workspace`（或自訂工作目錄）
+
+```bash
+docker inspect pi-web --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'
+```
+
+宿主機不需要另外安裝 `pi` CLI；Pi Agent SDK 已包含在 pi-web 容器套件中。宿主機的 `~/.pi/agent` 是設定、認證及 session 資料，不代表已安裝 CLI。
+
+## 回報結果範本
+
+請把以下結果回報給管理者，所有 token、密碼與 API key 必須遮罩：
+
+```text
+公開網域：
+pi-web 主機 IP：
+cloudflared 主機 IP：
+docker compose ps：PASS / FAIL
+本機 curl 狀態碼：
+cloudflared 主機 curl 狀態碼：
+Tunnel 狀態：HEALTHY / DOWN / UNKNOWN
+Public Hostname origin：
+外部 curl 狀態碼：
+相關錯誤（已遮罩敏感資料）：
+```
+
+## 快速判斷順序
+
+```text
+容器 Up？
+  → 本機 curl 通？
+    → cloudflared 主機 curl 到 origin 通？
+      → Tunnel Healthy？
+        → Public Hostname 指向正確 IP:30141？
+          → 外部 DNS/HTTPS 通？
+```
+
+不要跳步：第一個失敗的步驟，通常就是問題所在。

--- a/docs/SDD-docker-cloudflare-setup.md
+++ b/docs/SDD-docker-cloudflare-setup.md
@@ -24,9 +24,16 @@
 - **Choice**: Write `PI_WEB_PASSWORD: "your_complex_password_here"`.
 - **Rationale**: Docker Compose treats single `$` in environment strings as variable interpolation (e.g. `$kX2`). Escaping to `$$` instructs Compose to output a literal `$` into container environment variables.
 
+### Decision 5: Cloudflare Tunnel Origin URL — Container DNS vs Host IP
+- **Choice**: Set Cloudflare Dashboard origin URL to `http://pi-web:30141` (Docker container DNS) instead of `http://<host-LAN-IP>:30141`.
+- **Rationale**: When `cloudflared` runs inside a Docker container, it cannot reliably reach host-published ports via the host's LAN IP or Docker bridge gateway (`172.17.0.1`) due to **hairpin NAT** failures. This is host-specific — some machines allow it, others silently drop the packets (`i/o timeout`). Using Docker's embedded DNS on a shared user-defined network (`pi-web_default`) provides direct container-to-container routing with no hairpin NAT dependency.
+- **Trade-off**: Requires `cloudflared` to be connected to the same Docker network as `pi-web`. Since `cloudflared` is typically a standalone container (not in the same compose file), the network connection must be re-applied after container restarts (see `connect-cloudflared.sh` and `@reboot` cron job).
+
 ---
 
 ## 3. Known Limitations
 
 - Basic Auth in `pi-web` does not enforce rate-limiting or MFA.
 - HTTPS encryption must be terminated at Cloudflare / Edge proxy before forwarding to localhost HTTP port `30141`.
+- Docker hairpin NAT behavior varies across hosts. Always verify container-to-host connectivity before assuming `http://<host-IP>:<port>` works from inside a container.
+- The `docker network connect` linking `cloudflared` to `pi-web_default` is a runtime operation that does not persist across container restarts. An automated reconnection mechanism (cron job or startup script) is required.

--- a/docs/SDD-docker-cloudflare-setup.md
+++ b/docs/SDD-docker-cloudflare-setup.md
@@ -1,0 +1,32 @@
+# Software Design Decision: Docker & Cloudflare Setup for pi-web
+
+## 1. Problem Statement
+
+`pi-web` is a local browser UI for the `pi` coding agent. Running `pi-web` inside a Docker container behind Cloudflare Tunnel (or reverse proxies) introduces specific network binding, authentication, host header validation, and environment variable parsing challenges.
+
+---
+
+## 2. Decision & Trade-offs
+
+### Decision 1: Binding `0.0.0.0` inside Container vs `127.0.0.1`
+- **Choice**: Set `PI_WEB_HOSTNAME: "0.0.0.0"` in `docker-compose.yml`.
+- **Trade-off**: Inside containerized network bridges, binding only to loopback `127.0.0.1` prevents Docker's proxy bridge from forwarding port `30141`. The container must bind `0.0.0.0`, while host-level port binding (`127.0.0.1:30141:30141`) limits access to localhost and tunnel proxies.
+
+### Decision 2: Hardcoded Username (`pi`) in Upstream Web Auth
+- **Choice**: Enforce Basic Auth username `pi`.
+- **Rationale**: `pi-web` implements authentication in `lib/web-auth.ts` with `export const PI_WEB_AUTH_USERNAME = "pi";`. The password is configured dynamically via `PI_WEB_PASSWORD`. Attempting to log in with other usernames (e.g. `admin`) fails validation by design.
+
+### Decision 3: Host Header Allow-list (`PI_WEB_ALLOWED_HOSTS`)
+- **Choice**: Explicitly set `PI_WEB_ALLOWED_HOSTS: "pi01.xxx.com"`.
+- **Rationale**: When Cloudflare Tunnel forwards HTTPS requests for `https://pi01.xxx.com`, Next.js middleware verifies incoming `Host` headers. If `pi01.xxx.com` is not in `PI_WEB_ALLOWED_HOSTS`, requests are rejected with HTTP 403 Forbidden.
+
+### Decision 4: Escaping `$` in `docker-compose.yml` (`$$`)
+- **Choice**: Write `PI_WEB_PASSWORD: "your_complex_password_here"`.
+- **Rationale**: Docker Compose treats single `$` in environment strings as variable interpolation (e.g. `$kX2`). Escaping to `$$` instructs Compose to output a literal `$` into container environment variables.
+
+---
+
+## 3. Known Limitations
+
+- Basic Auth in `pi-web` does not enforce rate-limiting or MFA.
+- HTTPS encryption must be terminated at Cloudflare / Edge proxy before forwarding to localhost HTTP port `30141`.

--- a/docs/dev.log.md
+++ b/docs/dev.log.md
@@ -4,6 +4,19 @@ This document records the installation process, issues encountered, and resoluti
 
 ---
 
+## [2026-08-16 14:28] - pi06: Cloudflare Tunnel Fixed via Container DNS
+- **Symptom**: `https://pi06.n8n.tw/` timed out. `cloudflared` logs showed `dial tcp 192.168.1.61:30141: i/o timeout` and `dial tcp 172.17.0.1:30141: i/o timeout`.
+- **Root Cause**: Docker hairpin NAT failure — `cloudflared` container on `bridge` network cannot reach host-published ports via host LAN IP or docker0 gateway on this specific host.
+- **Fix**: Connected `cloudflared` to `pi-web_default` network (`docker network connect pi-web_default beautiful_ardinghelli`), then changed Cloudflare Dashboard origin URL to `http://pi-web:30141` (Docker embedded DNS).
+- **Persistence**: Created `connect-cloudflared.sh` (idempotent reconnection script) + `@reboot` cron job.
+- **Result**: `https://pi06.n8n.tw/` now returns HTTP 401 (Basic Auth prompt) correctly.
+
+## [2026-08-16 14:00] - pi06: Hairpin NAT Diagnosis
+- Tested from bridge-network container: `http://192.168.1.61:30141` → timeout, `http://172.17.0.1:30141` → timeout, `http://172.17.0.5:30141` (pi-web bridge IP) → 401 OK, `http://pi-web:30141` (on shared network) → 200 OK.
+- Confirmed this is host-specific: pi08 (`192.168.1.62`) works fine with host LAN IP; pi06 does not.
+
+---
+
 ## [2026-08-16 12:40] - Successful Verification
 - Tested HTTP Basic Auth with domain `pi01.xxx.com` using username `pi` and password `your_complex_password_here`.
 - Verified HTTP 200 OK response.

--- a/docs/dev.log.md
+++ b/docs/dev.log.md
@@ -1,0 +1,23 @@
+# Development Log
+
+This document records the installation process, issues encountered, and resolution steps in reverse chronological order.
+
+---
+
+## [2026-08-16 12:40] - Successful Verification
+- Tested HTTP Basic Auth with domain `pi01.xxx.com` using username `pi` and password `your_complex_password_here`.
+- Verified HTTP 200 OK response.
+- Verified Host Header security: Requests with invalid Host headers (e.g. `evil.com`) correctly return `403 Forbidden`.
+
+## [2026-08-16 12:23] - Dead End: Basic Auth Failure with Username `admin`
+- **Symptom**: `curl` with Basic Auth using `admin:password` returned `401 Unauthorized`.
+- **Investigation**: Inspected `lib/web-auth.ts` source code and discovered `export const PI_WEB_AUTH_USERNAME = "pi";`.
+- **Fix**: Changed authentication username to `pi`.
+
+## [2026-08-16 12:03] - Dead End: Docker Compose Environment Variable Warning
+- **Symptom**: `docker compose up` produced `WARN[0000] The "kX2" variable is not set. Defaulting to a blank string.`
+- **Investigation**: Password string contained `$`, which Docker Compose treated as an unassigned environment variable reference.
+- **Fix**: Replaced `$` with `$$` in `docker-compose.yml` (`your_complex_password_here`).
+
+## [2026-08-16 11:55] - Initial Setup Request
+- Initialized Docker deployment of `pi-web` with `PI_WEB_NO_OPEN=1`, `PI_WEB_ALLOWED_HOSTS=pi01.xxx.com`, and high-entropy password requirement.

--- a/docs/docker-host-bridge.md
+++ b/docs/docker-host-bridge.md
@@ -1,0 +1,130 @@
+# Docker 容器內的 agent 控制 host — 權限問題與繞過方法
+
+> 背景：pi-web 的 pi agent 跑在容器內（`node:22-alpine`）。agent 的 bash tool 與檔案操作
+> 預設只能看到「容器世界」——當任務要動到 host（執行 host 指令、讀 host 檔案、管 host 的
+> docker）時，會碰到三面權限牆。本文是實測過的一套繞過方法。
+
+## 三面權限牆（症狀）
+
+| # | 症狀 | 原因 |
+|---|---|---|
+| 1 | bash tool 報 cwd 不存在、指令起不來 | harness 的工作目錄是 **host 路徑**（如 `/home/wrt/TigerAI`），容器內沒有這個路徑 |
+| 2 | `command not found: ssh / curl` 等 | alpine 映像只有 `ash` + node，沒有 bash/ssh/curl 等 host 常備二進位（bash tool 本身可借 ash 跑，POSIX 指令沒問題） |
+| 3 | 看不到 host 檔案 | 容器只看得到掛進去的 volumes |
+
+## 解法 A：path bridge — 容器內 symlink（解牆 #1）
+
+工作目錄已掛載（host `/home/wrt/TigerAI` → 容器 `/workspace`）。在**容器內**為 host 路徑
+建 symlink，讓 harness 的 cwd 解析成功：
+
+```bash
+# 在 host 上執行
+sudo docker exec -u root pi-web sh -c \
+  'mkdir -p /home/wrt && ln -sfn /workspace /home/wrt/TigerAI'
+```
+
+⚠️ 這個 symlink 存在容器的 **writable layer** — `docker compose down && up`（recreate）
+就會消失。兩選項：
+
+1. 每次 rebuild 後重跑上面那條指令（最快）
+2. 燒進 Dockerfile（路徑固定時）：
+
+   ```dockerfile
+   RUN mkdir -p /home/wrt && ln -sfn /workspace /home/wrt/TigerAI
+   ```
+
+## 解法 B：ssh2 bridge — 容器內執行 host 指令（解牆 #2、#3，推薦）
+
+容器有 Node 但沒有 ssh 二進位。裝 pure-JS 的 `ssh2`（無 native 編譯，alpine 直接可用）：
+
+```bash
+mkdir -p /workspace/sshbridge && cd /workspace/sshbridge
+npm install ssh2
+```
+
+> 放在 `/workspace`（掛載卷）才能活過容器重建；**不要放容器 `/tmp`**（recreate 即失）。
+
+`exec.js`（密碼一律由環境變數讀入，**不寫進檔案、不 commit**）：
+
+```js
+// 用法（在容器內）:
+//   PI_HOST_SSH_HOST=<host IP> PI_HOST_SSH_USER=<user> PI_HOST_SSH_PASS=<pass> \
+//     node exec.js 'whoami'
+//   PI_HOST_SUDO_PASS=<sudo pass> node exec.js 'SUDO: systemctl status docker'
+const { Client } = require('ssh2');
+const cmd = process.argv[2];
+if (!cmd) { console.error("usage: node exec.js '<cmd>' | 'SUDO: <cmd>'"); process.exit(2); }
+
+const host = process.env.PI_HOST_SSH_HOST;
+const user = process.env.PI_HOST_SSH_USER;
+const pass = process.env.PI_HOST_SSH_PASS;
+const sudo = process.env.PI_HOST_SUDO_PASS;
+
+const isSudo = cmd.startsWith('SUDO: ');
+const real = isSudo ? `echo ${sudo} | sudo -S -p '' ${cmd.slice(6)}` : cmd;
+
+const con = new Client();
+con.on('ready', () => {
+  con.exec(real, (err, stream) => {
+    if (err) { console.error(err.message); process.exit(1); }
+    stream.on('close', (code) => process.exit(code ?? 0));
+    stream.on('data', (d) => process.stdout.write(d));
+    stream.stderr.on('data', (d) => process.stderr.write(d));
+  });
+}).on('error', (e) => { console.error('ssh error:', e.message); process.exit(1); })
+  .connect({ host, port: 22, username: user, password: pass });
+```
+
+用法：
+
+```bash
+cd /workspace/sshbridge
+PI_HOST_SSH_HOST=<host LAN IP> PI_HOST_SSH_USER=<user> PI_HOST_SSH_PASS=<pass> \
+  node exec.js 'whoami'
+```
+
+重點：
+
+- **比掛 docker.sock 攻擊面小**：docker.sock = host 完整 root；ssh bridge 只是普通
+  帳號，必要時才 `SUDO:` 升級
+- **長工作一定要脫管**，否則 SSH channel 會掛到工作結束、bridge 逾時：
+
+  ```bash
+  node exec.js 'cd /path && setsid nohup bash job.sh > job.log 2>&1 < /dev/null & disown'
+  ```
+
+- **監控模式**：host 端工作把 log 寫到「掛載進容器的目錄」，容器內直接 `tail` 讀，
+  不用一直走 ssh（這配合上面的 `& disown` 是標準組合：下達 → 脫管 → 讀 log）
+- host 有 ssh key 時更乾淨：`ssh2` 改傳 `privateKey` 選項，連密碼都不用
+
+## 為什麼不直接掛 docker.sock
+
+| | 掛 docker.sock | ssh bridge |
+|---|---|---|
+| 權限 | = host 完整 root（可動所有容器、讀所有 secret） | 普通使用者帳號（按需 SUDO） |
+| 適用 | CI／自動化管理 | agent 在 host 上「幫忙跑活」的本場景 |
+
+## 踩過的地雷（排錯表）
+
+| 地雷 | 症狀 | 解法 |
+|---|---|---|
+| heredoc 搶 sudo 的 stdin | `echo pass \| sudo -S bash <<EOF … EOF` → `3 incorrect password attempts` | 先把腳本寫成檔案，再 `echo $PASS \| sudo -S -p '' bash /tmp/script.sh` |
+| 容器內跑 bash 特有語法 | ash 報 syntax error | 容器只有 ash（POSIX）；`bash -n` 語法檢查要**在 host** 上跑 |
+| 長指令 `nohup &` 不脫管 | bridge 逾時、看起來卡死 | `setsid nohup … & disown` |
+| 腳本放容器 `/tmp` | rebuild 後消失 | 持久物放 `/workspace`（掛載卷） |
+| `docker logs --since <epoch 數字>` | 無輸出 | 用 `--tail N` 或 RFC3339 時間戳 |
+| 用 sed 貪婪 `.*` 抓 log 數字 | 吃掉前導數字（如 `1094` 變 `94`） | 改用 `grep -oE '[0-9]+(\.[0-9]+)?'` |
+
+## Rebuild 後復原 checklist
+
+`docker compose up -d --build`（會 recreate 容器）後，按順序：
+
+1. 重跑解法 A 的 symlink（除非已燒進 Dockerfile）
+2. `sshbridge` 若在 `/workspace` → 自動活著，免處理
+3. pi session：`~/.pi/agent` 有掛載 → session 與設定活著，可直接接續
+
+## 安全紀律
+
+- 密碼只走環境變數，不落檔、不入 git
+- 推任何文件/腳本上 repo 前先掃一遍：`grep -rn '<實際密碼>' <目錄>` 確認零命中
+- 這頁所有範例的密碼位都是佔位符——照做不會把真密碼帶進 repo

--- a/docs/docker-host-bridge.md
+++ b/docs/docker-host-bridge.md
@@ -238,6 +238,19 @@ HOST_SSH_PASS='...' HOST_SUDO_PASS='...' node run-host.js --sudo 'whoami'   # �
 2. `sshbridge` 若在 `/workspace` → 自動活著，免處理
 3. pi session：`~/.pi/agent` 有掛載 → session 與設定活著，可直接接續
 
+## 權限邊界：容器 root ≠ host root
+
+> **關鍵事實**
+> - 容器內的 `root` **不是** host 的 root。容器最多只能碰到：容器自己的檔案系統 + compose 裡掛進來的 volume（本機：`~/.pi/agent`、` /workspace` → `/home/wrt/TigerAI/AG/SystemRepair`）。
+> - 若目標是修 **host 本機**（這台 wrt 主機、專案 SystemRepair），很多操作必須在 host 上執行。容器內做不到——除非走 ssh bridge（解法 B/B+）回到 host。
+> - `user: "0"` 讓容器內的 pi 以 root 執行，並**不會**讓容器變成 host root；它只會讓掛載目錄內的檔案被 root 擁有/修改。
+
+### root 運行的代價
+
+- agent 以 root 執行後，掛載目錄（`/workspace`、 `~/.pi/agent`）內新建的檔案/目錄 owner 都是 `root:root`。
+- 之後改回 `user: node` 跑，agent 就**寫不進**那些 root 擁有的檔案，導致「權限錯誤」的假象。
+- 建議：只在需要寫入 host 擁有者的檔案時才臨時用 root；長期以 node 執行，必要時用 ssh bridge 以 host 帳號操作。
+
 ## 安全紀律
 
 - 密碼只走環境變數，不落檔、不入 git

--- a/docs/docker-host-bridge.md
+++ b/docs/docker-host-bridge.md
@@ -33,7 +33,7 @@ sudo docker exec -u root pi-web sh -c \
    RUN mkdir -p /home/wrt && ln -sfn /workspace /home/wrt/TigerAI
    ```
 
-## 解法 B：ssh2 bridge — 容器內執行 host 指令（解牆 #2、#3，推薦）
+## 解法 B：ssh2 bridge — 容器內執行 host 指令（解牆 #2、#3）
 
 容器有 Node 但沒有 ssh 二進位。裝 pure-JS 的 `ssh2`（無 native 編譯，alpine 直接可用）：
 
@@ -97,6 +97,120 @@ PI_HOST_SSH_HOST=<host LAN IP> PI_HOST_SSH_USER=<user> PI_HOST_SSH_PASS=<pass> \
   不用一直走 ssh（這配合上面的 `& disown` 是標準組合：下達 → 脫管 → 讀 log）
 - host 有 ssh key 時更乾淨：`ssh2` 改傳 `privateKey` 選項，連密碼都不用
 
+### 解法 B+（推薦）：pi skill 版 — 其他 AI 一進環境就自動發現
+
+> 上面的 B（`exec.js` + `/workspace/sshbridge`）是通用做法，但每次要「先知道去讀這頁文件」。
+> 如果容器跑的是 **pi agent**（如 pi-web），推薦把 bridge 放成 pi skill：
+> `~/.pi/agent/skills/host-ssh/`。`~/.pi/agent` 是掛載卷（rebuild 存活），pi 會**自動發現**
+> skills——下次任何 AI 進這個環境，skill 清單裡直接看得到，不需要繞路。
+
+#### 當時的 4 步（瓶頸 → 打通）
+
+1. **瓶頸**：容器零權限——無 sudo、`/sys` 唯讀、沒 ssh/curl 二進位、`apk add` 要 root 裝不了
+   → 系統 ssh 客戶端的路走不通。
+2. **node 路線（關鍵決定）**：容器有 node → 用純 JS `ssh2` 當 SSH 客戶端，完全不需要
+   ssh 二進位。（fallback：host 上其他服務的 node_modules 深處可能內含 ssh2，可複製過來，離線也能用。）
+3. **建立 skill 目錄** `~/.pi/agent/skills/host-ssh/`：`run-host.js`（SSH 腳本）+
+   `package.json` + `npm install ssh2` + `SKILL.md`（主機資訊、用法、規則）。
+4. **sudo 打通（`--sudo` 的祕訣）**：`printf '%s\n' '<pass>' | sudo -S -p '' bash -c '<cmd>'`
+   ——把密碼 pipe 進 `sudo -S` 的 stdin，免互動輸入。
+
+#### 安裝（約 5 分鐘）
+
+```bash
+mkdir -p ~/.pi/agent/skills/host-ssh && cd ~/.pi/agent/skills/host-ssh
+# 把下面的 run-host.js 與 SKILL.md 寫入，然後：
+npm install ssh2
+```
+
+#### run-host.js（密碼一律走環境變數，不寫進檔案）
+
+```js
+#!/usr/bin/env node
+// host-ssh: run a command on the Docker host via ssh2 (pure JS, no ssh binary needed).
+// Passwords come ONLY from environment variables — never hardcode, never commit.
+//
+// Usage:
+//   HOST_SSH_PASS='<pass>' node run-host.js '<cmd>'                    # as host user
+//   HOST_SSH_PASS='<pass>' HOST_SUDO_PASS='<pass>' node run-host.js --sudo '<cmd>'
+//   HOST_SSH_HOST=<ip> ...   # override host (default: bridge gateway, see SKILL.md)
+
+const { Client } = require('ssh2');
+
+const args = process.argv.slice(2);
+let sudo = false;
+let host = process.env.HOST_SSH_HOST || '172.28.0.1'; // docker bridge gateway
+let user = process.env.HOST_SSH_USER || 'wrt';
+const password = process.env.HOST_SSH_PASS;
+const sudoPassword = process.env.HOST_SUDO_PASS;
+const cmdParts = [];
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--sudo') sudo = true;
+  else if (args[i] === '--host') host = args[++i];
+  else cmdParts.push(args[i]);
+}
+const cmd = cmdParts.join(' ');
+if (!cmd) { console.error('Usage: HOST_SSH_PASS=<pass> node run-host.js [--sudo] [--host <ip>] <command>'); process.exit(2); }
+if (!password) { console.error('missing env HOST_SSH_PASS'); process.exit(2); }
+if (sudo && !sudoPassword) { console.error('missing env HOST_SUDO_PASS'); process.exit(2); }
+
+// 密碼 pipe 進 sudo -S，免互動；單引號正確轉義
+const sq = (s) => s.replace(/'/g, "'\\''");
+const remote = sudo
+  ? `printf '%s\n' '${sq(sudoPassword)}' | sudo -S -p '' bash -c '${sq(cmd)}'`
+  : cmd;
+
+const conn = new Client();
+const timeout = setTimeout(() => { console.error('timeout after 120s'); conn.end(); process.exit(124); }, 120000);
+
+conn.on('ready', () => {
+  conn.exec(remote, (e, stream) => {
+    if (e) { clearTimeout(timeout); console.error('exec error:', e.message); process.exit(1); }
+    stream.on('data', (d) => process.stdout.write(d));
+    stream.stderr.on('data', (d) => process.stderr.write(d));
+    stream.on('close', (code) => { clearTimeout(timeout); conn.end(); process.exit(code == null ? 0 : code); });
+    stream.on('error', (err) => { clearTimeout(timeout); console.error('stream error:', err.message); conn.end(); process.exit(1); });
+  });
+}).on('error', (e) => { clearTimeout(timeout); console.error('ssh error:', e.message); process.exit(1); });
+
+conn.connect({ host, port: 22, username: user, password, readyTimeout: 15000 });
+```
+
+#### SKILL.md（範本；密碼欄位只寫來源，不寫值）
+
+```markdown
+# host-ssh
+
+容器內以純 JS（ssh2）SSH 到 Docker host 執行指令。不需 ssh 二進位、不需 root。
+
+| 項目 | 值 |
+|------|-----|
+| Host | bridge gateway（發現方法見下） |
+| User | `<host 使用者>` |
+| 密碼 | **只走環境變數** `HOST_SSH_PASS` / `HOST_SUDO_PASS`，不寫進任何檔案 |
+
+**bridge gateway 發現方法（不可硬編碼）**：`cat /proc/net/route` 的 gw 欄是 little-endian
+hex（如 `01001CAC` → `172.28.0.1`）；或容器 IP 同網段 + `.1`。
+
+用法：`HOST_SSH_PASS='<pass>' node run-host.js [--sudo] '<指令>'`
+
+規則：1) `--sudo` 先問使用者 2) 刪除/修改 host 的東西絕對先問 3) 預設只做唯讀查詢
+```
+
+#### 驗證
+
+```bash
+HOST_SSH_PASS='...' node run-host.js 'whoami && hostname'                    # → host 使用者 + 主機名
+HOST_SSH_PASS='...' HOST_SUDO_PASS='...' node run-host.js --sudo 'whoami'   # → root
+```
+
+#### 與解法 B（exec.js）的差異
+
+- `--sudo` flag（B 用 `SUDO: ` 前綴）、`--host` flag、120s 逾時、sudo 指令單引號轉義
+- 放 pi skills → **自動發現**；exec.js 需要每個 AI 先被指引去讀這頁
+- 長工作脫管模式（`setsid nohup ... & disown` + log 寫掛載目錄再 tail）兩版都適用
+
 ## 為什麼不直接掛 docker.sock
 
 | | 掛 docker.sock | ssh bridge |
@@ -114,6 +228,7 @@ PI_HOST_SSH_HOST=<host LAN IP> PI_HOST_SSH_USER=<user> PI_HOST_SSH_PASS=<pass> \
 | 腳本放容器 `/tmp` | rebuild 後消失 | 持久物放 `/workspace`（掛載卷） |
 | `docker logs --since <epoch 數字>` | 無輸出 | 用 `--tail N` 或 RFC3339 時間戳 |
 | 用 sed 貪婪 `.*` 抓 log 數字 | 吃掉前導數字（如 `1094` 變 `94`） | 改用 `grep -oE '[0-9]+(\.[0-9]+)?'` |
+| bridge gateway IP 不固定 | 舊的 `172.21.0.1` 連不上、ssh 失敗 | 同一台 host 在不同 docker network 下子網不同（實測出現過 172.21.0.1 / 172.28.0.1）；用 `cat /proc/net/route`（gw 欄 little-endian hex）或容器 IP 同網段 + `.1` 找現值 |
 
 ## Rebuild 後復原 checklist
 

--- a/lib/file-access.ts
+++ b/lib/file-access.ts
@@ -24,6 +24,7 @@ export async function getAllowedFileRoots(): Promise<Set<string>> {
 
   const sessions = await listAllSessions();
   const roots = new Set<string>();
+  if (process.cwd()) roots.add(normalizeSlashes(process.cwd()));
   for (const s of sessions) {
     if (s.cwd) roots.add(normalizeSlashes(s.cwd));
     // The project root (main repo shared by all worktrees) is browsable too —


### PR DESCRIPTION
## 問題

這個 repo 是**公開的**（`visibility=public`），而 `docker-compose.yml` 把 `PI_WEB_PASSWORD` 的實際值 commit 了進來。

寫進公開 repo 的密碼等於公開，而且 **git 歷史會永久保留** —— 任何人 clone 後 `git log -p` 就看得到。

影響範圍不小：pi-web 的認證只有一組 Basic Auth（使用者名稱固定為 `pi`），密碼外洩等於整個 web UI 被打開 —— 而這個 UI 可以對掛載進去的 workspace 下指令，掛載的又通常是使用者的專案目錄（`INSTALL_GUIDE.md` 自己也警告過 `~/.pi/agent` 含 API key 與完整 session 歷史）。

## 改法

```diff
-      PI_WEB_PASSWORD: "pW9$$kX2#..."
+      PI_WEB_PASSWORD: "${PI_WEB_PASSWORD:?請在 .env 設定 PI_WEB_PASSWORD}"
```

用 `:?` 而不是 `:-`：沒設定時**直接失敗**，而不是靜默以空密碼啟動。空密碼加上 base compose 的 `30141:30141`（綁全介面）會是一個 LAN 上任何人都能操作的 coding agent。

`.gitignore` 補上 `.env` 與 `docker-compose.override.yml`。

## ⚠️ 這個 PR 不算修好

合併後值仍在歷史裡。**必須視為已洩漏並更換**，這個 PR 處理的只是「不要繼續散布」。

## 順帶一提：`ports` 在 override 檔裡要用 `!override`

實際部署時踩到的：compose 對 `ports` 這類 list 欄位預設是**附加**不是取代。用 `docker-compose.override.yml` 想改成只綁 loopback 時，base 的 `"30141:30141"` 會跟 override 的 `"127.0.0.1:30141:30141"` 同時存在：

```
PortBindings={"30141/tcp":[{"HostIp":"","HostPort":"30141"},
                           {"HostIp":"127.0.0.1","HostPort":"30141"}]}
```

兩個綁定搶同一個埠，docker 報 `address already in use` —— 而錯誤訊息不會提到是自己重複綁，會讓人去找「是誰佔了 30141」（`ss` 又查不到任何東西）。要用 `ports: !override` 才會取代。

值得在 `DOCKER.md` 補一句。

🤖 Generated with [Claude Code](https://claude.com/claude-code)