### PR TITLE
fix: implement extension-driven session switching (/pr, /work resume)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,11 @@ hooks/
 
 **Fix**: `send("fork")` captures `newSessionId`, then calls `this.destroy()` before returning. The next request for the original session reloads a clean AgentSession from the original file.
 
+### Extension-driven session switching (`ctx.newSession` / `ctx.switchSession`)
+Extension commands like `/pr` or `/work` replace the running session. pi-web has no `AgentSessionRuntime`, so `rpc-manager.ts` reimplements that flow: emit `session_before_switch` (a handler returning `{cancel:true}` makes the action report `cancelled`, which is what the extension reports as "Resume cancelled"), emit a `session_switch` event to connected browsers **before** teardown, emit `session_shutdown`, destroy the wrapper, then `startRpcSession()` the target with `sessionStartEvent.reason` `new`/`resume` so `session_start` handlers (branch checkout, etc.) run like they do in the TUI. `withSession()` runs against the replacement's `createReplacedSessionContext()` only after `waitUntilReady()`.
+
+The client follows via `case "session_switch"` in `useAgentSession` → `onSessionSwitched` → `AppShell.handleSessionForked` (same select + hydrate + URL replace as a fork). Sessions created by `ctx.newSession()` are written to disk immediately (`persistSessionFileIfMissing`) because pi otherwise delays the first flush until an assistant message exists, and the browser navigates to the file right away.
+
 ### Two kinds of branching — don't confuse them
 - **Fork** (Fork button on user message): creates a new independent `.jsonl` file. Shown as a child in the sidebar tree via `parentSession` header field.
 - **In-session branch** (Continue button / BranchNavigator): calls `navigate_tree` within the same file. Multiple entries share the same `parentId`. Switching between them calls `/api/sessions/[id]/context?leafId=`.

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -759,6 +759,10 @@ export function AppShell() {
     router.replace(`?session=${encodeURIComponent(newSessionId)}`, { scroll: false });
   }, [invalidateWorkspaceRestore, router, hydrateSelectedSession]);
 
+  // An extension (e.g. /pr, /work) replaced the running session server-side.
+  // Following it is the same navigation as a fork: select + hydrate the target.
+  const handleSessionSwitched = handleSessionForked;
+
   const handleInitialRestoreDone = useCallback(() => {
     setInitialSessionRestored(true);
   }, []);
@@ -2088,6 +2092,7 @@ export function AppShell() {
               onAttentionNeeded={handleAttentionNeeded}
               onSessionCreated={handleSessionCreated}
               onSessionForked={handleSessionForked}
+              onSessionSwitched={handleSessionSwitched}
               modelsRefreshKey={modelsRefreshKey}
               chatInputRef={chatInputRef}
               onBranchDataChange={handleBranchDataChange}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -34,6 +34,7 @@ interface Props {
   onAttentionNeeded?: (request: BlockingExtensionUiRequest) => void;
   onSessionCreated?: (session: SessionInfo, sourceDraftKey: string) => void;
   onSessionForked?: (newSessionId: string) => void;
+  onSessionSwitched?: (targetSessionId: string) => void;
   modelsRefreshKey?: number;
   chatInputRef?: React.RefObject<ChatInputHandle | null>;
   onBranchDataChange?: (tree: SessionTreeNode[], activeLeafId: string | null, onLeafChange: (leafId: string | null) => void) => void;
@@ -250,7 +251,7 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, defaultExpanded = fa
   );
 }
 
-export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSystemPromptLoaderChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile, soundEnabled = true, onSoundToggle, playDoneSound = () => {}, unlockAudio }: Props) {
+export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked, onSessionSwitched, modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSystemPromptLoaderChange, onSessionStatsChange, onSessionStatsPanelOpen, onContextUsageChange, onOpenFile, soundEnabled = true, onSoundToggle, playDoneSound = () => {}, unlockAudio }: Props) {
   const { t } = useI18n();
   const isMobile = useIsMobile();
 
@@ -293,7 +294,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     handleBuiltinSlashCommand,
     handleToolPresetChange, handleThinkingLevelChange, loadSlashCommands, scrollUserMsgToTop,
   } = useAgentSession({
-    session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd: wrappedOnAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked,
+    session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd: wrappedOnAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked, onSessionSwitched,
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSystemPromptLoaderChange, onSessionStatsPanelOpen,
   });
   const sessionBusy = agentRunning || bashRunning;

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -141,6 +141,8 @@ export interface UseAgentSessionOptions {
   onAttentionNeeded?: (request: BlockingExtensionUiRequest) => void;
   onSessionCreated?: (session: SessionInfo, sourceDraftKey: string) => void;
   onSessionForked?: (newSessionId: string) => void;
+  /** An extension replaced this session server-side (ctx.newSession/ctx.switchSession). */
+  onSessionSwitched?: (targetSessionId: string) => void;
   modelsRefreshKey?: number;
   chatInputRef?: React.RefObject<ChatInputHandle | null>;
   onBranchDataChange?: (tree: SessionTreeNode[], activeLeafId: string | null, onLeafChange: (leafId: string | null) => void) => void;
@@ -263,7 +265,7 @@ type SlashCommandsResponse = {
 
 export function useAgentSession(opts: UseAgentSessionOptions) {
   const {
-    session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked,
+    session, sessionRunning, newSessionCwd, newSessionDraftKey, onAgentEnd, onAttentionNeeded, onSessionCreated, onSessionForked, onSessionSwitched,
     modelsRefreshKey, onBranchDataChange, onSystemPromptChange, onSystemPromptLoaderChange, onSessionStatsPanelOpen,
   } = opts;
 
@@ -1032,6 +1034,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         }
         break;
       }
+      case "session_switch": {
+        // An extension command (e.g. /pr, /work) replaced this session with
+        // another one server-side. Follow it in the browser.
+        const targetSessionId = event.sessionId;
+        if (typeof targetSessionId === "string" && targetSessionId !== sessionIdRef.current) {
+          onSessionSwitched?.(targetSessionId);
+        }
+        break;
+      }
       case "agent_start":
         cancelEventStreamGrace();
         sdkAgentActiveRef.current = true;
@@ -1247,7 +1258,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         handleExtensionUiRequest(event as ExtensionUiRequest);
         break;
     }
-  }, [addNotice, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, scrollToBottom, settleUiStage]);
+  }, [addNotice, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, onSessionSwitched, scheduleEventStreamClose, scrollToBottom, settleUiStage]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -74,8 +74,23 @@ interface ExtensionRunnerLike {
     description?: string;
     sourceInfo: SlashCommandInfo["sourceInfo"];
   }>;
-  emit?(event: { type: "session_shutdown"; reason: "quit" }): Promise<unknown>;
+  emit?(event:
+    | { type: "session_shutdown"; reason: "quit" | "new" | "resume" | "fork"; targetSessionFile?: string }
+    | { type: "session_before_switch"; reason: "new" | "resume"; targetSessionFile?: string }
+  ): Promise<{ cancel?: boolean } | undefined>;
+  hasHandlers?(eventType: string): boolean;
   setUIContext?(uiContext?: unknown, mode?: "tui" | "rpc" | "json" | "print"): void;
+}
+
+/**
+ * Command-capable context bound to a replacement session after a switch.
+ * Only the members pi-web hands back to extension `withSession()` callbacks.
+ */
+export interface ReplacedSessionContextLike {
+  sendUserMessage(
+    content: string,
+    options?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
+  ): Promise<void>;
 }
 
 type DialogOptionsLike = {
@@ -144,6 +159,7 @@ export interface AgentSessionLike {
   readonly resourceLoader: ResourceLoaderLike;
 
   readonly bindExtensions?: unknown;
+  createReplacedSessionContext?(): ReplacedSessionContextLike;
   dispose(): void;
   reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void>;
   subscribe(listener: (event: AgentSessionEvent) => void): () => void;

--- a/lib/rpc-manager-session-switch.test.mjs
+++ b/lib/rpc-manager-session-switch.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const rpcManagerSource = () => readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+
+test("extension command actions implement session replacement instead of always cancelling", async () => {
+  const source = await rpcManagerSource();
+  const actionsSource = source.slice(source.indexOf("createExtensionCommandContextActions()"));
+
+  assert.match(actionsSource, /newSession: async \(options\) => this\.replaceWithNewSession\(options\)/);
+  assert.match(
+    actionsSource,
+    /switchSession: async \(sessionPath, options\) =>\s*this\.replaceWithExistingSession\(sessionPath, options\?\.withSession\)/,
+  );
+});
+
+test("session replacement honours session_before_switch cancellation", async () => {
+  const source = await rpcManagerSource();
+
+  assert.match(source, /type: "session_before_switch",\s*reason,/);
+  assert.match(source, /return result\?\.cancel === true;/);
+  assert.match(source, /if \(await this\.emitBeforeSwitch\("new"\)\) return \{ cancelled: true \};/);
+  assert.match(
+    source,
+    /if \(await this\.emitBeforeSwitch\("resume", sessionPath\)\) return \{ cancelled: true \};/,
+  );
+});
+
+test("session replacement notifies browsers before tearing the old session down", async () => {
+  const source = await rpcManagerSource();
+  const finishSource = source.slice(source.indexOf("private async finishSessionReplacement("));
+  const emitIndex = finishSource.indexOf('type: "session_switch"');
+  const teardownIndex = finishSource.indexOf("this.teardownForReplacement(");
+
+  assert.ok(emitIndex >= 0);
+  assert.ok(teardownIndex > emitIndex, "session_switch must be emitted before teardown");
+  assert.match(finishSource, /startRpcSession\(sessionId, sessionFile \?\? "", cwd, \{/);
+  assert.match(finishSource, /sessionStartEvent: \{\s*type: "session_start",\s*reason,/);
+  assert.match(finishSource, /await next\.waitUntilReady\(\);/);
+  assert.match(finishSource, /next\.inner\.createReplacedSessionContext\?\.\(\)/);
+});
+
+test("startRpcSession can adopt an already-open SessionManager and a session_start reason", async () => {
+  const source = await rpcManagerSource();
+  const startupSource = source.slice(source.indexOf("export async function startRpcSession"));
+
+  assert.match(startupSource, /if \(options\.sessionManager\) \{\s*sessionManager = options\.sessionManager;/);
+  assert.match(startupSource, /\.\.\.\(sessionStartEvent \? \{ sessionStartEvent \} : \{\}\)/);
+});
+
+test("extension-created sessions are flushed to disk so the browser can read them", async () => {
+  const source = await rpcManagerSource();
+
+  assert.match(source, /function persistSessionFileIfMissing\(manager: SessionManager\): void/);
+  assert.match(source, /persistSessionFileIfMissing\(sessionManager\);/);
+});
+
+test("the chat hook follows a server-side session switch", async () => {
+  const hookSource = await readFile(new URL("../hooks/useAgentSession.ts", import.meta.url), "utf8");
+
+  assert.match(hookSource, /case "session_switch": \{/);
+  assert.match(hookSource, /onSessionSwitched\?\.\(targetSessionId\)/);
+  assert.match(hookSource, /targetSessionId !== sessionIdRef\.current/);
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -2,8 +2,8 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
-import { existsSync, realpathSync, writeFileSync } from "fs";
-import { resolve } from "path";
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
 import { validateAgentImages } from "./image-attachments";
 import { invalidateModelsCache } from "./models-cache";
 import { resolveVisibleModels, selectInitialModelScope } from "./model-scope";
@@ -16,7 +16,7 @@ import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import { getProjectTrustStatus, projectTrustReloadOptions } from "./project-trust";
 import { persistExplicitStartupPreferences } from "./startup-preferences";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
-import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
+import type { AgentSessionLike, ExtensionUiContextLike, ReplacedSessionContextLike, ToolInfo } from "./pi-types";
 import type {
   ExtensionUiRequest,
   ExtensionUiResponse,
@@ -78,12 +78,21 @@ type ExtensionUiRequestBody = Record<string, unknown> & {
   expiresAt?: number;
 };
 
+type ReplacedSessionCallback = (ctx: ReplacedSessionContextLike) => Promise<void>;
+
 type ExtensionCommandContextActionsLike = {
   waitForIdle: () => Promise<void>;
-  newSession: () => Promise<{ cancelled: boolean }>;
+  newSession: (options?: {
+    parentSession?: string;
+    setup?: (sessionManager: SessionManager) => Promise<void>;
+    withSession?: ReplacedSessionCallback;
+  }) => Promise<{ cancelled: boolean }>;
   fork: () => Promise<{ cancelled: boolean }>;
   navigateTree: (targetId: string, options?: { summarize?: boolean }) => Promise<{ cancelled: boolean }>;
-  switchSession: () => Promise<{ cancelled: boolean }>;
+  switchSession: (
+    sessionPath: string,
+    options?: { withSession?: ReplacedSessionCallback },
+  ) => Promise<{ cancelled: boolean }>;
   reload: () => Promise<void>;
 };
 
@@ -112,7 +121,25 @@ export interface RpcSessionStartOptions {
   toolNames?: string[];
   initialModel?: { provider: string; modelId: string };
   thinkingLevel?: ThinkingLevel;
+  /**
+   * Reuse an already-open SessionManager instead of reopening the file.
+   * Used by extension-driven session replacement, where the new session file
+   * may not have been flushed to disk yet.
+   */
+  sessionManager?: SessionManager;
+  /**
+   * Reason reported to `session_start` handlers. Defaults to the SDK's
+   * "startup". Session replacement passes "new"/"resume" so extensions that
+   * react to switches (branch checkout, etc.) run like they do in the TUI.
+   */
+  sessionStartEvent?: SessionStartEventLike;
 }
+
+type SessionStartEventLike = {
+  type: "session_start";
+  reason: "new" | "resume" | "fork";
+  previousSessionFile?: string;
+};
 
 const CODING_TOOL_NAMES = ["read", "bash", "edit", "write", "grep", "find", "ls"];
 
@@ -154,6 +181,24 @@ function withExtensionTools(session: AgentSessionLike, toolNames: string[]): str
     .filter((name) => !codingToolNames.has(name));
 
   return [...new Set([...toolNames, ...extensionToolNames])];
+}
+
+/**
+ * Write a not-yet-flushed session file so readers (/api/sessions/[id]) can see it.
+ * Mirrors AgentSessionWrapper.persistBashOnlySession() for extension-created sessions.
+ */
+function persistSessionFileIfMissing(manager: SessionManager): void {
+  const sessionFile = manager.getSessionFile();
+  if (!sessionFile || existsSync(sessionFile)) return;
+  const header = manager.getHeader();
+  if (!header) return;
+
+  const content = [header, ...manager.getEntries()]
+    .map((entry) => JSON.stringify(entry))
+    .join("\n") + "\n";
+  mkdirSync(dirname(sessionFile), { recursive: true });
+  writeFileSync(sessionFile, content, { encoding: "utf8", flag: "wx" });
+  (manager as unknown as { flushed: boolean }).flushed = true;
 }
 
 // ============================================================================
@@ -1336,13 +1381,14 @@ export class AgentSessionWrapper {
         const agent = this.inner.agent as { waitForIdle?: () => Promise<void> };
         await agent.waitForIdle?.();
       },
-      newSession: async () => ({ cancelled: true }),
+      newSession: async (options) => this.replaceWithNewSession(options),
       fork: async () => ({ cancelled: true }),
       navigateTree: async (targetId, options) => {
         const result = await this.inner.navigateTree(targetId, { summarize: options?.summarize });
         return { cancelled: result.cancelled };
       },
-      switchSession: async () => ({ cancelled: true }),
+      switchSession: async (sessionPath, options) =>
+        this.replaceWithExistingSession(sessionPath, options?.withSession),
       reload: async () => {
         this.extensionStatuses.clear();
         this.resetExtensionWidgetsForReload();
@@ -1355,6 +1401,135 @@ export class AgentSessionWrapper {
         this.applyForcedEmptySystemPrompt();
       },
     };
+  }
+
+  /**
+   * Ask `session_before_switch` handlers whether a replacement may proceed.
+   * Mirrors AgentSessionRuntime.emitBeforeSwitch() so extension guards (e.g. a
+   * dirty-worktree prompt) can cancel the switch exactly like they do in the TUI.
+   */
+  private async emitBeforeSwitch(
+    reason: "new" | "resume",
+    targetSessionFile?: string,
+  ): Promise<boolean> {
+    const runner = this.inner.extensionRunner;
+    if (!runner.emit || runner.hasHandlers?.("session_before_switch") === false) return false;
+    const result = await runner.emit({
+      type: "session_before_switch",
+      reason,
+      ...(targetSessionFile ? { targetSessionFile } : {}),
+    });
+    return result?.cancel === true;
+  }
+
+  /**
+   * Extension-driven `ctx.newSession()`: create a fresh session file, tell the
+   * browser to follow it, then hand the extension a context bound to it.
+   */
+  private async replaceWithNewSession(options?: {
+    parentSession?: string;
+    setup?: (sessionManager: SessionManager) => Promise<void>;
+    withSession?: ReplacedSessionCallback;
+  }): Promise<{ cancelled: boolean }> {
+    if (await this.emitBeforeSwitch("new")) return { cancelled: true };
+
+    const current = this.inner.sessionManager;
+    const sessionManager = SessionManager.create(current.getCwd(), current.getSessionDir());
+    sessionManager.newSession(options?.parentSession ? { parentSession: options.parentSession } : undefined);
+    if (options?.setup) await options.setup(sessionManager);
+    // Pi delays the first flush until an assistant message exists. The browser
+    // navigates to this session immediately, so it must be readable on disk now.
+    persistSessionFileIfMissing(sessionManager);
+
+    return this.finishSessionReplacement("new", sessionManager, options?.withSession);
+  }
+
+  /**
+   * Extension-driven `ctx.switchSession(path)`: resume an existing session file.
+   */
+  private async replaceWithExistingSession(
+    sessionPath: string,
+    withSession?: ReplacedSessionCallback,
+  ): Promise<{ cancelled: boolean }> {
+    if (!existsSync(sessionPath)) throw new Error(`Session file not found: ${sessionPath}`);
+    if (await this.emitBeforeSwitch("resume", sessionPath)) return { cancelled: true };
+
+    const sessionManager = SessionManager.open(sessionPath, undefined);
+    return this.finishSessionReplacement("resume", sessionManager, withSession);
+  }
+
+  /**
+   * Shared tail of both replacement flows: notify browsers, tear this session
+   * down, start the replacement, and run the extension's withSession callback
+   * against it.
+   *
+   * The browser is told to follow BEFORE teardown, because this wrapper's event
+   * listeners disappear with it.
+   */
+  private async finishSessionReplacement(
+    reason: "new" | "resume",
+    sessionManager: SessionManager,
+    withSession?: ReplacedSessionCallback,
+  ): Promise<{ cancelled: boolean }> {
+    const previousSessionFile = this.inner.sessionFile;
+    const sessionFile = sessionManager.getSessionFile();
+    const sessionId = sessionManager.getSessionId();
+    const cwd = sessionManager.getCwd();
+    if (sessionFile) cacheSessionPath(sessionId, sessionFile);
+    invalidateSessionListCache();
+
+    this.emit({ type: "session_switch", sessionId, reason } as unknown as AgentEvent);
+
+    // The target may already be open elsewhere (another tab). Retire it so the
+    // replacement runs session_start handlers with the right reason.
+    const openTarget = getRegistry().get(sessionId);
+    if (openTarget && openTarget !== this && openTarget.isAlive()) await openTarget.shutdown();
+
+    await this.teardownForReplacement(reason, sessionFile);
+
+    const { session: next } = await startRpcSession(sessionId, sessionFile ?? "", cwd, {
+      sessionManager,
+      sessionStartEvent: {
+        type: "session_start",
+        reason,
+        ...(previousSessionFile ? { previousSessionFile } : {}),
+      },
+    });
+    await next.waitUntilReady();
+
+    if (withSession) {
+      const replacedContext = next.inner.createReplacedSessionContext?.();
+      if (replacedContext) await withSession(replacedContext);
+    }
+    return { cancelled: false };
+  }
+
+  /** Settle and dispose this session on behalf of its replacement. */
+  private async teardownForReplacement(
+    reason: "new" | "resume",
+    targetSessionFile: string | undefined,
+  ): Promise<void> {
+    try {
+      await this.inner.abort();
+    } catch (error) {
+      console.error(
+        "[pi-web] failed to abort session before switch:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+    try {
+      await this.inner.extensionRunner.emit?.({
+        type: "session_shutdown",
+        reason,
+        ...(targetSessionFile ? { targetSessionFile } : {}),
+      });
+    } catch (error) {
+      console.error(
+        "[pi-web] session_shutdown handler failed during switch:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+    this.destroy();
   }
 
   private syncProjectTrust(): void {
@@ -1567,7 +1742,7 @@ export async function startRpcSession(
   cwd: string | undefined,
   options: RpcSessionStartOptions = {},
 ): Promise<{ session: AgentSessionWrapper; realSessionId: string }> {
-  const { toolNames, initialModel, thinkingLevel } = options;
+  const { toolNames, initialModel, thinkingLevel, sessionStartEvent } = options;
   const registry = getRegistry();
   const locks = getLocks();
 
@@ -1578,7 +1753,9 @@ export async function startRpcSession(
   if (inflight) return inflight;
 
   let sessionManager: SessionManager;
-  if (sessionFile) {
+  if (options.sessionManager) {
+    sessionManager = options.sessionManager;
+  } else if (sessionFile) {
     sessionManager = SessionManager.open(sessionFile, undefined);
   } else {
     if (!cwd) throw new Error("cwd is required for a new session");
@@ -1645,6 +1822,7 @@ export async function startRpcSession(
     const { session: inner } = await createAgentSessionFromServices({
       services,
       sessionManager,
+      ...(sessionStartEvent ? { sessionStartEvent } : {}),
       ...(initial.model ? { model: initial.model } : {}),
       ...(initial.thinkingLevel ? { thinkingLevel: initial.thinkingLevel } : {}),
       ...(initial.scopedModels.length > 0 ? { scopedModels: initial.scopedModels } : {}),


### PR DESCRIPTION
## Problem

Extension commands that replace the running session — `ctx.switchSession()` and `ctx.newSession()`, used by extensions such as `/pr` and `/work` — always failed in Pi Web.

Both command-context actions in `lib/rpc-manager.ts` were stubbed to return `{ cancelled: true }`, so:

- answering **"Resume it?"** immediately printed `Resume cancelled`
- the fresh-session path printed `New session cancelled`

## Fix

Pi Web does not use the SDK's `AgentSessionRuntime`, so `rpc-manager.ts` now reimplements that replacement flow:

- emit `session_before_switch`, so only a real extension guard (e.g. a dirty-worktree prompt) can cancel
- emit a `session_switch` event to connected browsers **before** teardown, since the wrapper's event listeners disappear with it
- retire any wrapper already holding the target session, `abort()` + emit `session_shutdown` for the current one, then start the replacement with `sessionStartEvent.reason` `new`/`resume` so `session_start` handlers (branch checkout, etc.) run exactly like they do in the TUI
- run the extension's `withSession()` against the replacement's `createReplacedSessionContext()` after `waitUntilReady()`

`startRpcSession()` gained two options for this: `sessionManager` (adopt an already-open manager) and `sessionStartEvent` (report the switch reason). Sessions created via `ctx.newSession()` are flushed to disk immediately (`persistSessionFileIfMissing`) because pi otherwise delays the first flush until an assistant message exists, while the browser navigates to the new session right away.

Client side, `useAgentSession` handles the new `session_switch` event and follows it via `onSessionSwitched` -> `AppShell`'s existing select / hydrate / URL-replace path (the same navigation used after a fork).

## Files

- `lib/rpc-manager.ts` — replacement flow: `emitBeforeSwitch`, `replaceWithNewSession`, `replaceWithExistingSession`, `finishSessionReplacement`, `teardownForReplacement`, `persistSessionFileIfMissing`, new start options
- `lib/pi-types.ts` — widened `ExtensionRunnerLike.emit`, added `hasHandlers` and `createReplacedSessionContext`
- `hooks/useAgentSession.ts`, `components/ChatWindow.tsx`, `components/AppShell.tsx` — `session_switch` handling / `onSessionSwitched` plumbing
- `lib/rpc-manager-session-switch.test.mjs` — new source-assertion tests
- `AGENTS.md` — documents the flow

## Verification

- `tsc --noEmit`, `npm run lint`, `npm test` (593 tests) all pass
- Manually verified: `/pr <number>` -> "Resume" now switches the browser to the existing PR session and checks out its branch
