### PR TITLE
fix(images): compress oversized attachments before upload

### DIFF
--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
 });
 const React = await jiti.import("react");
 const { renderToStaticMarkup } = await jiti.import("react-dom/server");
-const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand } = await jiti.import("./ChatInput.tsx");
+const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, compressImageFile, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand, shouldCompressImageFile } = await jiti.import("./ChatInput.tsx");
 const { clearDraft, getDraft, mergeRestoredSubmissionDraft, mergeRestoredSubmissionText, rekeyDraft, setDraft } = await jiti.import("@/lib/draft-store.ts");
 const { I18nProvider } = await jiti.import("@/hooks/useI18n");
 
@@ -122,6 +122,57 @@ test("filters model options by name and id", () => {
 test("caps an upward menu to the visible space above its anchor", () => {
   assert.equal(getUpwardMenuMaxHeight(343, 36), 299);
   assert.equal(getUpwardMenuMaxHeight(40, 36), 0);
+});
+
+test("compresses large images while preserving small images and GIFs", async () => {
+  assert.equal(shouldCompressImageFile({ size: 1024 * 1024, type: "image/png" }), false);
+  assert.equal(shouldCompressImageFile({ size: 1024 * 1024 + 1, type: "image/png" }), true);
+  assert.equal(shouldCompressImageFile({ size: 2 * 1024 * 1024, type: "image/gif" }), false);
+
+  const originals = {
+    FileReader: globalThis.FileReader,
+    createImageBitmap: globalThis.createImageBitmap,
+    document: globalThis.document,
+  };
+  let bitmapCalls = 0;
+  let closed = false;
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({ fillStyle: "", fillRect() {}, drawImage() {} }),
+    toDataURL: () => "data:image/jpeg;base64,COMPRESSED",
+  };
+
+  globalThis.FileReader = class {
+    readAsDataURL() {
+      this.result = "data:image/png;base64,ORIGINAL";
+      this.onload();
+    }
+  };
+  globalThis.createImageBitmap = async () => {
+    bitmapCalls += 1;
+    return { width: 2048, height: 1024, close() { closed = true; } };
+  };
+  globalThis.document = { createElement: () => canvas };
+
+  try {
+    assert.deepEqual(await compressImageFile({ size: 1024, type: "image/png" }), {
+      data: "ORIGINAL",
+      mimeType: "image/png",
+    });
+    assert.deepEqual(await compressImageFile({ size: 2 * 1024 * 1024, type: "image/png" }), {
+      data: "COMPRESSED",
+      mimeType: "image/jpeg",
+    });
+    assert.equal(bitmapCalls, 1);
+    assert.equal(canvas.width, 1024);
+    assert.equal(canvas.height, 512);
+    assert.equal(closed, true);
+  } finally {
+    globalThis.FileReader = originals.FileReader;
+    globalThis.createImageBitmap = originals.createImageBitmap;
+    globalThis.document = originals.document;
+  }
 });
 
 test("recognizes exact slash commands for one-Enter submission", () => {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -253,6 +253,58 @@ export function buildSlashCommandLayout(
   };
 }
 
+const CLIENT_IMAGE_COMPRESSION_THRESHOLD_BYTES = 1024 * 1024;
+const CLIENT_MAX_IMAGE_SIDE = 1024;
+const CLIENT_JPEG_QUALITY = 0.85;
+
+export function shouldCompressImageFile(file: Pick<File, "size" | "type">): boolean {
+  return file.size > CLIENT_IMAGE_COMPRESSION_THRESHOLD_BYTES && file.type !== "image/gif";
+}
+
+function readImageFile(file: Blob, mimeType: string): Promise<{ data: string; mimeType: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const data = typeof reader.result === "string" ? reader.result.split(",")[1] : undefined;
+      if (!data) {
+        reject(new Error("Failed to read image"));
+        return;
+      }
+      resolve({ data, mimeType });
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function compressImageFile(file: File): Promise<{ data: string; mimeType: string }> {
+  const original = () => readImageFile(file, file.type);
+  if (!shouldCompressImageFile(file) || typeof createImageBitmap !== "function") return original();
+
+  const bitmap = await createImageBitmap(file).catch(() => null);
+  if (!bitmap) return original();
+
+  try {
+    const scale = Math.min(1, CLIENT_MAX_IMAGE_SIDE / Math.max(bitmap.width, bitmap.height));
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return original();
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    const data = canvas.toDataURL("image/jpeg", CLIENT_JPEG_QUALITY).split(",")[1];
+    return data && data.length < Math.ceil(file.size / 3) * 4
+      ? { data, mimeType: "image/jpeg" }
+      : original();
+  } catch {
+    return original();
+  } finally {
+    bitmap.close();
+  }
+}
+
 function imageToDraftImage(image: AttachedImage): ChatDraftImage {
   return { data: image.data, mimeType: image.mimeType };
 }
@@ -666,20 +718,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     pendingImageCountRef.current += imageFiles.length;
     try {
       const newImages = await Promise.all(
-        imageFiles.map(
-          (file) =>
-            new Promise<AttachedImage>((resolve, reject) => {
-              const reader = new FileReader();
-              reader.onload = () => {
-                const result = reader.result as string;
-                // result is "data:<mime>;base64,<data>"
-                const base64 = result.split(",")[1];
-                resolve({ data: base64, mimeType: file.type, previewUrl: URL.createObjectURL(file) });
-              };
-              reader.onerror = reject;
-              reader.readAsDataURL(file);
-            })
-        )
+        imageFiles.map(async (file) => ({
+          ...await compressImageFile(file),
+          previewUrl: URL.createObjectURL(file),
+        }))
       );
       setAttachedImages((prev) => {
         const accepted = newImages.slice(0, Math.max(0, MAX_ATTACHED_IMAGES - prev.length));


### PR DESCRIPTION
## Summary

Compresses oversized image attachments in the browser before they enter the conversation, reducing repeated base64 payload growth and avoiding provider/gateway HTTP 413 errors.

Tool-result image rendering is intentionally left to #499, which already provides inline rendering with lazy history loading.

## Behavior

- Images up to 1 MiB are preserved unchanged.
- GIFs are preserved to avoid dropping animation.
- Larger images are resized to a maximum 1024px side and encoded as JPEG at 0.85 quality.
- Compression is used only when it produces a smaller payload.
- Decode/canvas failures fall back to the original image through FileReader.

## Verification

- TypeScript: `tsc --noEmit`
- Lint: `npm run lint -- --quiet`
- Tests: 682 passed (`npm test`)