### PR TITLE
fix(notices): render multi-line notices (e.g. /acp panel) without truncating

### DIFF
--- a/components/ChatWindow.notices.test.mjs
+++ b/components/ChatWindow.notices.test.mjs
@@ -13,3 +13,8 @@ test("renders temporary notices once at the top center of the chat column", () =
     /position: "absolute",\s*top: 12,\s*left: 0,\s*right: isMobile \? 0 : CHAT_MINIMAP_WIDTH,[\s\S]*?justifyContent: "center",[\s\S]*?<NoticeShelf notices=\{notices\} floating \/>/,
   );
 });
+
+test("renders multi-line notices (e.g. /acp status panel) with pre-wrap monospace instead of truncating to one line", () => {
+  assert.match(source, /const isMultiLine = notice\.message\.includes\("\\n"\);/);
+  assert.match(source, /whiteSpace: "pre-wrap", fontFamily: "var\(--font-mono\)"/);
+});

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -961,17 +961,17 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
             : notice.type === "success"
               ? "#10b981"
               : "var(--accent)";
+        const isMultiLine = notice.message.includes("\n");
         return (
           <div
             key={notice.id}
             className="notice-shelf-item"
             style={{
               display: "flex",
-              alignItems: "center",
+              alignItems: isMultiLine ? "flex-start" : "center",
               gap: 10,
               minHeight: 60,
-              height: 60,
-              maxHeight: 60,
+              ...(isMultiLine ? { maxHeight: 420 } : { height: 60, maxHeight: 60 }),
               marginBottom: index === notices.length - 1 ? 0 : 6,
               overflow: "hidden",
               borderRadius: 14,
@@ -983,13 +983,13 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
               boxShadow: floating
                 ? "0 1px 2px rgba(15,23,42,0.05), 0 10px 28px -14px rgba(15,23,42,0.24)"
                 : "0 1px 2px rgba(15,23,42,0.04), 0 8px 24px -12px rgba(15,23,42,0.10)",
-              fontSize: 18,
+              fontSize: isMultiLine ? 12 : 18,
               lineHeight: 1.45,
               transformOrigin: "top center",
               animation: notice.exiting
                 ? "notice-shelf-out 0.18s ease-in forwards"
                 : "notice-shelf-in 0.18s ease-out both",
-              padding: "0 12px",
+              padding: isMultiLine ? "12px 14px" : "0 12px",
             }}
           >
             <span
@@ -999,9 +999,16 @@ function NoticeShelf({ notices, floating = false }: { notices: NoticeItem[]; flo
                 borderRadius: "50%",
                 background: color,
                 flexShrink: 0,
+                marginTop: isMultiLine ? 7 : 0,
               }}
             />
-            <span style={{ padding: "14px 0", minWidth: 0, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            <span
+              style={
+                isMultiLine
+                  ? { padding: 0, minWidth: 0, maxWidth: "100%", whiteSpace: "pre-wrap", fontFamily: "var(--font-mono)", overflowY: "auto" }
+                  : { padding: "14px 0", minWidth: 0, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }
+              }
+            >
               {notice.message}
             </span>
           </div>

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -91,6 +91,7 @@ export type NoticeItem = {
   message: string;
   type: NoticeType;
   exiting?: boolean;
+  visibleMs?: number;
 };
 
 type NoticeState = {
@@ -163,6 +164,7 @@ const EVENT_STREAM_READY_TIMEOUT_MS = 60_000;
 const EVENT_STREAM_RECONNECT_DELAY_MS = 1_000;
 const MAX_NOTICES = 5;
 const NOTICE_VISIBLE_MS = 5000;
+const MULTI_LINE_NOTICE_VISIBLE_MS = 30000;
 const NOTICE_EXIT_ANIMATION_MS = 180;
 function createNoticeId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -743,6 +745,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         id: notice.id ?? createNoticeId(),
         message,
         type: notice.type ?? "info",
+        visibleMs: message.includes("\n") ? MULTI_LINE_NOTICE_VISIBLE_MS : undefined,
       },
     });
   }, []);
@@ -1911,7 +1914,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     if (!oldest) return;
     const t = setTimeout(() => {
       dispatchNotice({ type: "mark_oldest_exiting" });
-    }, NOTICE_VISIBLE_MS);
+    }, oldest.visibleMs ?? NOTICE_VISIBLE_MS);
     return () => clearTimeout(t);
   }, [noticeState.visible]);
 


### PR DESCRIPTION
## Problem

Extension `ctx.ui.notify(...)` messages that span multiple lines are truncated to a single line in the notice shelf. The clearest example is the **billion-context-pi `/acp` status panel** (a ~15-line monospace block: context usage, sent-to-LLM, nudge state, blocks), which shows up as a one-line fragment ending in "…".

## Root cause

`NoticeShelf` (`components/ChatWindow.tsx`) rendered **every** notice in a fixed `height: 60` box with `whiteSpace: "nowrap"` + `textOverflow: "ellipsis"`. Any message containing newlines was collapsed onto one line and clipped. Notices also auto-dismiss after `NOTICE_VISIBLE_MS` (5s) — too short to read a multi-line panel even if it weren't clipped.

The server side (`lib/rpc-manager.ts` `notify`) and the event wiring (`hooks/useAgentSession.ts` `case "notify"` → `addNotice`) were already correct — the panel reaches the browser; only the rendering clipped it.

## Fix

- **`components/ChatWindow.tsx`** — detect multi-line notices (`message.includes("\n")`) and render them with `whiteSpace: "pre-wrap"`, a monospace font, auto height (scrollable, capped at 420px), and top alignment. Single-line notices keep the existing toast styling unchanged.
- **`hooks/useAgentSession.ts`** — add an optional `visibleMs` to `NoticeItem`; multi-line notices stay visible for 30s (`MULTI_LINE_NOTICE_VISIBLE_MS`) instead of 5s so the panel can be read. The dismiss timer now honors the oldest notice's `visibleMs`.
- **`components/ChatWindow.notices.test.mjs`** — add a regression test for the multi-line rendering path.

## Verification

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 588 pass, 0 fail
