### PR TITLE
fix: rendering for model-emitted bracketed math blocks

### DIFF
--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -69,6 +69,15 @@ P(\lambda)=o_b+\lambda r_b
   assert.match(oneLineHtml, /class="katex-display"/);
 });
 
+test("renders model-emitted bracket-only formula lines as display math", () => {
+  const html = renderMarkdown(String.raw`平均一致性：
+
+[ C(x) = \frac{2}{T(T-1)} \sum_{i<j} S(\hat{y}^{(i)}, \hat{y}^{(j)}) ]`);
+
+  assert.match(html, /class="katex-display"/);
+  assert.match(html, /\\sum/);
+});
+
 test("leaves an unmatched LaTeX bracket delimiter unchanged", () => {
   const markdown = String.raw`before
 \[

--- a/lib/markdown.test.mjs
+++ b/lib/markdown.test.mjs
@@ -110,9 +110,19 @@ describe("normalizeDisplayMath", () => {
       );
     });
 
-    it("leaves non-math bracket-only prose untouched", () => {
-      const input = "[普通说明文字]";
-      assert.equal(normalizeDisplayMath(input), input);
+    it("leaves ambiguous bracket-only Markdown untouched", () => {
+      for (const input of [
+        "[普通说明文字]",
+        "[See note (important)]",
+        "[status=ready]",
+        "[yes/no]",
+        "[API_v2]\n\n[API_v2]: https://example.com/docs",
+        "[C:\\Users\\alex]",
+        "[\\\\server\\share]",
+        "[https://example.com/\\alpha]",
+      ]) {
+        assert.equal(normalizeDisplayMath(input), input);
+      }
     });
   });
 });

--- a/lib/markdown.test.mjs
+++ b/lib/markdown.test.mjs
@@ -101,4 +101,18 @@ describe("normalizeDisplayMath", () => {
       );
     });
   });
+
+  describe("loose [ … ] formula blocks", () => {
+    it("normalizes model-emitted bracket-only formula lines", () => {
+      assert.equal(
+        normalizeDisplayMath("[ C(x) = \\frac{2}{T(T-1)} \\sum_{i<j} S(\\hat{y}^{(i)}, \\hat{y}^{(j)}) ]"),
+        "$$\nC(x) = \\frac{2}{T(T-1)} \\sum_{i<j} S(\\hat{y}^{(i)}, \\hat{y}^{(j)})\n$$",
+      );
+    });
+
+    it("leaves non-math bracket-only prose untouched", () => {
+      const input = "[普通说明文字]";
+      assert.equal(normalizeDisplayMath(input), input);
+    });
+  });
 });

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -89,6 +89,19 @@ export function normalizeDisplayMath(markdown: string): string {
       }
     }
 
+    const looseBracketDisplayOneLine = line.match(/^([ ]{0,3})\[[ \t]*(.+?)[ \t]*\][ \t]*$/);
+    if (looseBracketDisplayOneLine) {
+      const math = looseBracketDisplayOneLine[2].trim();
+      if (isLikelyMathExpression(math)) {
+        normalized.push(
+          `${looseBracketDisplayOneLine[1]}$$`,
+          `${looseBracketDisplayOneLine[1]}${math}`,
+          `${looseBracketDisplayOneLine[1]}$$`,
+        );
+        continue;
+      }
+    }
+
     const bracketDisplayStart = line.match(/^([ ]{0,3})\\\[[ \t]*$/);
     if (bracketDisplayStart) {
       const closingIndex = findBracketDisplayClose(lines, index + 1);
@@ -312,6 +325,17 @@ function normalizeInlineLatexMath(line: string): string {
   return line.replace(
     /(?<!\\)\\\(([^`\r\n$]+?)(?<!\\)\\\)/g,
     (match, math: string) => (math.trim() ? `$${math}$` : match),
+  );
+}
+
+function isLikelyMathExpression(value: string): boolean {
+  if (!value || value.length < 3) return false;
+  if (/]\s*\(/.test(value) || /\b(?:https?|file|mailto):/i.test(value)) return false;
+  return (
+    /\\[A-Za-z]+/.test(value) ||
+    /[_^{}=<>|]/.test(value) ||
+    /[A-Za-z]\s*\([^)]*\)/.test(value) ||
+    /(?:\\)?[A-Za-z]+\s*[+\-*/]\s*(?:\\)?[A-Za-z0-9]/.test(value)
   );
 }
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -329,14 +329,7 @@ function normalizeInlineLatexMath(line: string): string {
 }
 
 function isLikelyMathExpression(value: string): boolean {
-  if (!value || value.length < 3) return false;
-  if (/]\s*\(/.test(value) || /\b(?:https?|file|mailto):/i.test(value)) return false;
-  return (
-    /\\[A-Za-z]+/.test(value) ||
-    /[_^{}=<>|]/.test(value) ||
-    /[A-Za-z]\s*\([^)]*\)/.test(value) ||
-    /(?:\\)?[A-Za-z]+\s*[+\-*/]\s*(?:\\)?[A-Za-z0-9]/.test(value)
-  );
+  return /\\[A-Za-z]+/.test(value) && !/\b(?:https?|file|mailto):|\b[A-Za-z]:\\|^\\\\/i.test(value);
 }
 
 // Parse YAML frontmatter into a `yaml` node before the math/GFM plugins run, so


### PR DESCRIPTION
 ## Summary

  Fix rendering for model-emitted display math blocks written as standalone bracketed lines.

  Some models emit formulas like this:

  ```md
  [ C(x) = \frac{2}{T(T-1)} \sum_{i<j} S(\hat{y}^{(i)}, \hat{y}^{(j)}) ]
  ```

  Pi Web previously rendered that as plain text. This change normalizes likely math-only bracket lines into standard display
  math before Markdown parsing:

  ```md
  $$
  C(x) = \frac{2}{T(T-1)} \sum_{i<j} S(\hat{y}^{(i)}, \hat{y}^{(j)})
  $$
  ```

  Expected rendered result:

  ```math
  C(x) = \frac{2}{T(T-1)} \sum_{i<j} S(\hat{y}^{(i)}, \hat{y}^{(j)})
  ```

  ## Changes

  - Normalize standalone `[ ... ]` lines that look like math into display math fences.
  - Leave ordinary bracket-only prose unchanged.
  - Add regression tests for normalization and KaTeX rendering.

  ## Test Plan

  ```bash
  node --experimental-strip-types --test components/MarkdownBody.test.mjs lib/markdown.test.mjs
  node_modules/.bin/tsc --noEmit
  git diff --check -- lib/markdown.ts components/MarkdownBody.test.mjs lib/markdown.test.mjs
  ```