### PR TITLE
fix: report why the Next.js child stopped

### DIFF
--- a/bin/process-lifecycle.js
+++ b/bin/process-lifecycle.js
@@ -11,11 +11,30 @@ function getSignalExitCode(signal) {
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }
 
-function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = shutdownTimeoutMs) {
+function describeExit(code, signal) {
+  return signal ? `signal ${signal}` : `code ${code}`;
+}
+
+function wireChildProcessLifecycle(
+  child,
+  parentProcess = process,
+  timeoutMs = shutdownTimeoutMs,
+  log = console.error,
+) {
   const signalHandlers = new Map();
   let shutdownTimer;
+  // Set once we forward a signal, so an exit we asked for stays quiet and one
+  // we did not gets reported.
+  let shuttingDown = false;
 
   const forceKill = () => child.kill("SIGKILL");
+
+  const unwire = () => {
+    if (shutdownTimer) clearTimeout(shutdownTimer);
+    for (const [forwardedSignal, handler] of signalHandlers) {
+      parentProcess.removeListener(forwardedSignal, handler);
+    }
+  };
 
   for (const signal of forwardedSignals) {
     const handler = () => {
@@ -24,6 +43,7 @@ function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = s
         return;
       }
 
+      shuttingDown = true;
       shutdownTimer = setTimeout(forceKill, timeoutMs);
       shutdownTimer.unref();
       child.kill(signal);
@@ -32,11 +52,21 @@ function wireChildProcessLifecycle(child, parentProcess = process, timeoutMs = s
     parentProcess.on(signal, handler);
   }
 
-  child.once("exit", (code, signal) => {
-    if (shutdownTimer) clearTimeout(shutdownTimer);
+  // Without a listener an 'error' event is fatal to the wrapper itself, so a
+  // spawn failure surfaced as a bare stack trace rather than a reason.
+  child.once("error", (error) => {
+    unwire();
+    log(`[pi-web] could not run the Next.js process: ${error.message}`);
+    parentProcess.exit(1);
+  });
 
-    for (const [forwardedSignal, handler] of signalHandlers) {
-      parentProcess.removeListener(forwardedSignal, handler);
+  child.once("exit", (code, signal) => {
+    unwire();
+
+    // A shutdown the user asked for needs no explanation; anything else left
+    // the window closing with no stated reason.
+    if (!shuttingDown && (signal || (code ?? 0) !== 0)) {
+      log(`[pi-web] Next.js exited unexpectedly (${describeExit(code, signal)})`);
     }
 
     parentProcess.exit(code ?? getSignalExitCode(signal));

--- a/bin/process-lifecycle.js
+++ b/bin/process-lifecycle.js
@@ -11,10 +11,6 @@ function getSignalExitCode(signal) {
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }
 
-function describeExit(code, signal) {
-  return signal ? `signal ${signal}` : `code ${code}`;
-}
-
 function wireChildProcessLifecycle(
   child,
   parentProcess = process,
@@ -29,12 +25,25 @@ function wireChildProcessLifecycle(
 
   const forceKill = () => child.kill("SIGKILL");
 
-  const unwire = () => {
+  function unwire() {
     if (shutdownTimer) clearTimeout(shutdownTimer);
     for (const [forwardedSignal, handler] of signalHandlers) {
       parentProcess.removeListener(forwardedSignal, handler);
     }
-  };
+    child.removeListener("error", handleError);
+  }
+
+  function handleError(error) {
+    const failedToSpawn = child.pid === undefined;
+    log(
+      `[pi-web] ${failedToSpawn ? "could not run the Next.js process" : "Next.js process error"}: ${error.message}`,
+    );
+
+    if (failedToSpawn) {
+      unwire();
+      parentProcess.exit(1);
+    }
+  }
 
   for (const signal of forwardedSignals) {
     const handler = () => {
@@ -52,21 +61,17 @@ function wireChildProcessLifecycle(
     parentProcess.on(signal, handler);
   }
 
-  // Without a listener an 'error' event is fatal to the wrapper itself, so a
-  // spawn failure surfaced as a bare stack trace rather than a reason.
-  child.once("error", (error) => {
-    unwire();
-    log(`[pi-web] could not run the Next.js process: ${error.message}`);
-    parentProcess.exit(1);
-  });
+  child.on("error", handleError);
 
   child.once("exit", (code, signal) => {
     unwire();
 
     // A shutdown the user asked for needs no explanation; anything else left
     // the window closing with no stated reason.
-    if (!shuttingDown && (signal || (code ?? 0) !== 0)) {
-      log(`[pi-web] Next.js exited unexpectedly (${describeExit(code, signal)})`);
+    if (!shuttingDown) {
+      log(
+        `[pi-web] Next.js exited unexpectedly (${signal ? `signal ${signal}` : `code ${code}`})`,
+      );
     }
 
     parentProcess.exit(code ?? getSignalExitCode(signal));

--- a/lib/process-lifecycle.test.mjs
+++ b/lib/process-lifecycle.test.mjs
@@ -81,3 +81,63 @@ test("uses conventional exit statuses for known child signals", () => {
     assert.deepEqual(exitCodes, [expectedExitCode]);
   }
 });
+
+test("reports a spawn failure instead of crashing on an unhandled error event", () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  // Without a listener this event is fatal to the wrapper itself.
+  child.emit("error", new Error("spawn node ENOENT"));
+
+  assert.deepEqual(exitCodes, [1]);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /could not run the Next\.js process: spawn node ENOENT/);
+  assert.equal(parent.listenerCount("SIGINT"), 0, "the signal wiring must be torn down");
+});
+
+test("names the reason when the child stops on its own", () => {
+  for (const [code, signal, expected] of [
+    [null, "SIGKILL", /signal SIGKILL/],
+    [1, null, /code 1/],
+  ]) {
+    const { parent, child, exitCodes } = createProcesses();
+    const logged = [];
+
+    wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+    child.emit("exit", code, signal);
+
+    assert.equal(logged.length, 1, `expected one line for ${describe(code, signal)}`);
+    assert.match(logged[0], expected);
+    // The exit status still carries the failure.
+    assert.notDeepEqual(exitCodes, [0]);
+  }
+});
+
+test("stays quiet for a shutdown the user asked for", async () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  parent.emit("SIGINT");
+  child.emit("exit", null, "SIGINT");
+  await delay(20);
+
+  assert.deepEqual(logged, [], "ctrl+c is not an incident");
+  assert.deepEqual(exitCodes, [130]);
+});
+
+test("a clean exit says nothing", () => {
+  const { parent, child, exitCodes } = createProcesses();
+  const logged = [];
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  child.emit("exit", 0, null);
+
+  assert.deepEqual(logged, []);
+  assert.deepEqual(exitCodes, [0]);
+});
+
+function describe(code, signal) {
+  return signal ? `signal ${signal}` : `code ${code}`;
+}

--- a/lib/process-lifecycle.test.mjs
+++ b/lib/process-lifecycle.test.mjs
@@ -75,7 +75,7 @@ test("uses conventional exit statuses for known child signals", () => {
   ]) {
     const { parent, child, exitCodes } = createProcesses();
 
-    wireChildProcessLifecycle(child, parent);
+    wireChildProcessLifecycle(child, parent, undefined, () => {});
     child.emit("exit", null, signal);
 
     assert.deepEqual(exitCodes, [expectedExitCode]);
@@ -97,9 +97,10 @@ test("reports a spawn failure instead of crashing on an unhandled error event", 
 });
 
 test("names the reason when the child stops on its own", () => {
-  for (const [code, signal, expected] of [
-    [null, "SIGKILL", /signal SIGKILL/],
-    [1, null, /code 1/],
+  for (const [code, signal, expectedReason, expectedExitCode] of [
+    [null, "SIGKILL", "signal SIGKILL", 137],
+    [1, null, "code 1", 1],
+    [0, null, "code 0", 0],
   ]) {
     const { parent, child, exitCodes } = createProcesses();
     const logged = [];
@@ -107,11 +108,35 @@ test("names the reason when the child stops on its own", () => {
     wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
     child.emit("exit", code, signal);
 
-    assert.equal(logged.length, 1, `expected one line for ${describe(code, signal)}`);
-    assert.match(logged[0], expected);
-    // The exit status still carries the failure.
-    assert.notDeepEqual(exitCodes, [0]);
+    assert.deepEqual(logged, [`[pi-web] Next.js exited unexpectedly (${expectedReason})`]);
+    assert.deepEqual(exitCodes, [expectedExitCode]);
   }
+});
+
+test("keeps the shutdown fallback armed when signaling the child fails", async () => {
+  const { parent, child, forwardedSignals, exitCodes } = createProcesses();
+  const logged = [];
+
+  child.pid = 123;
+  child.kill = (signal) => {
+    forwardedSignals.push(signal);
+    if (signal === "SIGTERM") {
+      child.emit("error", new Error("kill EPERM"));
+      return false;
+    }
+    child.emit("exit", null, signal);
+    return true;
+  };
+
+  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
+  parent.emit("SIGTERM");
+  assert.deepEqual(exitCodes, []);
+
+  await delay(20);
+
+  assert.deepEqual(forwardedSignals, ["SIGTERM", "SIGKILL"]);
+  assert.deepEqual(logged, ["[pi-web] Next.js process error: kill EPERM"]);
+  assert.deepEqual(exitCodes, [137]);
 });
 
 test("stays quiet for a shutdown the user asked for", async () => {
@@ -126,18 +151,3 @@ test("stays quiet for a shutdown the user asked for", async () => {
   assert.deepEqual(logged, [], "ctrl+c is not an incident");
   assert.deepEqual(exitCodes, [130]);
 });
-
-test("a clean exit says nothing", () => {
-  const { parent, child, exitCodes } = createProcesses();
-  const logged = [];
-
-  wireChildProcessLifecycle(child, parent, 10, (line) => logged.push(line));
-  child.emit("exit", 0, null);
-
-  assert.deepEqual(logged, []);
-  assert.deepEqual(exitCodes, [0]);
-});
-
-function describe(code, signal) {
-  return signal ? `signal ${signal}` : `code ${code}`;
-}


### PR DESCRIPTION
Supersedes #515 and preserves its original diagnostics work, with two lifecycle fixes:

- report every child exit not initiated by the wrapper, including code 0
- distinguish spawn failures from runtime ChildProcess errors so a failed shutdown signal does not disarm the SIGKILL fallback

Also removes the child error listener during cleanup.

Test: node --experimental-strip-types --test lib/process-lifecycle.test.mjs (8 passed)

Fixes #506.