### PR TITLE
fix: keep modal dialogs clear of the iOS status bar in standalone mode

### DIFF
--- a/app/settings.css
+++ b/app/settings.css
@@ -1098,3 +1098,21 @@
   from { stroke-dashoffset: 18; opacity: 0; }
   to   { stroke-dashoffset: 0;  opacity: 1; }
 }
+
+/* iOS standalone: env(safe-area-inset-top) can report 0 and vh includes the
+   status-bar strip, so centered dialog headers end up under the clock and
+   Dynamic Island. Pad the backdrops with a hard fallback strip and cap the
+   dialog surfaces to the padded box so 84vh/vh sizing cannot push them back
+   under the status bar. */
+@media (display-mode: standalone) {
+  .settings-dialog-backdrop,
+  .config-panel-root.is-modal {
+    padding-top: max(59px, env(safe-area-inset-top));
+    padding-bottom: max(24px, env(safe-area-inset-bottom));
+  }
+
+  .settings-dialog-surface,
+  .config-panel-root.is-modal > .config-panel-surface {
+    max-height: 100%;
+  }
+}

--- a/app/settings.css
+++ b/app/settings.css
@@ -1099,20 +1099,32 @@
   to   { stroke-dashoffset: 0;  opacity: 1; }
 }
 
-/* iOS standalone: env(safe-area-inset-top) can report 0 and vh includes the
-   status-bar strip, so centered dialog headers end up under the clock and
-   Dynamic Island. Pad the backdrops with a hard fallback strip and cap the
-   dialog surfaces to the padded box so 84vh/vh sizing cannot push them back
-   under the status bar. */
-@media (display-mode: standalone) {
-  .settings-dialog-backdrop,
-  .config-panel-root.is-modal {
-    padding-top: max(59px, env(safe-area-inset-top));
-    padding-bottom: max(24px, env(safe-area-inset-bottom));
+/* iOS standalone: env() can report 0, so keep a device-sized fallback on the
+   status-bar edge and cap dialog surfaces to the resulting safe box. */
+@supports (-webkit-touch-callout: none) {
+  @media (display-mode: standalone) {
+    .settings-dialog-backdrop,
+    .config-panel-root.is-modal {
+      padding-top: max(59px, env(safe-area-inset-top));
+      padding-right: max(8px, env(safe-area-inset-right));
+      padding-bottom: max(24px, env(safe-area-inset-bottom));
+      padding-left: max(8px, env(safe-area-inset-left));
+    }
+
+    .settings-dialog-surface,
+    .config-panel-root.is-modal > .config-panel-surface {
+      max-width: 100%;
+      max-height: 100%;
+    }
   }
 
-  .settings-dialog-surface,
-  .config-panel-root.is-modal > .config-panel-surface {
-    max-height: 100%;
+  @media (display-mode: standalone) and (orientation: landscape) {
+    .settings-dialog-backdrop,
+    .config-panel-root.is-modal {
+      padding-top: max(8px, env(safe-area-inset-top));
+      padding-right: max(59px, env(safe-area-inset-right));
+      padding-bottom: max(8px, env(safe-area-inset-bottom));
+      padding-left: max(59px, env(safe-area-inset-left));
+    }
   }
 }

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -50,6 +50,8 @@ test("prevents iOS focus zoom from widening the layout", () => {
 });
 
 test("keeps modal dialogs clear of the iOS status bar in standalone mode", () => {
-  assert.match(settingsCssSource, /@media \(display-mode: standalone\) \{[\s\S]*?\.settings-dialog-backdrop,[\s\S]*?\.config-panel-root\.is-modal \{[\s\S]*?padding-top: max\(59px, env\(safe-area-inset-top\)\);[\s\S]*?padding-bottom: max\(24px, env\(safe-area-inset-bottom\)\);/);
-  assert.match(settingsCssSource, /@media \(display-mode: standalone\) \{[\s\S]*?\.settings-dialog-surface,[\s\S]*?\.config-panel-root\.is-modal > \.config-panel-surface \{[\s\S]*?max-height: 100%;/);
+  assert.match(settingsCssSource, /@supports \(-webkit-touch-callout: none\) \{[\s\S]*?@media \(display-mode: standalone\) \{/);
+  assert.match(settingsCssSource, /padding-top: max\(59px, env\(safe-area-inset-top\)\);[\s\S]*?padding-right: max\(8px, env\(safe-area-inset-right\)\);[\s\S]*?padding-bottom: max\(24px, env\(safe-area-inset-bottom\)\);[\s\S]*?padding-left: max\(8px, env\(safe-area-inset-left\)\);/);
+  assert.match(settingsCssSource, /@media \(display-mode: standalone\) and \(orientation: landscape\) \{[\s\S]*?padding-top: max\(8px, env\(safe-area-inset-top\)\);[\s\S]*?padding-right: max\(59px, env\(safe-area-inset-right\)\);[\s\S]*?padding-bottom: max\(8px, env\(safe-area-inset-bottom\)\);[\s\S]*?padding-left: max\(59px, env\(safe-area-inset-left\)\);/);
+  assert.match(settingsCssSource, /\.settings-dialog-surface,[\s\S]*?\.config-panel-root\.is-modal > \.config-panel-surface \{[\s\S]*?max-width: 100%;[\s\S]*?max-height: 100%;/);
 });

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const layoutSource = await readFile(new URL("../app/layout.tsx", import.meta.url), "utf8");
+const settingsCssSource = await readFile(new URL("../app/settings.css", import.meta.url), "utf8");
 const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 const appShellSource = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
 const chatWindowSource = await readFile(new URL("./ChatWindow.tsx", import.meta.url), "utf8");
@@ -46,4 +47,9 @@ test("contains chat content and inputs within the mobile viewport", () => {
 
 test("prevents iOS focus zoom from widening the layout", () => {
   assert.match(cssSource, /@media \(max-width: 640px\)[\s\S]*?textarea,[\s\S]*?input,[\s\S]*?select \{\s*font-size: 16px !important;/);
+});
+
+test("keeps modal dialogs clear of the iOS status bar in standalone mode", () => {
+  assert.match(settingsCssSource, /@media \(display-mode: standalone\) \{[\s\S]*?\.settings-dialog-backdrop,[\s\S]*?\.config-panel-root\.is-modal \{[\s\S]*?padding-top: max\(59px, env\(safe-area-inset-top\)\);[\s\S]*?padding-bottom: max\(24px, env\(safe-area-inset-bottom\)\);/);
+  assert.match(settingsCssSource, /@media \(display-mode: standalone\) \{[\s\S]*?\.settings-dialog-surface,[\s\S]*?\.config-panel-root\.is-modal > \.config-panel-surface \{[\s\S]*?max-height: 100%;/);
 });


### PR DESCRIPTION
Fixes #603

## 问题

0.8.10 起（#547 全屏铺满后），iOS PWA（standalone）中打开设置弹窗（`.settings-dialog-backdrop`）或 Provider 配置弹窗（`.config-panel-root.is-modal`），弹窗标题栏与系统状态栏/灵动岛重叠，页签无法点击。

## 根因

两层，真机验证缺一不可：

1. 两个遮罩 `inset: 0` 垂直居中且无 `env(safe-area-inset-*)` 避让；standalone 下 `dvh` 不含状态栏条而画布从屏幕顶开始，居中后头部落入状态栏区域。
2. 只给遮罩加 padding 不够：`.settings-dialog-surface` 的 `height: 84vh` 中 standalone 的 `vh` 含状态栏条（偏大），会把头部重新顶回状态栏；且真机上 `env(safe-area-inset-top)` 可能返回 0（`viewport-fit=cover` 已确认存在）。

## 修复

`app/settings.css` 新增 standalone 媒体查询块：

- 遮罩 `padding-top: max(59px, env(safe-area-inset-top))`、`padding-bottom: max(24px, env(safe-area-inset-bottom))`（env 可用时取更大值，不可用时硬兜底）；
- 两个弹窗 surface `max-height: 100%`，限制在留白后的内容区内。

## 测试

- 新增 `MobilePwaLayout.test.mjs` 断言（跟随 #547 建立的既有范式），`node --test components/MobilePwaLayout.test.mjs` 5/5 通过；
- iPhone（灵动岛机型，iOS PWA standalone）真机验证：弹窗标题栏回到状态栏下方，页签恢复正常点击。