### PR TITLE
fix(security): tolerate Chromium 150+ stripping port from Origin while keeping port CSRF defense

### DIFF
--- a/lib/request-security.test.mjs
+++ b/lib/request-security.test.mjs
@@ -178,6 +178,138 @@ test("rejects missing, malformed, and unconfigured Host headers", async () => {
   })), false);
 });
 
+test("allows same-origin requests when Chromium strips the port from Origin", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Loopback IP with the port stripped from Origin (Chromium 150+ behavior).
+  const loopback = new Request("http://127.0.0.1:30141/api/agent/running", {
+    headers: {
+      host: "127.0.0.1:30141",
+      origin: "http://127.0.0.1",
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  assert.equal(isApiRequestAllowed(loopback), true);
+
+  // LAN IP with the port stripped from Origin.
+  const lan = new Request("http://192.168.32.7:30141/api/test", {
+    method: "POST",
+    headers: {
+      host: "192.168.32.7:30141",
+      origin: "http://192.168.32.7",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(lan), true);
+
+  // Loopback name with the port stripped from Origin.
+  const named = new Request("http://localhost:30141/api/test", {
+    method: "POST",
+    headers: {
+      host: "localhost:30141",
+      origin: "http://localhost",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(named), true);
+});
+
+test("still rejects when Origin hostname differs from Host even with port stripped", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Cross-loopback-name origin should not slip through just because both
+  // sides happen to be loopback addresses.
+  const crossName = new Request("http://localhost:30141/api/test", {
+    headers: {
+      host: "localhost:30141",
+      origin: "http://127.0.0.1",
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  assert.equal(isApiRequestAllowed(crossName), false);
+
+  // Attacker host matching its own Origin must still be blocked by the
+  // Host allowlist, not the Origin comparison.
+  const dnsRebind = new Request("http://localhost:30141/api/skills/install", {
+    method: "POST",
+    headers: {
+      host: "attacker.example:30141",
+      origin: "http://attacker.example",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(dnsRebind), false);
+});
+
+test("rejects cross-port CSRF when Origin includes a mismatched port", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Attacker host on a sibling port. The Host allowlist permits the hostname
+  // because pi-web.operator.dev is the operator-configured origin. A naive
+  // hostname-only Origin check would accept this; the port-aware check must
+  // not.
+  const crossPort = new Request("http://pi-web.operator.dev:30141/api/skills/install", {
+    method: "POST",
+    headers: {
+      host: "pi-web.operator.dev:30141",
+      origin: "http://pi-web.operator.dev:8080",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(crossPort, ["pi-web.operator.dev"]), false);
+});
+
+test("accepts same-origin requests when Origin port matches the request port", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Legacy / pre-Chromium-150 behavior: Origin includes the port and it
+  // matches Host. Must still pass.
+  const matchingPort = new Request("http://127.0.0.1:30141/api/agent/running", {
+    headers: {
+      host: "127.0.0.1:30141",
+      origin: "http://127.0.0.1:30141",
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  assert.equal(isApiRequestAllowed(matchingPort), true);
+});
+
+test("rejects Origin whose scheme differs even when hostname and port match", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // https attacker on a loopback port must not be able to drive an http API.
+  const httpsDowngrade = new Request("http://127.0.0.1:30141/api/test", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:30141",
+      origin: "https://127.0.0.1:30141",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+  });
+  assert.equal(isApiRequestAllowed(httpsDowngrade), false);
+});
+
+test("accepts real-world Chrome 152 POST against /api with the port stripped from Origin", async () => {
+  const { isApiRequestAllowed } = await loadSubject();
+  // Mirrors the failing request captured on Chrome 152.0.0.0:
+  //   POST /api/default-cwd HTTP/1.1
+  //   Host: 127.0.0.1:30141
+  //   Origin: http://127.0.0.1          ← port stripped by Chromium
+  //   Sec-Fetch-Site: same-origin
+  //   Sec-Fetch-Mode: cors
+  //   Content-Length: 0
+  const captured = new Request("http://127.0.0.1:30141/api/default-cwd", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:30141",
+      origin: "http://127.0.0.1",
+      "sec-fetch-site": "same-origin",
+      "sec-fetch-mode": "cors",
+    },
+  });
+  assert.equal(isApiRequestAllowed(captured), true);
+});
+
 test("recognizes JSON request content types", async () => {
   const { hasJsonContentType } = await loadSubject();
   assert.equal(hasJsonContentType(new Request("http://localhost", {

--- a/lib/request-security.ts
+++ b/lib/request-security.ts
@@ -128,7 +128,60 @@ function isProxyRewrittenSameOrigin(request: Request, origin: string): boolean {
   return originAuthority !== null && originAuthority === normalizeAuthority(host);
 }
 
-/** Reject browser cross-site API requests while preserving non-browser clients. */
+/**
+ * Chromium 150+ strips the port from the `Origin` header for same-origin
+ * requests against non-default-port backends. Verified on Chrome 152.0.0.0:
+ * a browser fetch from `http://127.0.0.1:30141` sends
+ * `Origin: http://127.0.0.1` (no port) for both GET and POST in cors mode,
+ * and `Referer` strips the port the same way. The previous strict
+ * canonical-origin comparison therefore rejected every legitimate `/api/*`
+ * call against a non-default-port pi-web server.
+ *
+ * Accept such requests only when the request is genuinely same-origin,
+ * scheme + hostname match the request URL, and any port included in Origin
+ * matches the request port — the latter blocks cross-port same-site CSRF
+ * (e.g. an attacker on `myapp.com:8080` forging a request to
+ * `myapp.com:30141` with `Origin: http://myapp.com:8080`). See issue #542.
+ *
+ * Scheme is taken from `request.url` (via `getRequestOrigin`), not the Host
+ * header, so an http→https mismatch is still rejected even though the Host
+ * header itself has no scheme.
+ */
+function isChromePortStrippedSameOrigin(request: Request, origin: string): boolean {
+  if (request.headers.get("sec-fetch-site") !== "same-origin") return false;
+
+  const requestOrigin = getRequestOrigin(request);
+  if (!requestOrigin) return false;
+
+  let originUrl: URL;
+  let requestUrl: URL;
+  try {
+    originUrl = new URL(origin);
+    requestUrl = new URL(requestOrigin);
+  } catch {
+    return false;
+  }
+
+  if (originUrl.protocol !== requestUrl.protocol) return false;
+  if (originUrl.hostname !== requestUrl.hostname) return false;
+  if (originUrl.port && originUrl.port !== requestUrl.port) return false;
+
+  return true;
+}
+
+/**
+ * Reject browser cross-site API requests while preserving non-browser clients.
+ *
+ * Three accept paths:
+ *
+ * 1. Strict canonical-origin match — covers the common same-origin case.
+ * 2. Proxy rewritten Origin onto the backend authority — Azure Dev Tunnels,
+ *    Daytona, and similar relays. Requires same-origin Fetch Metadata and
+ *    an `x-forwarded-proto` header to prove a proxy is in front.
+ * 3. Chromium 150+ stripped the port from Origin — same-origin request
+ *    against a non-default-port backend. Scheme + hostname must still match
+ *    Host; the port is only checked when Origin carries one.
+ */
 export function isApiRequestOriginAllowed(request: Request): boolean {
   const origin = request.headers.get("origin");
   const fetchSite = request.headers.get("sec-fetch-site");
@@ -137,8 +190,10 @@ export function isApiRequestOriginAllowed(request: Request): boolean {
 
   const requestOrigin = getRequestOrigin(request);
   if (requestOrigin !== null && canonicalOrigin(origin) === requestOrigin) return true;
+  if (isProxyRewrittenSameOrigin(request, origin)) return true;
+  if (isChromePortStrippedSameOrigin(request, origin)) return true;
 
-  return isProxyRewrittenSameOrigin(request, origin);
+  return false;
 }
 
 export function shouldCheckApiRequestOrigin(request: Request): boolean {


### PR DESCRIPTION
## Summary

`isApiRequestOriginAllowed` (`lib/request-security.ts`) rejects every `/api/*` request with 403 on Chromium 150+, because Chrome now strips the port from the `Origin` header for same-origin requests on non-default ports.

Fixes #542

## Evidence

**Requested by the reviewer on #544**: HAR or raw headers from a failing POST request, with the exact Chrome version.

Exact Chrome version (from `chrome://version/`):

```
Google Chrome    152.0.7977.65 (正式版本) （64 位）
revision         fc4d67f1788019a27e32511137ceccbd2fafdaaa-refs/branch-heads/7977@{#1892}
OS               Windows 11 Version 25H2 (Build 26200.9168)
JS engine        V8 15.2.124.18
User-Agent       Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36
```

The User-Agent only carries the major version (`152.0.0.0`); the build version is `152.0.7977.65`. The behavior described below was verified against this exact build.

Failing POST request, captured from DevTools → Network:

```
POST /api/default-cwd HTTP/1.1
Host: 127.0.0.1:30141
Origin: http://127.0.0.1                          ← port stripped by Chrome
Referer: http://127.0.0.1:30141/                  ← Referer also strips the port
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: cors
sec-ch-ua: "Chromium";v="152", "Not?A_Brand";v="24", "Google Chrome";v="152"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "Windows"
Content-Length: 0
```

Response: `403 Forbidden`, body `{"error":"Untrusted API request"}`.

The same browser also fires GET requests in `cors` mode (e.g. `/api/agent/running` polled every ~2.5s) which produce identical behavior — `Origin: http://127.0.0.1` paired with `Host: 127.0.0.1:30141`. HAR of one such session attached to the original #544.

### Why the reviewer couldn't reproduce this

`Origin` is only sent when `Sec-Fetch-Mode: cors` (or similar) is set. A naïve reproduction that uses cURL, opens the URL differently, or runs against a default port will see 200 responses — the bug only surfaces for browser fetches against non-default ports.

### Chrome version note

The capture is from **Chrome 152.0.7977.65**, which is newer than the 151 the reviewer reported testing on. If a real Chrome 151 client behaves differently (i.e. preserves the port on POST), please share its raw `Origin` / `Host` headers and we can revisit. Practically the fix should hold for either Chromium generation:

| Client behavior           | Origin header        | Result    |
|---------------------------|----------------------|-----------|
| Chrome 151, port preserved | `http://127.0.0.1:30141` | accepted (strict match) |
| Chrome 152+, port stripped | `http://127.0.0.1`       | accepted (port-aware match) |
| Cross-port CSRF attempt    | `http://myapp.com:8080` vs `Host: myapp.com:30141` | rejected |

So the patch is forward-compatible with both Chrome 151 and Chrome 152+ — the only branch where it changes behavior vs. the current `main` is when Chrome strips the port on a same-origin request, and that branch is precisely the broken one.

## Reproduction

1. `npm install && npm run dev` on a fresh checkout
2. Open `http://127.0.0.1:30141` in Chrome 150+
3. DevTools → Network → any `/api/*` request → 403, body `{"error":"Untrusted API request"}`
4. Inspect Request Headers — `Origin` lacks the `:30141` suffix

## Fix

Build on top of the proxy-rewrite handler that landed on `main`. Add a third accept path in `isApiRequestOriginAllowed` for the Chromium port-strip:

| Origin              | Host                  | Behavior |
|---------------------|-----------------------|----------|
| `http://127.0.0.1`  | `127.0.0.1:30141`     | accept (Chromium 150+ strip) |
| `http://127.0.0.1:30141` | `127.0.0.1:30141` | accept (port-matching baseline) |
| `http://myapp.com:8080` | `myapp.com:30141` | **reject** (cross-port CSRF) |
| `https://myapp.com:30141` | `myapp.com:30141` | **reject** (scheme downgrade) |
| `http://attacker.example` | `127.0.0.1:30141` | **reject** (cross-site) |

## Security

The Host allowlist (`isApiRequestHostAllowed`) is unchanged and remains the authoritative gate on where the request was addressed. The proxy-rewrite handler is unchanged. The only loosening vs. strict canonical-origin comparison is accepting same-origin requests where Chromium has stripped the port from `Origin`.

## Tests

Existing 13 tests + 6 new ones, all 19/19 green:

- `allows same-origin requests when Chromium strips the port from Origin` (loopback IP / LAN IP / loopback name)
- `still rejects when Origin hostname differs from Host even with port stripped` (cross-name and DNS rebind regression)
- `rejects cross-port CSRF when Origin includes a mismatched port` (the regression a hostname-only fix would have introduced)
- `accepts same-origin requests when Origin port matches the request port` (pre-Chromium-150 baseline)
- `rejects Origin whose scheme differs even when hostname and port match` (https → http downgrade)
- `accepts real-world Chrome 152 POST against /api with the port stripped from Origin` (mirrors the captured `POST /api/default-cwd` exactly)

## Related

- #497 — same defect, open since 14 Aug
- #511 — alternate fix (requires X-Forwarded-Proto, doesn't cover our variant)
- gofixpoint/amika#373 — independently described Chromium port-stripping as "a separate upstream bug" against #542
- This supersedes the original #544 (hostname-only fix), which would have weakened cross-port CSRF defense