### PR TITLE
fix: keep client router.replace relative for sub-path deployments

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -610,7 +610,7 @@ export function AppShell() {
       // the default welcome page when none is remembered.
       restoreWorkspaceContext(newProject);
     }
-    router.replace("/", { scroll: false });
+    router.replace(typeof window !== "undefined" ? window.location.pathname : "/", { scroll: false });
   }, [activeCwd, invalidateWorkspaceRestore, newSessionCwd, router, selectedSession, restoreWorkspaceContext]);
 
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
@@ -667,7 +667,7 @@ export function AppShell() {
     setSystemInfoLoading(false);
     setActiveTopPanel(null);
     if (isMobile) setSidebarOpen(false);
-    router.replace("/", { scroll: false });
+    router.replace(typeof window !== "undefined" ? window.location.pathname : "/", { scroll: false });
   }, [invalidateWorkspaceRestore, router, isMobile]);
 
   // Global keyboard shortcuts (handles Esc, Ctrl+Alt+N etc.)
@@ -867,7 +867,7 @@ export function AppShell() {
       setSystemTools(null);
       setSystemInfoLoading(false);
       setActiveTopPanel(null);
-      router.replace("/", { scroll: false });
+      router.replace(typeof window !== "undefined" ? window.location.pathname : "/", { scroll: false });
     }
   }, [invalidateWorkspaceRestore, selectedSession, router]);
 


### PR DESCRIPTION
## What does this PR do?

Three `router.replace("/")` calls in `AppShell.tsx` (`handleCwdChange`, `handleNewSession`, branch-switch cleanup) push the browser to the **origin root**, discarding the mount prefix on deployments served behind a path-prefix reverse proxy (e.g. `example.com/pi/`). The user lands on a 404/blank root page after switching project, creating a session, or switching branch.

Fix: replace `"/"` with `window.location.pathname` so the replace keeps the current mount prefix while still clearing the `?session=` query param. The original intent (drop the session query) is preserved — only the destination changes.

## Related Issue

No existing issue found for this. (Happy to file one first if preferred — sub-path deployments were discussed in #370 / #50 but those were about basePath support, which stays out of scope here.)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`components/AppShell.tsx` — 3 call sites, `"/"` → `typeof window !== "undefined" ? window.location.pathname : "/"`.

## Verification

Deployed behind an Nginx reverse proxy at a `/pi/` prefix (proxy strips the prefix, no basePath — same shape as #370 discussion): before the fix, project switch / new session / branch switch all navigate the browser to the origin root; after, they stay on the mounted prefix and only the `?session=` param clears. Also ran `components/AppShell*` vitest suites (pass) and `tsc --noEmit` (clean).

中文摘要：子路径反代部署下 `router.replace("/")` 会把浏览器顶到域名根路径，切换项目/新建会话/切换分支后直接 404。改为 `window.location.pathname` 保留挂载前缀，仅清除 session 查询参数——原语义不变，只改目的地。
