### PR TITLE
fix: tolerate SSE-buffering reverse proxies in the composer

### DIFF
--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -164,7 +164,16 @@ const PROMPT_SETTLE_INITIAL_DELAY_MS = 800;
 const PROMPT_SETTLE_POLL_MS = 600;
 const PROMPT_SETTLE_MAX_MS = 20_000;
 const EVENT_STREAM_IDLE_GRACE_MS = 30_000;
-const AGENT_STATE_RECONCILE_MS = 15_000;
+// Reverse proxies / WAFs that buffer text/event-stream responses can hold SSE
+// frames back, leaving prompt settlement to this poll. The default keeps the
+// historical cadence; deployments behind a buffering proxy can lower it via
+// NEXT_PUBLIC_AGENT_STATE_RECONCILE_MS (e.g. 2000) to settle within ~2s.
+const AGENT_STATE_RECONCILE_MS = Number(
+  (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_AGENT_STATE_RECONCILE_MS) || 15_000,
+) || 15_000;
+// Same class of mitigation: if the connected SSE event never arrives (buffering
+// proxy), still send the prompt after this long instead of dropping it silently.
+const SSE_CONNECT_RACE_TIMEOUT_MS = 3_000;
 const BASH_STATE_RECONCILE_MS = 1_000;
 const EVENT_STREAM_READY_TIMEOUT_MS = 60_000;
 const EVENT_STREAM_RECONNECT_DELAY_MS = 1_000;
@@ -1334,7 +1343,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             await sendAgentCommand(sid, { type: "set_model", provider: selectedModel.provider, modelId: selectedModel.modelId });
           }
         }
-        await ensureEventsConnected(sid);
+        // SSE readiness is best-effort: a buffering proxy may never deliver the
+        // connected event, so race a short timeout rather than block (and
+        // silently drop) the prompt; the reconcile poll settles the UI.
+        await Promise.race([ensureEventsConnected(sid), new Promise((r) => setTimeout(r, SSE_CONNECT_RACE_TIMEOUT_MS))]);
         promptRequestStarted = true;
         await sendAgentCommand(sid, {
           type: "prompt",
@@ -1344,7 +1356,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         promoteNewSession(1, message);
       } else if (session) {
         sentSessionId = session.id;
-        await ensureEventsConnected(session.id);
+        await Promise.race([ensureEventsConnected(session.id), new Promise((r) => setTimeout(r, SSE_CONNECT_RACE_TIMEOUT_MS))]);
         promptRequestStarted = true;
         await sendAgentCommand(session.id, {
           type: "prompt",


### PR DESCRIPTION
## What does this PR do?

Deployments behind a reverse proxy / WAF that buffers `text/event-stream` responses break two client paths, because SSE frames never reach the browser:

1. `ensureEventsConnected()` before `sendAgentCommand` waits for a connected event that never arrives — the composer **silently swallows the message** (input clears, no POST, no error). This PR races it against a 3s timeout (`SSE_CONNECT_RACE_TIMEOUT_MS`), so the prompt always goes out; a missed stream only costs event-based niceties, not the prompt itself.
2. Prompt settlement then relies on the reconcile poll (15s default). Kept the default, added opt-in `NEXT_PUBLIC_AGENT_STATE_RECONCILE_MS` so buffering-proxy deployments can lower it (e.g. 2000 → UI settles ~2s after completion).

## Design note

Defaults are unchanged — direct-connection users see zero behavior difference. The env override is opt-in for non-ideal proxies where the correct server-side fix (disabling SSE buffering) isn't available.

## Related Issue

No existing issue found for the silent-swallow symptom. 

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`hooks/useAgentSession.ts`:
- two `await ensureEventsConnected(...)` call sites → raced against `SSE_CONNECT_RACE_TIMEOUT_MS` (3s)
- `AGENT_STATE_RECONCILE_MS` now overridable via `NEXT_PUBLIC_AGENT_STATE_RECONCILE_MS` (default unchanged at 15s)

## Verification

Running behind Nginx with SSE buffering on (cannot change the upstream WAF config): without the fix, prompts never POST and the UI hangs; with it, prompts send, complete, and render within ~2s using the env override. Full vitest suite passes (844 tests), `tsc --noEmit` clean.

中文摘要：反代/WAF 缓冲 SSE 时，`ensureEventsConnected` 永远等不到 connected 事件，输入框会静默吞掉消息（不 POST 不报错）。改为 3s 竞速保底必发；reconcile 轮询保持 15s 默认、新增 `NEXT_PUBLIC_AGENT_STATE_RECONCILE_MS` 供缓冲代理部署降到 2s。默认行为零变化。
