### PR TITLE
Fix wide markdown tables being squeezed instead of scrolling horizontally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -479,10 +479,10 @@ pre, code {
 .markdown-body table {
   border-collapse: separate;
   border-spacing: 0;
-  width: max-content;
   min-width: 100%;
   font-size: 13px;
 }
+.markdown-table-wrap > table { width: max-content; }
 .markdown-body th, .markdown-body td {
   border: 0;
   border-bottom: 1px solid var(--border);

--- a/app/globals.css
+++ b/app/globals.css
@@ -479,6 +479,7 @@ pre, code {
 .markdown-body table {
   border-collapse: separate;
   border-spacing: 0;
+  width: max-content;
   min-width: 100%;
   font-size: 13px;
 }


### PR DESCRIPTION
Fixes #649.

## Problem

Markdown tables with many columns get cramped and wrap excessively. The wrapper `.markdown-table-wrap` already had `overflow-x: auto`, but table auto layout prefers shrinking columns and wrapping cell text to fit the container width, so the table never overflowed and the scrollbar never engaged.

## Fix

One line in `app/globals.css`: set the table `width: max-content` so wide tables keep their natural width and overflow the wrapper (which scrolls), while the existing `min-width: 100%` keeps narrow tables at full container width.

## Verification

Tested locally with a 12-column × 11-row table (plus surrounding prose) in the dev server:

https://github.com/user-attachments/assets/8dfba685-7a96-4286-a378-294ca620a0fb


