### PR TITLE
fix: keep file panel animation smooth by caching the highlight tree

### DIFF
--- a/components/FileViewer.test.mjs
+++ b/components/FileViewer.test.mjs
@@ -6,17 +6,26 @@ const source = await readFile(new URL("./FileViewer.tsx", import.meta.url), "utf
 
 test("large source previews bypass the per-line syntax highlighter", () => {
   assert.match(source, /const SOURCE_HIGHLIGHT_MAX_LINES = 1_000;/);
-  assert.match(source, /const useLightweightSource = lines\.length > SOURCE_HIGHLIGHT_MAX_LINES;/);
+  assert.match(source, /const useLightweightSource = sourceLines\.length > SOURCE_HIGHLIGHT_MAX_LINES;/);
 
-  const lightweightStart = source.indexOf(") : useLightweightSource ? (");
-  const syntaxStart = source.indexOf("<SyntaxHighlighter", lightweightStart);
+  // Both source trees are memoized so unrelated re-renders (panel open/close,
+  // selection changes) reuse them instead of rebuilding every line element.
+  assert.match(source, /const highlightedSource = useMemo\(/);
+
+  const lightweightStart = source.indexOf("const lightweightSourceLines = useMemo(");
+  const lightweightEnd = source.indexOf("[sourceLines, wrapLines]", lightweightStart);
   assert.notEqual(lightweightStart, -1);
-  assert.notEqual(syntaxStart, -1);
+  assert.notEqual(lightweightEnd, -1);
 
-  const lightweightSource = source.slice(lightweightStart, syntaxStart);
-  assert.match(lightweightSource, /className="file-source-view is-lightweight"/);
-  assert.match(lightweightSource, /lines\.map\(\(line, lineIndex\) =>/);
+  const lightweightSource = source.slice(lightweightStart, lightweightEnd);
+  assert.match(lightweightSource, /sourceLines\.map\(\(line, lineIndex\) =>/);
   assert.match(lightweightSource, /className="file-source-line"/);
   assert.match(lightweightSource, /className="file-source-line-content"/);
   assert.match(lightweightSource, /style=\{FILE_LINE_NUMBER_STYLE\}/);
+
+  // The lightweight branch still wins over the syntax highlighter in the JSX.
+  const branchStart = source.indexOf(") : useLightweightSource ? (");
+  assert.notEqual(branchStart, -1);
+  assert.match(source.slice(branchStart), /className="file-source-view is-lightweight"/);
+  assert.notEqual(source.indexOf("highlightedSource", branchStart), -1);
 });

--- a/components/FileViewer.test.mjs
+++ b/components/FileViewer.test.mjs
@@ -1,24 +1,26 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import React from "react";
+import ts from "typescript";
 
 const source = await readFile(new URL("./FileViewer.tsx", import.meta.url), "utf8");
 
 test("large source previews bypass the per-line syntax highlighter", () => {
   assert.match(source, /const SOURCE_HIGHLIGHT_MAX_LINES = 1_000;/);
-  assert.match(source, /const useLightweightSource = sourceLines\.length > SOURCE_HIGHLIGHT_MAX_LINES;/);
+  assert.match(source, /const useLightweightSource = sourceLines\.length > SOURCE_HIGHLIGHT_MAX_LINES/);
 
   // Both source trees are memoized so unrelated re-renders (panel open/close,
   // selection changes) reuse them instead of rebuilding every line element.
   assert.match(source, /const highlightedSource = useMemo\(/);
 
   const lightweightStart = source.indexOf("const lightweightSourceLines = useMemo(");
-  const lightweightEnd = source.indexOf("[sourceLines, wrapLines]", lightweightStart);
+  const lightweightEnd = source.indexOf("[sourceLines, useLightweightSource, wrapLines]", lightweightStart);
   assert.notEqual(lightweightStart, -1);
   assert.notEqual(lightweightEnd, -1);
 
   const lightweightSource = source.slice(lightweightStart, lightweightEnd);
-  assert.match(lightweightSource, /sourceLines\.map\(\(line, lineIndex\) =>/);
+  assert.match(lightweightSource, /useLightweightSource \? sourceLines\.map\(\(line, lineIndex\) =>/);
   assert.match(lightweightSource, /className="file-source-line"/);
   assert.match(lightweightSource, /className="file-source-line-content"/);
   assert.match(lightweightSource, /style=\{FILE_LINE_NUMBER_STYLE\}/);
@@ -28,4 +30,39 @@ test("large source previews bypass the per-line syntax highlighter", () => {
   assert.notEqual(branchStart, -1);
   assert.match(source.slice(branchStart), /className="file-source-view is-lightweight"/);
   assert.notEqual(source.indexOf("highlightedSource", branchStart), -1);
+});
+
+test("lightweight source rows are skipped for highlighted, diff, and preview views", () => {
+  // Execute the source-view calculations without mounting the file-fetching component.
+  const file = ts.createSourceFile("FileViewer.tsx", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const viewer = file.statements.find((node) => ts.isFunctionDeclaration(node) && node.name?.text === "TextFileViewer");
+  const calculations = viewer.body.statements.filter((node) =>
+    ts.isVariableStatement(node) && node.declarationList.declarations.some((declaration) =>
+      ["viewerContent", "sourceLines", "language", "isHtml", "isMarkdown", "hasPreview", "effectiveDisplayMode", "useLightweightSource", "lightweightSourceLines"].includes(declaration.name.getText(file)),
+    ),
+  ).map((node) => node.getText(file)).join("\n");
+  const { outputText } = ts.transpileModule(`
+    return (data, displayMode, hasGitDiff = false, isDeletedDiff = false, wrapLines = false) => {
+      const SOURCE_HIGHLIGHT_MAX_LINES = 1_000;
+      const FILE_LINE_NUMBER_STYLE = {};
+      ${calculations}
+      return lightweightSourceLines;
+    };
+  `, { compilerOptions: { jsx: ts.JsxEmit.React } });
+  const render = new Function("React", "useMemo", outputText)(React, (calculate) => calculate());
+  const large = { content: "line\n".repeat(1_000), language: "text" };
+
+  assert.equal(render({ ...large, content: "line\n".repeat(999) }, "source"), null);
+  assert.equal(render(large, "diff", true), null);
+  assert.equal(render(large, "source", true, true), null);
+  for (const language of ["html", "markdown"]) {
+    assert.equal(render({ ...large, language }, "preview"), null);
+  }
+  for (const mode of ["source", "diff", "preview"]) {
+    const rows = render(large, mode);
+    assert.equal(rows.length, 1_001, `${mode} must retain its source fallback`);
+    assert.equal(rows[0].props["data-line-number"], 1);
+    assert.equal(rows[0].props.children[1].props.children, "line");
+  }
+  assert.equal(render(large, "source", false, false, true)[0].props.children[1].props.style.whiteSpace, "pre-wrap");
 });

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -1196,14 +1196,90 @@ function TextFileViewer({
     [data],
   );
 
+  const viewerContent = data?.content ?? "";
+  const sourceLines = useMemo(() => viewerContent.split("\n"), [viewerContent]);
+  const language = data?.language ?? "text";
+  const useLightweightSource = sourceLines.length > SOURCE_HIGHLIGHT_MAX_LINES;
+  // react-syntax-highlighter rebuilds every token element on each render, which
+  // costs hundreds of milliseconds on large files. Cache the rendered trees so
+  // unrelated re-renders (panel open/close, selection changes) reuse them as-is.
+  const highlightedSource = useMemo(
+    () => (
+      <SyntaxHighlighter
+        className={wrapLines ? "file-source-view is-wrapped" : "file-source-view"}
+        language={language === "text" ? "plaintext" : language}
+        style={isDark ? vscDarkPlus : vs}
+        showLineNumbers
+        lineNumberStyle={{
+          ...FILE_LINE_NUMBER_STYLE,
+        }}
+        customStyle={{
+          margin: 0,
+          padding: 0,
+          border: 0,
+          background: "var(--bg)",
+          ...FILE_CODE_STYLE,
+          width: wrapLines ? "100%" : "max-content",
+          minWidth: "100%",
+          minHeight: "100%",
+          overflow: "visible",
+        }}
+        codeTagProps={{
+          style: {
+            fontFamily: "var(--font-mono)",
+            overflowWrap: wrapLines ? "anywhere" : "normal",
+          },
+        }}
+        renderer={(rendererProps) => (
+          <SourceCodeRenderer {...rendererProps} wrapLines={wrapLines} />
+        )}
+        wrapLongLines={wrapLines}
+      >
+        {viewerContent}
+      </SyntaxHighlighter>
+    ),
+    [isDark, language, viewerContent, wrapLines],
+  );
+  const lightweightSourceLines = useMemo(
+    () => sourceLines.map((line, lineIndex) => (
+      <span
+        className="file-source-line"
+        data-line-number={lineIndex + 1}
+        key={`source-line-${lineIndex}`}
+        style={{ display: "flex", minWidth: "100%" }}
+      >
+        <span aria-hidden="true" style={FILE_LINE_NUMBER_STYLE}>
+          {lineIndex + 1}
+        </span>
+        <span
+          className="file-source-line-content"
+          style={{
+            flex: "1 1 auto",
+            minWidth: 0,
+            overflowWrap: wrapLines ? "anywhere" : "normal",
+            whiteSpace: wrapLines ? "pre-wrap" : "pre",
+          }}
+        >
+          {line}
+        </span>
+      </span>
+    )),
+    [sourceLines, wrapLines],
+  );
+
   useEffect(() => {
     const updateSelectedLineRange = () => {
       const root = contentRef.current;
-      setSelectedLineRange(
-        onMentionLines && displayMode === "source" && root
+      setSelectedLineRange((current) => {
+        const next = onMentionLines && displayMode === "source" && root
           ? getSelectedSourceLineRange(root, window.getSelection())
-          : null,
-      );
+          : null;
+        // Skip no-op updates: selectionchange fires continuously while dragging,
+        // and a fresh-but-equal range object would re-render the whole viewer.
+        if (current === null && next === null) return current;
+        if (current && next && current.startLine === next.startLine && current.endLine === next.endLine) return current;
+        return next;
+      });
     };
 
     updateSelectedLineRange();
@@ -1284,14 +1360,12 @@ function TextFileViewer({
 
   if (!data && !isDeletedDiff) return null;
 
-  const language = data?.language ?? "text";
-  const content = data?.content ?? "";
+  const content = viewerContent;
   const isHtml = language === "html";
   const isMarkdown = language === "markdown";
   const hasPreview = isHtml || isMarkdown;
   const markdownDirectory = getFileDirectory(filePath);
-  const lines = content.split("\n");
-  const useLightweightSource = lines.length > SOURCE_HIGHLIGHT_MAX_LINES;
+  const lines = sourceLines;
   const effectiveDisplayMode = isDeletedDiff ? "diff" : displayMode;
   const displayModes: DisplayMode[] = isDeletedDiff
     ? ["diff"]
@@ -1514,63 +1588,10 @@ function TextFileViewer({
               ...FILE_CODE_STYLE,
             }}
           >
-            {lines.map((line, lineIndex) => (
-              <span
-                className="file-source-line"
-                data-line-number={lineIndex + 1}
-                key={`source-line-${lineIndex}`}
-                style={{ display: "flex", minWidth: "100%" }}
-              >
-                <span aria-hidden="true" style={FILE_LINE_NUMBER_STYLE}>
-                  {lineIndex + 1}
-                </span>
-                <span
-                  className="file-source-line-content"
-                  style={{
-                    flex: "1 1 auto",
-                    minWidth: 0,
-                    overflowWrap: wrapLines ? "anywhere" : "normal",
-                    whiteSpace: wrapLines ? "pre-wrap" : "pre",
-                  }}
-                >
-                  {line}
-                </span>
-              </span>
-            ))}
+            {lightweightSourceLines}
           </div>
         ) : (
-          <SyntaxHighlighter
-            className={wrapLines ? "file-source-view is-wrapped" : "file-source-view"}
-            language={language === "text" ? "plaintext" : language}
-            style={isDark ? vscDarkPlus : vs}
-            showLineNumbers
-            lineNumberStyle={{
-              ...FILE_LINE_NUMBER_STYLE,
-            }}
-            customStyle={{
-              margin: 0,
-              padding: 0,
-              border: 0,
-              background: "var(--bg)",
-              ...FILE_CODE_STYLE,
-              width: wrapLines ? "100%" : "max-content",
-              minWidth: "100%",
-              minHeight: "100%",
-              overflow: "visible",
-            }}
-            codeTagProps={{
-              style: {
-                fontFamily: "var(--font-mono)",
-                overflowWrap: wrapLines ? "anywhere" : "normal",
-              },
-            }}
-            renderer={(rendererProps) => (
-              <SourceCodeRenderer {...rendererProps} wrapLines={wrapLines} />
-            )}
-            wrapLongLines={wrapLines}
-          >
-            {content}
-          </SyntaxHighlighter>
+          highlightedSource
         )}
       </div>
     </div>

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -1199,7 +1199,13 @@ function TextFileViewer({
   const viewerContent = data?.content ?? "";
   const sourceLines = useMemo(() => viewerContent.split("\n"), [viewerContent]);
   const language = data?.language ?? "text";
-  const useLightweightSource = sourceLines.length > SOURCE_HIGHLIGHT_MAX_LINES;
+  const isHtml = language === "html";
+  const isMarkdown = language === "markdown";
+  const hasPreview = isHtml || isMarkdown;
+  const effectiveDisplayMode = isDeletedDiff ? "diff" : displayMode;
+  const useLightweightSource = sourceLines.length > SOURCE_HIGHLIGHT_MAX_LINES
+    && !(effectiveDisplayMode === "diff" && hasGitDiff)
+    && !(effectiveDisplayMode === "preview" && hasPreview);
   // react-syntax-highlighter rebuilds every token element on each render, which
   // costs hundreds of milliseconds on large files. Cache the rendered trees so
   // unrelated re-renders (panel open/close, selection changes) reuse them as-is.
@@ -1241,7 +1247,7 @@ function TextFileViewer({
     [isDark, language, viewerContent, wrapLines],
   );
   const lightweightSourceLines = useMemo(
-    () => sourceLines.map((line, lineIndex) => (
+    () => useLightweightSource ? sourceLines.map((line, lineIndex) => (
       <span
         className="file-source-line"
         data-line-number={lineIndex + 1}
@@ -1263,8 +1269,8 @@ function TextFileViewer({
           {line}
         </span>
       </span>
-    )),
-    [sourceLines, wrapLines],
+    )) : null,
+    [sourceLines, useLightweightSource, wrapLines],
   );
 
   useEffect(() => {
@@ -1361,12 +1367,8 @@ function TextFileViewer({
   if (!data && !isDeletedDiff) return null;
 
   const content = viewerContent;
-  const isHtml = language === "html";
-  const isMarkdown = language === "markdown";
-  const hasPreview = isHtml || isMarkdown;
   const markdownDirectory = getFileDirectory(filePath);
   const lines = sourceLines;
-  const effectiveDisplayMode = isDeletedDiff ? "diff" : displayMode;
   const displayModes: DisplayMode[] = isDeletedDiff
     ? ["diff"]
     : [


### PR DESCRIPTION
## Summary

Caches the rendered syntax-highlight tree and the lightweight source-line list in `FileViewer` with `useMemo`, so unrelated re-renders no longer rebuild every token element. This removes the multi-hundred-millisecond long task that previously made the file panel's open/close animation stutter and made text selection feel laggy.

## Behavior

- File content, language, theme, and line-wrapping still determine what is rendered; the cached trees are rebuilt whenever any of them change.
- Highlighted and lightweight source views render exactly the same markup as before — only redundant rebuilds are skipped.
- Selection updates during drag now skip no-op state writes: an unchanged selected line range reuses the previous state object instead of triggering a viewer-wide re-render.
- No changes to loading, error, diff, preview, or mention-line behavior.

## Verification

- TypeScript: `tsc --noEmit`
- Lint: `npm run lint -- --quiet`
- Tests: 844 passed (`npm test`)
- Manual profiling (668-line JS file): open/close panel animation runs at full frame rate with no long tasks (previously ~500 ms long task per re-render); drag-selecting text stays at full frame rate.

## Recording

- Before the fix: 
https://github.com/user-attachments/assets/6f17756c-c50f-440b-a7b3-f36966870742
- After the fix: 
https://github.com/user-attachments/assets/f9fb20e0-3b50-4631-9d42-f3bed2d84d21

