### PR TITLE
fix: allow deleting sessions whose parent file is missing

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -146,9 +146,15 @@ export async function DELETE(
 
     // Read only the bounded header before deleting.
     const parentSessionPath = readSessionHeader(filePath)?.parentSession;
-    const parentSessionId = parentSessionPath
-      ? readSessionHeader(parentSessionPath)?.id
-      : undefined;
+    let parentSessionId: string | undefined;
+    if (parentSessionPath) {
+      try {
+        // The parent may have been deleted or moved already; treat it as absent.
+        parentSessionId = readSessionHeader(parentSessionPath)?.id;
+      } catch {
+        parentSessionId = undefined;
+      }
+    }
 
     // Re-attach all direct children to this session's parent (cascade re-parent)
     // Scan sibling files in the same directory


### PR DESCRIPTION
## Problem

Deleting a session fails with HTTP 500 when its `parentSession` header points to a file that no longer exists:

```
Error: ENOENT: no such file or directory, open '...\sessions\--C--...home-server--\2026-08-09T05-19-52-466Z_019fe4f6...jsonl'
```

In `DELETE /api/sessions/[id]` (`app/api/sessions/[id]/route.ts`), `readSessionHeader(parentSessionPath)` throws when the parent file was deleted or moved first (common when fork chains span directories and the parent is removed earlier). The whole delete then fails, leaving the session undeletable via the UI permanently.

## Fix

Tolerate a missing parent header file and treat it as `undefined`:

```ts
const parentSessionPath = readSessionHeader(filePath)?.parentSession;
let parentSessionId: string | undefined;
if (parentSessionPath) {
  try {
    parentSessionId = readSessionHeader(parentSessionPath)?.id;
  } catch {
    parentSessionId = undefined;
  }
}
```

Deleting proceeds without re-parenting children when the parent is already gone (safer than failing the whole delete).

## Repro

1. Open a session (A), fork it to create child (B) in a different project/directory
2. Delete A (or move the file manually)
3. Try to delete B in the UI → stucks at confirmed state, refresh shows it still there; API returns 500