### PR TITLE
feat(files): add video preview support

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -17,6 +17,7 @@ import {
   getDocumentMime,
   getFileExt,
   getImageMime,
+  getVideoMime,
 } from "@/lib/file-types";
 import { resolveDirentIsDirectory } from "@/lib/file-dirent";
 import { isFilePathReferencedBySession } from "@/lib/session-file-references";
@@ -479,6 +480,10 @@ export async function GET(
       if (audioMime) {
         return streamFile(filePath, stat, audioMime, request.headers.get("range"));
       }
+      const videoMime = getVideoMime(filePath);
+      if (videoMime) {
+        return streamFile(filePath, stat, videoMime, request.headers.get("range"));
+      }
       const documentMime = getDocumentMime(filePath);
       if (documentMime) {
         return streamFile(filePath, stat, documentMime, request.headers.get("range"));
@@ -495,7 +500,7 @@ export async function GET(
       if (!stat?.isFile()) {
         return NextResponse.json({ error: "Not a file" }, { status: 400 });
       }
-      const mime = getImageMime(filePath) || getAudioMime(filePath) || getDocumentMime(filePath) || "application/octet-stream";
+      const mime = getImageMime(filePath) || getVideoMime(filePath) || getAudioMime(filePath) || getDocumentMime(filePath) || "application/octet-stream";
       return streamFile(filePath, stat, mime, request.headers.get("range"), true);
     }
 
@@ -505,11 +510,12 @@ export async function GET(
       }
       const imageMime = getImageMime(filePath);
       const audioMime = getAudioMime(filePath);
+      const videoMime = getVideoMime(filePath);
       const documentMime = getDocumentMime(filePath);
       return NextResponse.json({
         size: stat.size,
         language: getLanguage(filePath),
-        mime: imageMime || audioMime || documentMime || "text/plain",
+        mime: imageMime || audioMime || videoMime || documentMime || "text/plain",
         previewKind: documentPreviewKind(filePath),
       });
     }

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -16,6 +16,7 @@ import {
   isAudioPath,
   isDocumentPreviewPath,
   isImagePath,
+  isVideoPath,
 } from "@/lib/file-types";
 import { encodeFilePathForApi, getFileDirectory, getFileName, getRelativeFilePath } from "@/lib/file-paths";
 import { resolveLocalFileHref } from "@/lib/file-links";
@@ -748,6 +749,159 @@ function AudioViewer({ filePath, cwd, sourceSessionId, watchEnabled = true }: Pr
   );
 }
 
+function VideoViewer({ filePath, cwd, sourceSessionId, watchEnabled = true }: Props) {
+  const { t } = useI18n();
+  const [watching, setWatching] = useState(false);
+  const [bust, setBust] = useState(0);
+  const [size, setSize] = useState<number | null>(null);
+  const [duration, setDuration] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+  const syncRequestRef = useRef(0);
+
+  const ext = getFileName(filePath).toLowerCase().split(".").pop() ?? "";
+
+  useEffect(() => {
+    setBust(0);
+    setSize(null);
+    setDuration(null);
+    setError(null);
+    setWatching(false);
+  }, [filePath, sourceSessionId]);
+
+  useEffect(() => {
+    setWatching(false);
+
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+
+    if (!watchEnabled) return;
+
+    let active = true;
+    const synchronize = () => {
+      const requestId = ++syncRequestRef.current;
+      fetch(getFileApiUrl(filePath, "meta", sourceSessionId))
+        .then((response) => response.json())
+        .then((next: { size?: number; error?: string }) => {
+          if (!active || requestId !== syncRequestRef.current) return;
+          if (next.error) {
+            setError(next.error);
+            return;
+          }
+          if (typeof next.size === "number") setSize(next.size);
+          setDuration(null);
+          setError(null);
+          setBust((value) => value + 1);
+        })
+        .catch((nextError) => {
+          if (active && requestId === syncRequestRef.current) setError(String(nextError));
+        });
+    };
+
+    const es = new EventSource(getFileApiUrl(filePath, "watch", sourceSessionId));
+    esRef.current = es;
+
+    es.addEventListener("connected", () => {
+      setWatching(true);
+      synchronize();
+    });
+    es.addEventListener("change", (e) => {
+      syncRequestRef.current += 1;
+      try {
+        const d = JSON.parse((e as MessageEvent).data) as { size?: number };
+        if (typeof d.size === "number") setSize(d.size);
+      } catch { /* ignore */ }
+      setDuration(null);
+      setError(null);
+      setBust((b) => b + 1);
+    });
+    const markDisconnected = () => {
+      setWatching(false);
+    };
+    es.addEventListener("error", markDisconnected);
+    es.onerror = markDisconnected;
+
+    return () => {
+      active = false;
+      es.close();
+      if (esRef.current === es) esRef.current = null;
+    };
+  }, [filePath, sourceSessionId, watchEnabled]);
+
+  const src = getFileApiUrl(filePath, "read", sourceSessionId, bust ? { v: bust } : undefined);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "4px 16px",
+          borderBottom: "1px solid var(--border)",
+          fontSize: 11,
+          color: "var(--text-dim)",
+          background: "var(--bg)",
+          flexShrink: 0,
+        }}
+      >
+        <span style={{ fontFamily: "var(--font-mono)" }} title={filePath}>
+          {getRelativeFilePath(filePath, cwd)}
+        </span>
+        <span style={{ marginLeft: "auto" }}>{ext || "video"}</span>
+        {duration != null && <span>{formatDuration(duration)}</span>}
+        {size != null && <span>{formatSize(size)}</span>}
+        <span
+          title={watching ? t("i18n.liveSync") : t("i18n.notWatching")}
+          style={{ display: "flex", alignItems: "center", gap: 4, color: watching ? "#4ade80" : "var(--text-dim)" }}
+        >
+          <span
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: "50%",
+              background: watching ? "#4ade80" : "var(--border)",
+              display: "inline-block",
+              boxShadow: watching ? "0 0 4px #4ade80" : "none",
+            }}
+          />
+          {watching ? "live" : "static"}
+        </span>
+        <DownloadLink filePath={filePath} sourceSessionId={sourceSessionId} />
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 24,
+          background: "var(--bg-panel)",
+        }}
+      >
+        <div style={{ width: "min(100%, 720px)", display: "flex", justifyContent: "center" }}>
+          {error && (
+            <div style={{ color: "#f87171", fontSize: 13, marginBottom: 12, textAlign: "center" }}>
+              {error}
+            </div>
+          )}
+          <video
+            key={src}
+            controls
+            preload="metadata"
+            src={src}
+            onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+            onError={() => setError("Failed to load video")}
+            style={{ maxWidth: "100%", maxHeight: "72vh", objectFit: "contain", background: "#000", borderRadius: 6 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DocumentViewer({ filePath, cwd, sourceSessionId, watchEnabled = true }: Props) {
   const { t } = useI18n();
   const [watching, setWatching] = useState(false);
@@ -938,6 +1092,9 @@ export function FileViewer({
   }
   if (isAudioPath(filePath)) {
     return <AudioViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} watchEnabled={watchEnabled} />;
+  }
+  if (isVideoPath(filePath)) {
+    return <VideoViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} watchEnabled={watchEnabled} />;
   }
   if (isDocumentPreviewPath(filePath)) {
     return <DocumentViewer filePath={filePath} cwd={cwd} sourceSessionId={sourceSessionId} watchEnabled={watchEnabled} />;

--- a/lib/file-types.test.mjs
+++ b/lib/file-types.test.mjs
@@ -5,23 +5,38 @@ async function loadSubject() {
   return import("./file-types.ts");
 }
 
-test("detects image, audio, and document preview paths", async () => {
+test("detects image, audio, video, and document preview paths", async () => {
   const {
     getAudioMime,
     getDocumentMime,
     getImageMime,
+    getVideoMime,
     isAudioPath,
     isDocumentPreviewPath,
     isImagePath,
+    isVideoPath,
   } = await loadSubject();
 
   assert.equal(getImageMime("/tmp/screenshot.PNG"), "image/png");
   assert.equal(getAudioMime("C:\\Users\\me\\voice.OPUS"), "audio/ogg");
   assert.equal(getDocumentMime("/tmp/report.docx"), "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+  assert.equal(getVideoMime("/tmp/clip.mp4"), "video/mp4");
+  assert.equal(getVideoMime("C:\\Users\\me\\recording.MOV"), "video/quicktime");
   assert.equal(isImagePath("/tmp/screenshot.PNG"), true);
   assert.equal(isAudioPath("C:\\Users\\me\\voice.OPUS"), true);
+  assert.equal(isVideoPath("/tmp/clip.webm"), true);
   assert.equal(isDocumentPreviewPath("/tmp/report.pdf"), true);
   assert.equal(isDocumentPreviewPath("/tmp/report.txt"), false);
+});
+
+test("webm is video while weba stays audio", async () => {
+  const { getAudioMime, getVideoMime, isAudioPath, isVideoPath } = await loadSubject();
+
+  assert.equal(getAudioMime("/tmp/voice.weba"), "audio/webm");
+  assert.equal(isAudioPath("/tmp/voice.weba"), true);
+  assert.equal(getVideoMime("/tmp/recording.webm"), "video/webm");
+  assert.equal(isVideoPath("/tmp/recording.webm"), true);
+  assert.equal(isAudioPath("/tmp/recording.webm"), false);
 });
 
 test("extracts extensions from mixed path styles", async () => {

--- a/lib/file-types.ts
+++ b/lib/file-types.ts
@@ -26,7 +26,14 @@ export const AUDIO_EXT_TO_MIME: Record<string, string> = {
   aac: "audio/aac",
   flac: "audio/flac",
   weba: "audio/webm",
-  webm: "audio/webm",
+};
+
+export const VIDEO_EXT_TO_MIME: Record<string, string> = {
+  mp4: "video/mp4",
+  m4v: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  ogv: "video/ogg",
 };
 
 export const DOCUMENT_EXT_TO_MIME: Record<DocumentPreviewKind, string> = {
@@ -50,6 +57,10 @@ export function getAudioMime(filePath: string): string | null {
   return AUDIO_EXT_TO_MIME[getFileExt(filePath)] ?? null;
 }
 
+export function getVideoMime(filePath: string): string | null {
+  return VIDEO_EXT_TO_MIME[getFileExt(filePath)] ?? null;
+}
+
 export function getDocumentMime(filePath: string): string | null {
   return DOCUMENT_EXT_TO_MIME[getFileExt(filePath) as DocumentPreviewKind] ?? null;
 }
@@ -66,6 +77,10 @@ export function isImagePath(filePath: string): boolean {
 
 export function isAudioPath(filePath: string): boolean {
   return getAudioMime(filePath) !== null;
+}
+
+export function isVideoPath(filePath: string): boolean {
+  return getVideoMime(filePath) !== null;
 }
 
 export function isDocumentPreviewPath(filePath: string): boolean {


### PR DESCRIPTION
## Summary

Adds native video preview to the file panel, addressing #654. Recordings produced by tools like `agent-browser` (mp4/webm) could not be reviewed in Pi Web even though images could.

## Changes

- **`lib/file-types.ts`**: add `VIDEO_EXT_TO_MIME` (`mp4`/`m4v`/`webm`/`mov`/`ogv`) plus `getVideoMime()` and `isVideoPath()`. Move `.webm` out of `AUDIO_EXT_TO_MIME` (`weba` stays audio) so WebM videos are no longer misdetected as audio.
- **`app/api/files/[...path]/route.ts`**: route video files through the existing `streamFile()` path for `read`, `download`, and `meta`. `streamFile()` already supports HTTP Range requests, so videos are streamable, seekable, and not subject to the 256 KB text-preview cap.
- **`components/FileViewer.tsx`**: add a `VideoViewer` component mirroring `AudioViewer` (live watch badge, duration, file size, download button) and route video paths to it. The player is centered with `objectFit: contain` so portrait videos fit.
- **`lib/file-types.test.mjs`**: cover video detection and the `webm`/`weba` disambiguation.

## Verification

- `node --test lib/file-types.test.mjs` (video + webm/weba tests pass)
- `node_modules/.bin/tsc --noEmit` (exit 0)
- ESLint on the changed files (exit 0)
- `node --test app/api/files/*.test.mjs` and `components/FileViewer.test.mjs` pass

Note: 3 unrelated tests in `lib/` fail on Windows in this checkout (symlink `EPERM` and a PATH-separator comparison) and also fail on the clean baseline before this change.