### PR TITLE
feat(sessions): make idle timeout configurable via PI_WEB_IDLE_TIMEOUT_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For port and hostname, command-line options override the corresponding environme
 | `PI_WEB_SKIP_VERSION_CHECK=1` | Disable Pi Web update checks | Unset |
 | `PI_WEB_ALLOWED_HOSTS` | Additional exact proxy or custom hostnames, comma-separated | Unset |
 | `PI_WEB_PASSWORD` | Enable HTTP Basic Auth; the username is always `pi` | Authentication disabled |
+| `PI_WEB_IDLE_TIMEOUT_MS` | Session idle timeout in milliseconds; `0` disables idle shutdown | `600000` (10 min) |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For port and hostname, command-line options override the corresponding environme
 | `PI_WEB_SKIP_VERSION_CHECK=1` | Disable Pi Web update checks | Unset |
 | `PI_WEB_ALLOWED_HOSTS` | Additional exact proxy or custom hostnames, comma-separated | Unset |
 | `PI_WEB_PASSWORD` | Enable HTTP Basic Auth; the username is always `pi` | Authentication disabled |
-| `PI_WEB_IDLE_TIMEOUT_MS` | Session idle timeout in milliseconds; `0` disables idle shutdown | `600000` (10 min) |
+| `PI_WEB_IDLE_TIMEOUT_MS` | Session idle timeout in milliseconds, up to `2147483647`; `0` disables idle shutdown; invalid or out-of-range values use the default | `600000` (10 min) |
 
 For example:
 

--- a/lib/rpc-manager-idle-timeout.test.mjs
+++ b/lib/rpc-manager-idle-timeout.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false });
+const { resolveSessionIdleTimeoutMs } = await jiti.import("./rpc-manager.ts");
+
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
+
+function makePromptInner(prompt) {
+  return {
+    sessionId: "session-1",
+    isBashRunning: false,
+    isStreaming: false,
+    extensionRunner: {},
+    sessionManager: { getCwd: () => "/tmp" },
+    agent: { state: {} },
+    getContextUsage: () => null,
+    getSteeringMessages: () => [],
+    getFollowUpMessages: () => [],
+    prompt,
+    dispose() {},
+  };
+}
+
+test("defaults to the 10-minute idle timeout when the env var is unset or blank", () => {
+  assert.equal(resolveSessionIdleTimeoutMs(), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs(""), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("   "), 10 * 60 * 1000);
+});
+
+test("treats zero as disabling idle shutdown", () => {
+  assert.equal(resolveSessionIdleTimeoutMs("0"), 0);
+});
+
+test("uses a positive value as the timeout in milliseconds", () => {
+  assert.equal(resolveSessionIdleTimeoutMs("1800000"), 1_800_000);
+});
+
+test("falls back to the 10-minute default for invalid or negative values", () => {
+  assert.equal(resolveSessionIdleTimeoutMs("abc"), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("-5"), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("NaN"), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("Infinity"), 10 * 60 * 1000);
+});
+
+test("PI_WEB_IDLE_TIMEOUT_MS=0 disables idle shutdown", async (t) => {
+  process.env.PI_WEB_IDLE_TIMEOUT_MS = "0";
+  try {
+    const freshJiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false });
+    const { AgentSessionWrapper } = await freshJiti.import("./rpc-manager.ts");
+
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const inner = makePromptInner(() => Promise.resolve());
+    inner.isStreaming = true;
+    inner.subscribe = () => () => {};
+    inner.dispose = () => {};
+    const wrapper = new AgentSessionWrapper(inner);
+    t.after(() => wrapper.destroy());
+    wrapper.start();
+
+    // Far beyond the default 10-minute timeout: the wrapper must survive.
+    t.mock.timers.tick(60 * 60 * 1000);
+    await nextTurn();
+    assert.equal(wrapper.isAlive(), true);
+  } finally {
+    delete process.env.PI_WEB_IDLE_TIMEOUT_MS;
+  }
+});

--- a/lib/rpc-manager-idle-timeout.test.mjs
+++ b/lib/rpc-manager-idle-timeout.test.mjs
@@ -7,18 +7,15 @@ const { resolveSessionIdleTimeoutMs } = await jiti.import("./rpc-manager.ts");
 
 const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
 
-function makePromptInner(prompt) {
+function makeIdleInner() {
   return {
     sessionId: "session-1",
     isBashRunning: false,
     isStreaming: false,
+    isCompacting: false,
     extensionRunner: {},
-    sessionManager: { getCwd: () => "/tmp" },
     agent: { state: {} },
-    getContextUsage: () => null,
-    getSteeringMessages: () => [],
-    getFollowUpMessages: () => [],
-    prompt,
+    subscribe: () => () => {},
     dispose() {},
   };
 }
@@ -35,35 +32,50 @@ test("treats zero as disabling idle shutdown", () => {
 
 test("uses a positive value as the timeout in milliseconds", () => {
   assert.equal(resolveSessionIdleTimeoutMs("1800000"), 1_800_000);
+  assert.equal(resolveSessionIdleTimeoutMs("2147483647"), 2_147_483_647);
 });
 
-test("falls back to the 10-minute default for invalid or negative values", () => {
+test("falls back to the 10-minute default and warns for invalid or out-of-range values", (t) => {
+  const warn = t.mock.method(console, "warn", () => {});
   assert.equal(resolveSessionIdleTimeoutMs("abc"), 10 * 60 * 1000);
   assert.equal(resolveSessionIdleTimeoutMs("-5"), 10 * 60 * 1000);
   assert.equal(resolveSessionIdleTimeoutMs("NaN"), 10 * 60 * 1000);
   assert.equal(resolveSessionIdleTimeoutMs("Infinity"), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("2147483648"), 10 * 60 * 1000);
+  assert.equal(resolveSessionIdleTimeoutMs("2592000000"), 10 * 60 * 1000);
+  assert.equal(warn.mock.callCount(), 6);
 });
 
-test("PI_WEB_IDLE_TIMEOUT_MS=0 disables idle shutdown", async (t) => {
-  process.env.PI_WEB_IDLE_TIMEOUT_MS = "0";
-  try {
-    const freshJiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false });
-    const { AgentSessionWrapper } = await freshJiti.import("./rpc-manager.ts");
+for (const [rawValue, timeoutMs] of [
+  ["0", 0],
+  ["1800000", 1_800_000],
+  ["2592000000", 600_000],
+]) {
+  test(`PI_WEB_IDLE_TIMEOUT_MS=${rawValue} applies to an idle session`, async (t) => {
+    const previousValue = process.env.PI_WEB_IDLE_TIMEOUT_MS;
+    process.env.PI_WEB_IDLE_TIMEOUT_MS = rawValue;
+    try {
+      const freshJiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false });
+      const { AgentSessionWrapper } = await freshJiti.import("./rpc-manager.ts");
 
-    t.mock.timers.enable({ apis: ["setTimeout"] });
-    const inner = makePromptInner(() => Promise.resolve());
-    inner.isStreaming = true;
-    inner.subscribe = () => () => {};
-    inner.dispose = () => {};
-    const wrapper = new AgentSessionWrapper(inner);
-    t.after(() => wrapper.destroy());
-    wrapper.start();
+      t.mock.timers.enable({ apis: ["setTimeout"] });
+      const wrapper = new AgentSessionWrapper(makeIdleInner());
+      t.after(() => wrapper.destroy());
+      wrapper.start();
+      assert.equal(wrapper.isRunning(), false);
 
-    // Far beyond the default 10-minute timeout: the wrapper must survive.
-    t.mock.timers.tick(60 * 60 * 1000);
-    await nextTurn();
-    assert.equal(wrapper.isAlive(), true);
-  } finally {
-    delete process.env.PI_WEB_IDLE_TIMEOUT_MS;
-  }
-});
+      t.mock.timers.tick(timeoutMs === 0 ? 60 * 60 * 1000 : timeoutMs - 1);
+      await nextTurn();
+      assert.equal(wrapper.isAlive(), true);
+
+      if (timeoutMs !== 0) {
+        t.mock.timers.tick(1);
+        await nextTurn();
+        assert.equal(wrapper.isAlive(), false);
+      }
+    } finally {
+      if (previousValue === undefined) delete process.env.PI_WEB_IDLE_TIMEOUT_MS;
+      else process.env.PI_WEB_IDLE_TIMEOUT_MS = previousValue;
+    }
+  });
+}

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -128,8 +128,9 @@ const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 /**
  * Resolves the PI_WEB_IDLE_TIMEOUT_MS environment variable into a session idle
  * timeout in milliseconds. An unset/blank value returns the 10-minute default,
- * `0` disables idle shutdown, and a positive number is used as-is. Invalid or
- * negative values fall back to the default with a console warning.
+ * `0` disables idle shutdown, and positive values up to Node's timer limit
+ * (2147483647 ms) are used as-is. Invalid or out-of-range values fall back to
+ * the default with a console warning.
  * @param rawValue Value to parse; defaults to the environment variable.
  */
 export function resolveSessionIdleTimeoutMs(
@@ -137,7 +138,7 @@ export function resolveSessionIdleTimeoutMs(
 ): number {
   if (rawValue !== undefined && rawValue.trim() !== "") {
     const parsed = Number(rawValue);
-    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 2_147_483_647) return parsed;
     console.warn(`[pi-web] invalid PI_WEB_IDLE_TIMEOUT_MS "${rawValue}", falling back to 10 minutes`);
   }
   return DEFAULT_SESSION_IDLE_TIMEOUT_MS;

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -123,6 +123,28 @@ const IDLE_RESET_EVENT_TYPES = new Set([
   "compaction_end",
 ]);
 
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Resolves the PI_WEB_IDLE_TIMEOUT_MS environment variable into a session idle
+ * timeout in milliseconds. An unset/blank value returns the 10-minute default,
+ * `0` disables idle shutdown, and a positive number is used as-is. Invalid or
+ * negative values fall back to the default with a console warning.
+ * @param rawValue Value to parse; defaults to the environment variable.
+ */
+export function resolveSessionIdleTimeoutMs(
+  rawValue: string | undefined = process.env.PI_WEB_IDLE_TIMEOUT_MS,
+): number {
+  if (rawValue !== undefined && rawValue.trim() !== "") {
+    const parsed = Number(rawValue);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    console.warn(`[pi-web] invalid PI_WEB_IDLE_TIMEOUT_MS "${rawValue}", falling back to 10 minutes`);
+  }
+  return DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+}
+
+const SESSION_IDLE_TIMEOUT_MS = resolveSessionIdleTimeoutMs();
+
 const SESSION_REPLACEMENT_COMMAND_TYPES = new Set(["fork", "clone"]);
 const COMMANDS_ALLOWED_DURING_SESSION_REPLACEMENT = new Set([
   "get_state",
@@ -433,6 +455,8 @@ export class AgentSessionWrapper {
   private resetIdleTimer(): void {
     if (this.idleTimer) clearTimeout(this.idleTimer);
     if (!this._alive) return;
+    // A resolved timeout of 0 disables idle shutdown entirely.
+    if (SESSION_IDLE_TIMEOUT_MS === 0) return;
     if (!this.isRunning()) this.forceShutdownOnIdle = false;
     this.idleTimer = setTimeout(() => {
       if (this.isRunning() && !this.forceShutdownOnIdle) {
@@ -442,7 +466,7 @@ export class AgentSessionWrapper {
       void this.shutdown().catch((error) => {
         console.error("[pi-web] failed to shut down idle session:", error instanceof Error ? error.message : error);
       });
-    }, 10 * 60 * 1000);
+    }, SESSION_IDLE_TIMEOUT_MS);
   }
 
   private persistBashOnlySession(): void {


### PR DESCRIPTION
## Summary

Makes the session idle timeout configurable through the `PI_WEB_IDLE_TIMEOUT_MS` environment variable, addressing #629. Sessions are currently killed after a hardcoded 10 minutes of inactivity, which breaks coordination scenarios (e.g. pi-intercom) where a session merely listens for other sessions' messages, and long-running extensions whose background tasks emit no agent events.

## Behavior

| `PI_WEB_IDLE_TIMEOUT_MS` | Result |
| --- | --- |
| unset / blank | 10-minute default (no behavior change) |
| `0` | idle shutdown disabled |
| positive number | used as the timeout in milliseconds |
| invalid / negative | fall back to 10 minutes + console warning |

## Changes

- **`lib/rpc-manager.ts`**: add `resolveSessionIdleTimeoutMs()` and a module-level `SESSION_IDLE_TIMEOUT_MS` read from `PI_WEB_IDLE_TIMEOUT_MS`. `resetIdleTimer()` now uses the resolved value and skips scheduling entirely when it is `0`.
- **`lib/rpc-manager-idle-timeout.test.mjs`**: cover the parsing rules and verify that `PI_WEB_IDLE_TIMEOUT_MS=0` keeps an idle session alive far past the default window.
- **`README.md`**: document `PI_WEB_IDLE_TIMEOUT_MS` in the configuration table.

## Verification

- `lib/rpc-manager-idle-timeout.test.mjs` (5 pass, incl. env=0 keeps session alive)
- `lib/rpc-manager.test.mjs` (21 pass) and `lib/rpc-manager-shutdown.test.mjs` (19 pass) — the default 10-minute idle test still passes
- `node_modules/.bin/tsc --noEmit` (exit 0)
- ESLint on changed files (exit 0)

Note: 3 unrelated tests in `lib/` fail on Windows in this checkout (symlink `EPERM` and a PATH-separator comparison); they also fail on the clean baseline.