### PR TITLE
fix(web): let widget trigger area shrink to content in extension status shelf

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -198,7 +198,7 @@ body {
 }
 
 .extension-status-shelf.has-widgets.has-status .extension-widget-triggers {
-  flex: 0 1 70%;
+  flex: 0 0 auto;
   max-width: 70%;
   border-right: 1px solid var(--border);
 }


### PR DESCRIPTION
Fixes #669

## What

`.extension-status-shelf.has-widgets.has-status .extension-widget-triggers` currently uses `flex: 0 1 70%`, which reserves 70% of the shelf width for widget trigger buttons even when they occupy only ~108px. Because `.extension-status-line` is `flex: 1 1 0`, the remaining space becomes a blank band between the triggers and the status text, bounded by two separators — it reads as a rendering bug when a session has a single widget (repro: install any extension that registers both `setWidget` and `setStatus`, e.g. `npm:pi-subs`).

## Change

One line: `flex: 0 1 70%` → `flex: 0 0 auto` (basis: content instead of 70%).

- `max-width: 70%` cap is kept, so many triggers still cannot crowd out the status line.
- `.extension-status-line` (`flex: 1 1 0`) keeps filling the remaining space; its text is left-aligned, so the status simply sits next to the triggers now.
- No other rules touched; the trigger container's own `border-right` still provides the separator.

## Verified

- Locally against the v0.8.11 built CSS with an extension registering both a widget and a status line: blank band gone, both regions readable.
- Single-widget and multi-trigger layouts (one extension with 4+ status entries in the line) checked.

Screenshot after fix (single widget + status):

```
┌──────────┬───────────────────────────────────────────────────┐
│ subs   3 │ ⌁ Codex 42% ...                                   │
└──────────┴───────────────────────────────────────────────────┘
```

 Happy to adjust if you'd prefer a different approach (e.g. making it configurable via CSS var).