### PR TITLE
fix: render extension dialogs inline with keyboard nav, stacking, and expiry (#462)

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -285,7 +285,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
-    notices, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, setNoticePaused,
+    notices, extensionDialogs, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput, setNoticePaused,
     isAutoModelSelection,
     agentPhase,
     isNew,
@@ -302,6 +302,10 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSystemToolsChange, onSystemInfoLoaderChange, onSessionStatsPanelOpen,
   });
   const sessionBusy = agentRunning || bashRunning;
+
+  // The active dialog is the most recent unanswered request; older ones wait
+  // in the stack and surface as each earlier one is answered or expires.
+  const extensionDialog = extensionDialogs.length > 0 ? extensionDialogs[extensionDialogs.length - 1] : null;
 
   useEffect(() => {
     if (
@@ -657,13 +661,6 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
         </div>
       )}
 
-      {extensionDialog && (
-        <ExtensionDialog
-          request={extensionDialog}
-          onRespond={respondToExtensionUi}
-        />
-      )}
-
       {extensionCustomUi && (
         <ExtensionCustomPanel
           request={extensionCustomUi}
@@ -718,6 +715,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
               </div>
             </div>
             {chatInputElement}
+            <ExtensionDialogCardList dialogs={extensionDialogs} onRespond={respondToExtensionUi} />
             <ExtensionStatusBar statuses={extensionStatuses} widgets={extensionWidgets} />
           </div>
         </div>
@@ -944,6 +942,8 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
               />
             )}
 
+            <ExtensionDialogCardList dialogs={extensionDialogs} onRespond={respondToExtensionUi} />
+
             <div ref={promptAnchorSpacerRef} aria-hidden="true" />
 
             <div ref={messagesEndRef} />
@@ -1073,6 +1073,42 @@ function NoticeShelf({ notices, floating = false, onPauseChange }: { notices: No
 
 type ExtensionDialogRequest = Extract<ExtensionUiRequest, { method: "select" | "confirm" | "input" | "editor" }>;
 
+/** Renders all unanswered dialogs as inline cards in the conversation. Only
+ *  the newest request is shown; older ones stay queued behind it and surface
+ *  as each earlier one is answered or expires. */
+function ExtensionDialogCardList({
+  dialogs,
+  onRespond,
+}: {
+  dialogs: ExtensionDialogRequest[];
+  onRespond: (request: ExtensionDialogRequest, response: { value: string } | { confirmed: boolean } | { cancelled: true }) => void;
+}) {
+  const { t } = useI18n();
+  if (dialogs.length === 0) return null;
+  const active = dialogs[dialogs.length - 1];
+  const queuedCount = dialogs.length - 1;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, margin: "10px 0 4px" }}>
+      {queuedCount > 0 && (
+        <div style={{ color: "var(--text-dim)", fontSize: 12, fontFamily: "var(--font-mono)" }}>
+          {t("chat.extensionQueued", { count: queuedCount })}
+        </div>
+      )}
+      <ExtensionDialog request={active} onRespond={onRespond} />
+    </div>
+  );
+}
+
+/** Effective expiry (epoch ms) for a request, or null when the extension set
+ *  no timeout/expiresAt (the dialog then waits indefinitely). */
+function resolveDialogExpiry(request: ExtensionDialogRequest): number | null {
+  if (request.expiresAt != null) return request.expiresAt;
+  if (request.timeout != null) return Date.now() + request.timeout;
+  return null;
+}
+
+const EXPIRY_TICK_MS = 250;
+
 function ExtensionDialog({
   request,
   onRespond,
@@ -1082,10 +1118,31 @@ function ExtensionDialog({
 }) {
   const { t } = useI18n();
   const [value, setValue] = useState(request.method === "editor" ? request.prefill ?? "" : "");
+  const [activeOption, setActiveOption] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+  const expiryRef = useRef<number | null>(null);
+  if (expiryRef.current === null) expiryRef.current = resolveDialogExpiry(request);
 
   useEffect(() => {
     setValue(request.method === "editor" ? request.prefill ?? "" : "");
+    setActiveOption(0);
+    setNow(Date.now());
+    expiryRef.current = resolveDialogExpiry(request);
   }, [request]);
+
+  // Countdown + auto-cancel for requests that carry timeout/expiresAt: when the
+  // deadline passes the extension's await resolves with its default value,
+  // matching the daemon-side timeout and the TUI's auto-dismiss behavior.
+  const expired = expiryRef.current !== null && now >= expiryRef.current;
+  useEffect(() => {
+    if (expired) {
+      onRespond(request, { cancelled: true });
+      return;
+    }
+    if (expiryRef.current === null) return;
+    const timer = setInterval(() => setNow(Date.now()), EXPIRY_TICK_MS);
+    return () => clearInterval(timer);
+  }, [expired, onRespond, request]);
 
   const submitValue = () => {
     if (request.method === "confirm") {
@@ -1094,168 +1151,204 @@ function ExtensionDialog({
       onRespond(request, { value });
     }
   };
+  const cancel = () => onRespond(request, { cancelled: true });
+
+  const selectOptions = request.method === "select" ? request.options : [];
+  const selectRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (request.method === "select") selectRef.current?.focus();
+  }, [request]);
+
+  const remainingSeconds = expiryRef.current !== null
+    ? Math.max(0, Math.ceil((expiryRef.current - now) / 1000))
+    : null;
 
   return (
     <div
+      role="dialog"
+      aria-label={request.title}
       style={{
-        position: "absolute",
-        inset: 0,
-        zIndex: 90,
+        width: "100%",
+        maxWidth: 560,
         display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: 20,
-        background: "rgba(0,0,0,0.18)",
+        flexDirection: "column",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        background: "var(--bg)",
+        boxShadow: "0 1px 2px rgba(15,23,42,0.05), 0 10px 28px -14px rgba(15,23,42,0.24)",
+        overflow: "hidden",
       }}
     >
+      <div style={{ flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ color: "var(--text)", fontSize: 14, fontWeight: 650, overflowWrap: "anywhere" }}>{request.title}</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 3, color: "var(--text-dim)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
+            <span>{t("chat.extensionRequest")}</span>
+            {remainingSeconds !== null && (
+              <span style={remainingSeconds <= 10 ? { color: "#ef4444" } : undefined}>
+                {t("chat.extensionExpiresIn", { seconds: remainingSeconds })}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div
-        role="dialog"
-        aria-modal="true"
         style={{
-          width: "min(560px, 100%)",
-          maxHeight: "min(760px, 100%)",
-          display: "flex",
-          flexDirection: "column",
-          border: "1px solid var(--border)",
-          borderRadius: 8,
-          background: "var(--bg)",
-          boxShadow: "0 20px 60px rgba(0,0,0,0.28)",
-          overflow: "hidden",
+          padding: 14,
+          ...(request.method === "select"
+            ? { maxHeight: 260, overflowY: "auto" }
+            : {}),
         }}
       >
-        <div style={{ flexShrink: 0, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
-          <div style={{ color: "var(--text)", fontSize: 14, fontWeight: 650 }}>{request.title}</div>
-          <div style={{ marginTop: 3, color: "var(--text-dim)", fontSize: 11, fontFamily: "var(--font-mono)" }}>{t("chat.extensionRequest")}</div>
-        </div>
+        {request.method === "confirm" && (
+          <div style={{ color: "var(--text-muted)", fontSize: 13, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{request.message}</div>
+        )}
+        {request.method === "select" && (
+          <div
+            ref={selectRef}
+            tabIndex={0}
+            role="listbox"
+            aria-label={request.title}
+            onKeyDown={(event) => {
+              if (selectOptions.length === 0) return;
+              if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+                event.preventDefault();
+                setActiveOption((i) => (i + 1) % selectOptions.length);
+              } else if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+                event.preventDefault();
+                setActiveOption((i) => (i - 1 + selectOptions.length) % selectOptions.length);
+              } else if (event.key === "Home") {
+                event.preventDefault();
+                setActiveOption(0);
+              } else if (event.key === "End") {
+                event.preventDefault();
+                setActiveOption(selectOptions.length - 1);
+              } else if (event.key === "Enter") {
+                event.preventDefault();
+                onRespond(request, { value: selectOptions[activeOption] });
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                cancel();
+              }
+            }}
+            style={{ display: "grid", gap: 8, outline: "none" }}
+          >
+            {selectOptions.map((option, index) => (
+              <div
+                key={option}
+                role="option"
+                aria-selected={index === activeOption}
+                onClick={() => onRespond(request, { value: option })}
+                onMouseEnter={() => setActiveOption(index)}
+                style={{
+                  padding: "9px 10px",
+                  borderRadius: 7,
+                  border: "1px solid var(--border)",
+                  background: index === activeOption ? "var(--bg-selected)" : "var(--bg-panel)",
+                  color: "var(--text)",
+                  cursor: "pointer",
+                  fontSize: 13,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {option}
+              </div>
+            ))}
+          </div>
+        )}
+        {request.method === "input" && (
+          <input
+            autoFocus
+            value={value}
+            placeholder={request.placeholder}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submitValue();
+              if (e.key === "Escape") cancel();
+            }}
+            style={{
+              width: "100%",
+              padding: "9px 10px",
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--bg-panel)",
+              color: "var(--text)",
+              outline: "none",
+              fontSize: 13,
+            }}
+          />
+        )}
+        {request.method === "editor" && (
+          <textarea
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") cancel();
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submitValue();
+            }}
+            style={{
+              width: "100%",
+              minHeight: 220,
+              padding: 10,
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--bg-panel)",
+              color: "var(--text)",
+              outline: "none",
+              resize: "vertical",
+              fontSize: 13,
+              lineHeight: 1.55,
+              fontFamily: "var(--font-mono)",
+            }}
+          />
+        )}
+      </div>
 
-        <div
+      <div style={{ flexShrink: 0, display: "flex", justifyContent: "flex-end", gap: 8, padding: "10px 14px", borderTop: "1px solid var(--border)", background: "var(--bg-panel)" }}>
+        <button
+          onClick={cancel}
           style={{
-            padding: 14,
-            ...(request.method === "select"
-              ? { flex: "1 1 auto", minHeight: 0, overflowY: "auto" }
-              : {}),
+            padding: "6px 10px",
+            borderRadius: 6,
+            border: "1px solid var(--border)",
+            background: "var(--bg)",
+            color: "var(--text-muted)",
+            cursor: "pointer",
           }}
         >
-          {request.method === "confirm" && (
-            <div style={{ color: "var(--text-muted)", fontSize: 13, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{request.message}</div>
-          )}
-          {request.method === "select" && (
-            <div style={{ display: "grid", gap: 8 }}>
-              {request.options.map((option) => (
-                <button
-                  key={option}
-                  onClick={() => onRespond(request, { value: option })}
-                  style={{
-                    width: "100%",
-                    padding: "9px 10px",
-                    borderRadius: 7,
-                    border: "1px solid var(--border)",
-                    background: "var(--bg-panel)",
-                    color: "var(--text)",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    fontSize: 13,
-                    overflowWrap: "anywhere",
-                  }}
-                >
-                  {option}
-                </button>
-              ))}
-            </div>
-          )}
-          {request.method === "input" && (
-            <input
-              autoFocus
-              value={value}
-              placeholder={request.placeholder}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") submitValue();
-                if (e.key === "Escape") onRespond(request, { cancelled: true });
-              }}
-              style={{
-                width: "100%",
-                padding: "9px 10px",
-                borderRadius: 7,
-                border: "1px solid var(--border)",
-                background: "var(--bg-panel)",
-                color: "var(--text)",
-                outline: "none",
-                fontSize: 13,
-              }}
-            />
-          )}
-          {request.method === "editor" && (
-            <textarea
-              autoFocus
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") onRespond(request, { cancelled: true });
-                if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submitValue();
-              }}
-              style={{
-                width: "100%",
-                minHeight: 220,
-                padding: 10,
-                borderRadius: 7,
-                border: "1px solid var(--border)",
-                background: "var(--bg-panel)",
-                color: "var(--text)",
-                outline: "none",
-                resize: "vertical",
-                fontSize: 13,
-                lineHeight: 1.55,
-                fontFamily: "var(--font-mono)",
-              }}
-            />
-          )}
-        </div>
-
-        <div style={{ flexShrink: 0, display: "flex", justifyContent: "flex-end", gap: 8, padding: "10px 14px", borderTop: "1px solid var(--border)", background: "var(--bg-panel)" }}>
+           {t("chat.cancel")}
+        </button>
+        {request.method === "confirm" ? (
           <button
-            onClick={() => onRespond(request, { cancelled: true })}
+            onClick={submitValue}
             style={{
               padding: "6px 10px",
               borderRadius: 6,
-              border: "1px solid var(--border)",
-              background: "var(--bg)",
-              color: "var(--text-muted)",
+              border: "1px solid var(--accent)",
+              background: "var(--accent)",
+              color: "#fff",
               cursor: "pointer",
             }}
           >
-             {t("chat.cancel")}
+             {t("chat.confirm")}
           </button>
-          {request.method === "confirm" ? (
-            <button
-              onClick={submitValue}
-              style={{
-                padding: "6px 10px",
-                borderRadius: 6,
-                border: "1px solid var(--accent)",
-                background: "var(--accent)",
-                color: "#fff",
-                cursor: "pointer",
-              }}
-            >
-               {t("chat.confirm")}
-            </button>
-          ) : request.method !== "select" ? (
-            <button
-              onClick={submitValue}
-              style={{
-                padding: "6px 10px",
-                borderRadius: 6,
-                border: "1px solid var(--accent)",
-                background: "var(--accent)",
-                color: "#fff",
-                cursor: "pointer",
-              }}
-            >
-               {t("chat.submit")}
-            </button>
-          ) : null}
-        </div>
+        ) : request.method !== "select" ? (
+          <button
+            onClick={submitValue}
+            style={{
+              padding: "6px 10px",
+              borderRadius: 6,
+              border: "1px solid var(--accent)",
+              background: "var(--accent)",
+              color: "#fff",
+              cursor: "pointer",
+            }}
+          >
+             {t("chat.submit")}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/components/MobilePwaLayout.test.mjs
+++ b/components/MobilePwaLayout.test.mjs
@@ -42,7 +42,11 @@ test("contains chat content and inputs within the mobile viewport", () => {
   assert.match(cssSource, /\.markdown-body \{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;[\s\S]*?overflow-x: hidden;/);
   assert.match(cssSource, /\.markdown-code-block \{[\s\S]*?min-width: 0;[\s\S]*?max-width: 100%;/);
   assert.match(chatWindowSource, /overflow-x-hidden overflow-y-auto/);
-  assert.match(chatWindowSource, /maxHeight: "min\(760px, 100%\)"/);
+  // Extension dialogs are inline cards in the transcript (sized to the column)
+  // instead of a full-viewport modal, so they never exceed the mobile viewport.
+  assert.match(chatWindowSource, /role="dialog"\n\s+aria-label=\{request\.title\}/);
+  assert.match(chatWindowSource, /maxWidth: 560/);
+  assert.doesNotMatch(chatWindowSource, /aria-modal="true"[\s\S]*?chat\.extensionRequest/);
   assert.match(chatInputSource, /flex: 1,\s*minWidth: 0,\s*width: "100%",/);
 });
 

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -314,7 +314,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [slashCommandsLoading, setSlashCommandsLoading] = useState(false);
   const [noticeState, dispatchNotice] = useReducer(noticeReducer, { visible: [], pending: [] });
   const [sessionStatsOverride, setSessionStatsOverride] = useState<SessionStatsInfo | null>(null);
-  const [extensionDialog, setExtensionDialog] = useState<ExtensionUiDialogRequest | null>(null);
+  const [extensionDialogs, setExtensionDialogs] = useState<ExtensionUiDialogRequest[]>([]);
   const [extensionCustomUi, setExtensionCustomUi] = useState<ExtensionUiCustomRequest | null>(null);
   const [extensionStatuses, setExtensionStatuses] = useState<ExtensionStatusItem[]>([]);
   const [extensionWidgets, setExtensionWidgets] = useState<ExtensionWidgetItem[]>([]);
@@ -730,7 +730,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     response: { value: string } | { confirmed: boolean } | { cancelled: true },
   ) => {
     const sid = sessionIdRef.current;
-    setExtensionDialog((current) => current?.id === request.id ? null : current);
+    setExtensionDialogs((current) => current.filter((item) => item.id !== request.id));
     if (!sid) return;
     try {
       await sendAgentCommand(sid, {
@@ -778,7 +778,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       case "confirm":
       case "input":
       case "editor":
-        setExtensionDialog(request);
+        // Keep every unanswered dialog in a stack so composed flows (e.g.
+        // select -> input) and pipelined requests from concurrent extensions
+        // resolve in answer order instead of clobbering each other. The events
+        // stream replays pending requests on reconnect, so dedupe by request id.
+        setExtensionDialogs((current) =>
+          current.some((item) => item.id === request.id) ? current : [...current, request],
+        );
         break;
       case "notify": {
         addNotice({
@@ -1924,6 +1930,19 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     if (!agentRunning) setPromptAnchorActive(false);
   }, [agentRunning]);
 
+  // Drop dialogs/custom UI left over from a previous session when the active
+  // session changes. Pending extension requests are replayed by the events
+  // stream, and stale ones from the old session must not linger in the UI.
+  const activeSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const next = session?.id ?? null;
+    if (activeSessionIdRef.current !== null && activeSessionIdRef.current !== next) {
+      setExtensionDialogs([]);
+      setExtensionCustomUi(null);
+    }
+    activeSessionIdRef.current = next;
+  }, [session?.id]);
+
   useLayoutEffect(() => {
     if (messages.length > 0) {
       if (pendingScrollToUserRef.current) {
@@ -2009,7 +2028,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     retryInfo, contextUsage, systemPrompt, forkingEntryId,
     isCompacting, compactError, compactResult, currentModel, displayModel, modelSwitching, sessionStats,
     slashCommands, slashCommandsLoading, queuedMessages,
-    notices: noticeState.visible, extensionDialog, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
+    notices: noticeState.visible, extensionDialogs, extensionCustomUi, extensionStatuses, extensionWidgets, respondToExtensionUi, sendExtensionCustomInput,
     isAutoModelSelection: isNew && newSessionModel === null,
     agentPhase,
     isNew,

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -50,9 +50,11 @@ export function useGlobalKeyboardShortcuts(
       if (e.key === "Escape") {
         if (!globalAbortHandler) return;
 
-        const tag = (e.target as HTMLElement)?.tagName;
+        const target = e.target as HTMLElement | null;
         // Let textarea/input handle Esc internally (ChatInput menus / stop).
-        if (tag === "TEXTAREA" || tag === "INPUT") return;
+        if (target?.tagName === "TEXTAREA" || target?.tagName === "INPUT") return;
+        // Let extension dialogs handle Esc (cancels the dialog, not the agent).
+        if (target?.closest?.("[role='dialog']")) return;
 
         e.preventDefault();
         globalAbortHandler();

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -277,6 +277,8 @@ export const enLocale: LocalePlugin = {
     "chat.openWrittenFile": "Open {name}",
     "chat.loadEarlier": "Scroll up to load earlier messages",
     "chat.extensionRequest": "extension request",
+    "chat.extensionExpiresIn": "expires in {seconds}s",
+    "chat.extensionQueued": "{count} more pending",
     "chat.cancel": "Cancel",
     "chat.confirm": "Confirm",
     "chat.submit": "Submit",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -277,6 +277,8 @@ export const zhCNLocale: LocalePlugin = {
     "chat.openWrittenFile": "打开 {name}",
     "chat.loadEarlier": "向上滚动以加载更早的消息",
     "chat.extensionRequest": "扩展请求",
+    "chat.extensionExpiresIn": "{seconds} 秒后过期",
+    "chat.extensionQueued": "还有 {count} 个待处理",
     "chat.cancel": "取消",
     "chat.confirm": "确认",
     "chat.submit": "提交",

--- a/lib/i18n/messages/zh-TW.ts
+++ b/lib/i18n/messages/zh-TW.ts
@@ -277,6 +277,8 @@ export const zhTWLocale: LocalePlugin = {
     "chat.openWrittenFile": "開啟 {name}",
     "chat.loadEarlier": "向上捲動以載入較早的訊息",
     "chat.extensionRequest": "擴充功能請求",
+    "chat.extensionExpiresIn": "{seconds} 秒後過期",
+    "chat.extensionQueued": "還有 {count} 個待處理",
     "chat.cancel": "取消",
     "chat.confirm": "確認",
     "chat.submit": "送出",


### PR DESCRIPTION
Closes #462

## Summary

`ctx.ui.select()` / `confirm()` / `input()` / `editor()` dialogs were rendered as a full-window overlay that hid the chat context, ignored the `timeout`/`expiresAt` fields in the protocol, offered no keyboard support for `select`, and used a single state slot that couldn't express composed flows. This PR implements all three proposed steps (P0 + P1 + P2) from the issue.

## Changes

**P1 — Inline cards in the transcript**
- Dialogs now render as inline cards in the conversation transcript (message stream, plus the new-session state below the composer) instead of a dimming `position:absolute; inset:0` overlay. The conversation stays readable while answering; no overlay, no click-outside needed.
- Dropped `aria-modal="true"`: the card is intentionally non-modal (`role="dialog"` + `aria-label` instead).

**P0 — Keyboard navigation + Esc**
- `select` supports Arrow Up/Down (and Left/Right), Home/End, Enter to pick the highlighted option, and Esc to cancel. Hover syncs the active option.
- The global stop-agent Esc shortcut now yields when focus is inside an extension dialog (`hooks/useKeyboardShortcuts.ts`), so Esc cancels the dialog instead of aborting the run.

**P2 — Dialog stack + timeout/expiresAt**
- Unanswered dialogs queue in a stack instead of clobbering each other, so composed flows (select → input) and pipelined requests from concurrent extensions resolve in order. Entries are deduped by request id because the events stream replays pending requests on reconnect (`hooks/useAgentSession.ts`).
- Dialogs carrying `timeout`/`expiresAt` show a live countdown ("expires in Ns") and auto-cancel at the deadline, resolving the extension's await with its default value — matching the daemon-side timeout and the TUI's auto-dismiss. Stale dialogs are dropped when switching sessions.

## Verification

- `tsc --noEmit`, `eslint .`, and the full test suite (844 tests) pass.
- End-to-end with a real extension command on the running dev instance (playwright, headless chromium):
  - Keyboard select → input composed flow round-trips the user's actual answers back to the extension;
  - Esc cancels the select (notify received);
  - a 6s `timeout` shows the countdown, auto-dismisses, and notifies the extension;
  - two queued dialogs show one active card + a "N more pending" indicator and resolve sequentially;
  - a page reload (SSE reconnect) replays only one dialog card (dedupe).

## Notes

- `ExtensionCustomPanel` (custom UI method) is intentionally left as an overlay — out of scope for this issue.
- The select options list caps at `maxHeight: 260` with internal scroll (replaces the old `flex: 1` overlay cap); the card is `maxWidth: 560`, `width: 100%`.