### PR TITLE
fix: let extension widget triggers size to content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -198,7 +198,7 @@ body {
 }
 
 .extension-status-shelf.has-widgets.has-status .extension-widget-triggers {
-  flex: 0 1 70%;
+  flex: 0 1 auto;
   max-width: 70%;
   border-right: 1px solid var(--border);
 }


### PR DESCRIPTION
Fixes #682.

`.extension-status-shelf.has-widgets.has-status .extension-widget-triggers`
sets `flex: 0 1 70%`. With `flex-grow: 0` and `flex-basis: 70%`, the trigger
strip claims 70% of the shelf no matter how many triggers exist, so a single
short tab leaves most of that space blank while `.extension-status-line`
is squeezed into the remaining ~30% and wraps onto a second row.

`max-width: 70%` in the same rule already expresses the intended cap, so the
basis only needs to follow the content:

```css
.extension-status-shelf.has-widgets.has-status .extension-widget-triggers {
- flex: 0 1 70%;
+ flex: 0 1 auto;
  max-width: 70%;
  border-right: 1px solid var(--border);
}
```

Behaviour with many triggers is unchanged: the strip still grows up to the
70% cap and keeps scrolling horizontally through the existing
`overflow-x: auto`.

This affects any combination of one widget plus one status line, which is
common in practice — a todo-style widget extension together with an MCP or
model status extension already reproduces it. The rule has no media query,
so on narrow/PWA viewports the status line is reduced to a very small column.

Verified by applying the same declaration to the built stylesheet of a
running pi-web 0.8.11 instance: the trigger strip then sizes to its tab and
the status line renders on one row.

CSS-only change; no component, state, or behaviour changes.
