### PR TITLE
fix: keep substantial assistant answers visible

### DIFF
--- a/components/ChatWindow.process-details.test.mjs
+++ b/components/ChatWindow.process-details.test.mjs
@@ -4,10 +4,10 @@ import test from "node:test";
 
 const source = await readFile(new URL("./ChatWindow.tsx", import.meta.url), "utf8");
 
-test("expands process details when a completed turn has no final answer", () => {
+test("uses message content to choose the initial process-details state", () => {
   assert.match(source, /const \[expanded, setExpanded\] = useState\(defaultExpanded\)/);
   assert.match(
     source,
-    /<ProcessDetailsGroup[\s\S]*?defaultExpanded=\{!finalAnswerMessage\}/,
+    /<ProcessDetailsGroup[\s\S]*?defaultExpanded=\{shouldExpandProcessDetails\(processMessages, \{ hasFinalAnswer: Boolean\(finalAnswerMessage\) \}\)\}/,
   );
 });

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, BlockingExtensionUiRequest, CustomMessage, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage, UserMessage } from "@/lib/types";
 import { normalizeCustomPanelLines } from "@/lib/ansi";
 import { asBracketedPaste, toTerminalKeyData } from "@/lib/terminal-input";
-import { countToolCallBlocks, getAssistantErrorMessage, getDisplayableAssistantBlocks, splitFinalAssistantBlocks } from "@/lib/message-display";
+import { countToolCallBlocks, getAssistantErrorMessage, getDisplayableAssistantBlocks, shouldExpandProcessDetails, splitFinalAssistantBlocks } from "@/lib/message-display";
 import { extractTurnWrittenFiles, type WrittenFile } from "@/lib/turn-written-files";
 import { MessageView } from "./MessageView";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
@@ -854,6 +854,8 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
                 const finalAnswerMessage = finalSplit.answerBlocks.length > 0 || getAssistantErrorMessage(finalAssistant)
                   ? withAssistantBlocks(finalAssistant, finalSplit.answerBlocks)
                   : null;
+                const processMessages = visibleProcessIndices.map((processIdx) => messages[processIdx]);
+                if (finalProcessMessage) processMessages.push(finalProcessMessage);
 
                 const processCount = visibleProcessIndices.length + (finalProcessMessage ? 1 : 0);
                 if (processCount > 0) {
@@ -864,7 +866,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
                   const processGroup = (
                     <ProcessDetailsGroup
                       messageCount={processCount}
-                      defaultExpanded={!finalAnswerMessage}
+                      defaultExpanded={shouldExpandProcessDetails(processMessages, { hasFinalAnswer: Boolean(finalAnswerMessage) })}
                       t={t}
                       toolCallCount={countToolCalls(messages, visibleProcessIndices) + countToolCallBlocks(finalSplit.processBlocks)}
                     >

--- a/lib/message-display.test.mjs
+++ b/lib/message-display.test.mjs
@@ -128,3 +128,44 @@ test("falls back when a provider error has no message", async () => {
     null,
   );
 });
+
+test("expands process details when an earlier assistant message contains a substantial answer", async () => {
+  const { shouldExpandProcessDetails } = await loadSubject();
+  const processMessages = [
+    assistant([{ type: "text", text: "A".repeat(201) }]),
+    assistant([{ type: "toolCall", toolCallId: "call-1", toolName: "memory", input: {} }]),
+  ];
+
+  assert.equal(shouldExpandProcessDetails(processMessages, { hasFinalAnswer: true }), true);
+});
+
+test("keeps routine process details collapsed when a final answer is visible", async () => {
+  const { shouldExpandProcessDetails } = await loadSubject();
+  const processMessages = [
+    assistant([{ type: "text", text: "I will inspect the repository." }]),
+    assistant([{ type: "toolCall", toolCallId: "call-1", toolName: "bash", input: {} }]),
+  ];
+
+  assert.equal(shouldExpandProcessDetails(processMessages, { hasFinalAnswer: true }), false);
+});
+
+test("expands process details when an earlier assistant message contains an image", async () => {
+  const { shouldExpandProcessDetails } = await loadSubject();
+  const processMessages = [
+    assistant([{ type: "image", source: { type: "url", url: "https://example.com/result.png" } }]),
+  ];
+
+  assert.equal(shouldExpandProcessDetails(processMessages, { hasFinalAnswer: true }), true);
+});
+
+test("expands process details when there is no final answer", async () => {
+  const { shouldExpandProcessDetails } = await loadSubject();
+
+  assert.equal(
+    shouldExpandProcessDetails(
+      [assistant([{ type: "toolCall", toolCallId: "call-1", toolName: "bash", input: {} }])],
+      { hasFinalAnswer: false },
+    ),
+    true,
+  );
+});

--- a/lib/message-display.ts
+++ b/lib/message-display.ts
@@ -1,8 +1,14 @@
-import type { AssistantContentBlock, AssistantMessage, ThinkingContent, ToolCallContent } from "./types";
+import type { AgentMessage, AssistantContentBlock, AssistantMessage, ThinkingContent, ToolCallContent } from "./types";
 
 interface DisplayOptions {
   isStreaming?: boolean;
 }
+
+interface ProcessDetailsOptions {
+  hasFinalAnswer: boolean;
+}
+
+const SUBSTANTIAL_ASSISTANT_TEXT_LENGTH = 200;
 
 export function isEmptyThinkingBlock(block: AssistantContentBlock, options: DisplayOptions = {}): block is ThinkingContent {
   return block.type === "thinking" && !block.deferred && !options.isStreaming && block.thinking.trim() === "";
@@ -44,4 +50,19 @@ export function splitFinalAssistantBlocks(
 
 export function countToolCallBlocks(blocks: AssistantContentBlock[]): number {
   return blocks.filter((block): block is ToolCallContent => block.type === "toolCall").length;
+}
+
+export function shouldExpandProcessDetails(
+  messages: AgentMessage[],
+  options: ProcessDetailsOptions,
+): boolean {
+  if (!options.hasFinalAnswer) return true;
+
+  return messages.some((message) => {
+    if (message.role !== "assistant") return false;
+    return getDisplayableAssistantBlocks(message).some((block) => (
+      block.type === "image"
+      || (block.type === "text" && block.text.trim().length > SUBSTANTIAL_ASSISTANT_TEXT_LENGTH)
+    ));
+  });
 }


### PR DESCRIPTION
## Summary

- auto-expand process details when folded assistant messages contain substantial text or images
- keep routine short progress messages collapsed when a final answer is visible
- preserve the existing expanded state when no final answer exists
- add regression coverage for text, image, and fallback behavior

Fixes #622

## Testing

- `npm test` — 848 passed
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`