### PR TITLE
feat: preview completed Mermaid diagrams

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -684,6 +684,8 @@ pre, code {
 
 .mermaid-preview-button {
   width: 100%;
+  max-height: min(600px, 60dvh);
+  overflow: auto;
   border: 0;
   color: inherit;
   cursor: zoom-in;

--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -10,13 +10,19 @@ const jiti = createJiti(import.meta.url, {
 });
 const { MarkdownBody } = await jiti.import("./MarkdownBody.tsx");
 const { normalizeDisplayMath } = await jiti.import("../lib/markdown.ts");
+const { I18nProvider } = await jiti.import("@/hooks/useI18n");
 
-function renderMarkdown(markdown) {
+function renderMarkdown(markdown, props = {}) {
   return renderToStaticMarkup(
-    React.createElement(MarkdownBody, {
-      cwd: "/home/me/project",
-      onOpenFile() {},
-    }, markdown),
+    React.createElement(
+      I18nProvider,
+      null,
+      React.createElement(MarkdownBody, {
+        cwd: "/home/me/project",
+        onOpenFile() {},
+        ...props,
+      }, markdown),
+    ),
   );
 }
 
@@ -105,4 +111,20 @@ test("does not normalize escaped delimiters or link destinations", () => {
 
   assert.equal(normalizeDisplayMath(escaped), escaped);
   assert.equal(normalizeDisplayMath(link), link);
+});
+
+test("previews completed Mermaid diagrams by default", () => {
+  const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```");
+
+  assert.match(html, /mermaid-block-loading/);
+  assert.match(html, />Source</);
+  assert.doesNotMatch(html, /A --&gt; B/);
+});
+
+test("keeps Mermaid source visible while the response is streaming", () => {
+  const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```", { isStreaming: true });
+
+  assert.doesNotMatch(html, /mermaid-block-loading/);
+  assert.match(html, />Preview</);
+  assert.match(html, /A --&gt; B/);
 });

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -25,7 +25,13 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       const isBlock = className?.includes("language-") || raw.includes("\n");
       if (isBlock) {
         if (lang === "mermaid") {
-          return <MermaidBlock code={raw.replace(/\n$/, "")} isStreaming={isStreaming} />;
+          return (
+            <MermaidBlock
+              code={raw.replace(/\n$/, "")}
+              isStreaming={isStreaming}
+              defaultPreview
+            />
+          );
         }
         return <CodeBlock code={raw.replace(/\n$/, "")} lang={lang} isStreaming={isStreaming} />;
       }

--- a/components/MermaidBlock.test.mjs
+++ b/components/MermaidBlock.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
 });
 const React = await jiti.import("react");
 const { renderToStaticMarkup } = await jiti.import("react-dom/server");
-const { MermaidBlock, CodeBlock } = await jiti.import("./MermaidBlock.tsx");
+const { MermaidBlock, CodeBlock, downloadMermaidSvg } = await jiti.import("./MermaidBlock.tsx");
 const { I18nProvider } = await jiti.import("@/hooks/useI18n");
 
 // Simple sequenceDiagram for testing
@@ -91,4 +91,32 @@ test("MermaidBlock handles Chinese characters in diagram", () => {
 
   assert.doesNotMatch(html, /mermaid-block-error/);
   assert.match(html, /mermaid-block/);
+});
+
+test("downloadMermaidSvg downloads the rendered SVG and releases its URL", async () => {
+  const originalDocument = globalThis.document;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const link = { href: "", download: "", clicked: false, click() { this.clicked = true; } };
+  globalThis.document = { createElement: () => link };
+  URL.createObjectURL = (blob) => {
+    assert.equal(blob.type, "image/svg+xml;charset=utf-8");
+    return "blob:mermaid";
+  };
+  let revoked = null;
+  URL.revokeObjectURL = (url) => { revoked = url; };
+
+  try {
+    downloadMermaidSvg("<svg />");
+    assert.equal(link.href, "blob:mermaid");
+    assert.equal(link.download, "mermaid-diagram.svg");
+    assert.equal(link.clicked, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(revoked, "blob:mermaid");
+  } finally {
+    if (originalDocument === undefined) delete globalThis.document;
+    else globalThis.document = originalDocument;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  }
 });

--- a/components/MermaidBlock.test.mjs
+++ b/components/MermaidBlock.test.mjs
@@ -93,21 +93,33 @@ test("MermaidBlock handles Chinese characters in diagram", () => {
   assert.match(html, /mermaid-block/);
 });
 
-test("downloadMermaidSvg downloads the rendered SVG and releases its URL", async () => {
+test("downloadMermaidSvg downloads XML-serialized SVG and releases its URL", async () => {
   const originalDocument = globalThis.document;
+  const originalXMLSerializer = globalThis.XMLSerializer;
   const originalCreateObjectURL = URL.createObjectURL;
   const originalRevokeObjectURL = URL.revokeObjectURL;
+  const svgElement = { nodeName: "svg" };
+  const serializedSvg = '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div xmlns="http://www.w3.org/1999/xhtml">first<br />second</div></foreignObject></svg>';
   const link = { href: "", download: "", clicked: false, click() { this.clicked = true; } };
+  let downloadedBlob;
   globalThis.document = { createElement: () => link };
+  globalThis.XMLSerializer = class {
+    serializeToString(element) {
+      assert.equal(element, svgElement);
+      return serializedSvg;
+    }
+  };
   URL.createObjectURL = (blob) => {
     assert.equal(blob.type, "image/svg+xml;charset=utf-8");
+    downloadedBlob = blob;
     return "blob:mermaid";
   };
   let revoked = null;
   URL.revokeObjectURL = (url) => { revoked = url; };
 
   try {
-    downloadMermaidSvg("<svg />");
+    downloadMermaidSvg(svgElement);
+    assert.equal(await downloadedBlob.text(), serializedSvg);
     assert.equal(link.href, "blob:mermaid");
     assert.equal(link.download, "mermaid-diagram.svg");
     assert.equal(link.clicked, true);
@@ -116,6 +128,8 @@ test("downloadMermaidSvg downloads the rendered SVG and releases its URL", async
   } finally {
     if (originalDocument === undefined) delete globalThis.document;
     else globalThis.document = originalDocument;
+    if (originalXMLSerializer === undefined) delete globalThis.XMLSerializer;
+    else globalThis.XMLSerializer = originalXMLSerializer;
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
   }

--- a/components/MermaidBlock.tsx
+++ b/components/MermaidBlock.tsx
@@ -18,6 +18,15 @@ const ZOOM_STEP = 0.25;
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 3;
 
+export function downloadMermaidSvg(svg: string): void {
+  const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml;charset=utf-8" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "mermaid-diagram.svg";
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
 type RenderState =
   | { key: string; status: "loading" }
   | { key: string; status: "error" }
@@ -109,7 +118,20 @@ export function MermaidBlock({ code, isStreaming, defaultPreview = false }: Merm
     <div className="markdown-code-block">
       <div className="markdown-code-header">
         <span className="markdown-code-lang">mermaid</span>
-        {previewButton}
+        <div className="markdown-code-actions">
+          {renderState?.key === currentKey && renderState.status === "ready" && (
+            <button
+              type="button"
+              className="markdown-code-action"
+              title={`${t("i18n.downloadFile")} (SVG)`}
+              aria-label={`${t("i18n.downloadFile")} (SVG)`}
+              onClick={() => downloadMermaidSvg(renderState.svg)}
+            >
+              SVG
+            </button>
+          )}
+          {previewButton}
+        </div>
       </div>
       {body}
     </div>

--- a/components/MermaidBlock.tsx
+++ b/components/MermaidBlock.tsx
@@ -18,8 +18,10 @@ const ZOOM_STEP = 0.25;
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 3;
 
-export function downloadMermaidSvg(svg: string): void {
-  const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml;charset=utf-8" }));
+export function downloadMermaidSvg(svg: SVGSVGElement): void {
+  // Mermaid's HTML serialization can leave void tags such as <br> unclosed.
+  const xml = new XMLSerializer().serializeToString(svg);
+  const url = URL.createObjectURL(new Blob([xml], { type: "image/svg+xml;charset=utf-8" }));
   const link = document.createElement("a");
   link.href = url;
   link.download = "mermaid-diagram.svg";
@@ -38,6 +40,7 @@ export function MermaidBlock({ code, isStreaming, defaultPreview = false }: Merm
   const [showPreview, setShowPreview] = useState(defaultPreview);
   const [renderState, setRenderState] = useState<RenderState | null>(null);
   const [zoomOpen, setZoomOpen] = useState(false);
+  const previewRef = useRef<HTMLButtonElement>(null);
   const currentKey = `${isDark ? "dark" : "light"}\n${code}`;
   const previewVisible = showPreview && !isStreaming;
 
@@ -102,6 +105,7 @@ export function MermaidBlock({ code, isStreaming, defaultPreview = false }: Merm
       <>
         {!zoomOpen && (
           <button
+            ref={previewRef}
             type="button"
             className="mermaid-block mermaid-preview-button"
             title={t("i18n.openMermaidViewer")}
@@ -125,7 +129,10 @@ export function MermaidBlock({ code, isStreaming, defaultPreview = false }: Merm
               className="markdown-code-action"
               title={`${t("i18n.downloadFile")} (SVG)`}
               aria-label={`${t("i18n.downloadFile")} (SVG)`}
-              onClick={() => downloadMermaidSvg(renderState.svg)}
+              onClick={() => {
+                const svg = previewRef.current?.querySelector("svg");
+                if (svg) downloadMermaidSvg(svg);
+              }}
             >
               SVG
             </button>


### PR DESCRIPTION
## Summary

- Preview completed Mermaid fences by default while keeping source visible during streaming.
- Download rendered diagrams as SVG using XML serialization, so HTML labels such as `<br>` remain valid in standalone SVG files.
- Limit inline previews to `min(600px, 60dvh)` with internal scrolling, preserving the existing zoom viewer.

## Tests

- `npm test` (847 passed)
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- Chromium at 1280x800 and 390x844, in light and dark modes: streaming-to-preview transition, source toggle, actual SVG download and standalone XML rendering, scrolling a 40-node diagram to its final node, and zooming followed by another download.

Closes #672
