### PR TITLE
fix: use monospace font in Markdown previews

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1048,6 +1048,7 @@ pre, code {
 }
 
 /* File viewer markdown preview — larger headings */
+.markdown-file-preview { font-family: var(--font-mono); }
 .markdown-file-preview h1 { font-size: 1.8em; }
 .markdown-file-preview h2 { font-size: 1.4em; }
 .markdown-file-preview h3 { font-size: 1.15em; }

--- a/components/FileViewer.test.mjs
+++ b/components/FileViewer.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./FileViewer.tsx", import.meta.url), "utf8");
+const styles = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
 test("large source previews bypass the per-line syntax highlighter", () => {
   assert.match(source, /const SOURCE_HIGHLIGHT_MAX_LINES = 1_000;/);
@@ -19,4 +20,8 @@ test("large source previews bypass the per-line syntax highlighter", () => {
   assert.match(lightweightSource, /className="file-source-line"/);
   assert.match(lightweightSource, /className="file-source-line-content"/);
   assert.match(lightweightSource, /style=\{FILE_LINE_NUMBER_STYLE\}/);
+});
+
+test("markdown file previews use a monospace font for ASCII diagrams", () => {
+  assert.match(styles, /\.markdown-file-preview\s*\{\s*font-family:\s*var\(--font-mono\);\s*\}/);
 });


### PR DESCRIPTION
## Summary

- use the existing monospace font stack in rendered Markdown file previews
- keep the change scoped to the file viewer so chat typography is unchanged
- add regression coverage for the preview style

## Tests

- `npm test` (845 passed)
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`

Closes #638
