### PR TITLE
fix: renotify repeated completion notifications

### DIFF
--- a/lib/browser-notifications.ts
+++ b/lib/browser-notifications.ts
@@ -72,7 +72,7 @@ export async function showBrowserNotification(
 ): Promise<NotificationDelivery> {
   const notificationOptions: NotificationOptions = {
     body: options.body,
-    ...(options.tag ? { tag: options.tag } : {}),
+    ...(options.tag ? { tag: options.tag, renotify: true } : {}),
   };
 
   if (environment.getServiceWorkerRegistration) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -82,7 +82,7 @@ self.addEventListener("push", (event) => {
       return self.registration.showNotification(title, {
         body,
         data: { url: typeof url === "string" && url ? url : "/" },
-        ...(typeof tag === "string" && tag ? { tag } : {}),
+        ...(typeof tag === "string" && tag ? { tag, renotify: true } : {}),
       });
     }),
   );


### PR DESCRIPTION
## Summary

Repeated completion notifications for the same session reuse a stable notification `tag`.

Because `renotify` defaults to `false`, replacing an existing notification with the same tag may update the notification in the notification center without alerting the user again.

This change enables `renotify` whenever a notification tag is present, so each new completion alerts the user while still keeping only one notification per session.

## Reproduction

1. Run a task and switch away from Pi Web.
2. Wait for the completion notification.
3. Leave the notification in the system notification center.
4. Run another task in the same session.
5. The existing notification is replaced, but no new alert/banner is shown.
6. Dismissing the old notification makes the next completion alert normally again.

## Changes

* Enable `renotify: true` for tagged Web Push notifications.
* Apply the same behavior to in-page browser notifications for consistency.

The stable per-session tag is preserved, so repeated completions still do not accumulate duplicate notifications.
