### PR TITLE
fix: restore Windows drive roots in file routes

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -5,8 +5,6 @@ import {
   getAllowedFileRoots,
   isExistingFilePathAllowed,
   isFilePathAllowed,
-  isWindowsAbsolutePath,
-  normalizeSlashes,
 } from "@/lib/file-access";
 import {
   DOCX_PREVIEW_MAX_BYTES,
@@ -27,7 +25,7 @@ import {
   validateUploadFileNames,
 } from "@/lib/file-upload";
 import { parseFormDataWithinLimit, RequestBodyTooLargeError } from "@/lib/bounded-form-data";
-import { samePath } from "@/lib/paths";
+import { filePathFromApiSegments, samePath } from "@/lib/paths";
 
 const IGNORED_NAMES = new Set([
   "node_modules", ".git", ".next", "dist", "build", "__pycache__",
@@ -70,13 +68,6 @@ function getLanguage(filePath: string): string {
   return EXT_TO_LANGUAGE[ext] ?? "text";
 }
 
-function filePathFromSegments(segments: string[]): string {
-  const joined = segments.join("/");
-  const slashJoined = normalizeSlashes(joined);
-  if (isWindowsAbsolutePath(slashJoined)) return slashJoined;
-  return "/" + joined.replace(/^\/+/, "");
-}
-
 function parseFileRequestType(value: string): FileRequestType | null {
   return FILE_REQUEST_TYPE_SET.has(value) ? (value as FileRequestType) : null;
 }
@@ -84,7 +75,7 @@ function parseFileRequestType(value: string): FileRequestType | null {
 async function getUploadDirectory(segments: string[]): Promise<
   { directory: string } | { response: NextResponse }
 > {
-  const directory = filePathFromSegments(segments);
+  const directory = filePathFromApiSegments(segments);
   const allowedRoots = await getAllowedFileRoots();
   if (!isFilePathAllowed(directory, allowedRoots)) {
     return { response: NextResponse.json({ error: "Access denied" }, { status: 403 }) };
@@ -429,7 +420,7 @@ export async function GET(
 ) {
   try {
     const { path: segments } = await params;
-    const filePath = filePathFromSegments(segments);
+    const filePath = filePathFromApiSegments(segments);
     const rawType = request.nextUrl.searchParams.get("type") ?? "list";
     const type = parseFileRequestType(rawType);
     if (!type) {

--- a/lib/paths.test.mjs
+++ b/lib/paths.test.mjs
@@ -56,3 +56,11 @@ test("isWindowsAbsolutePath recognizes drive and UNC paths", async () => {
   assert.equal(isWindowsAbsolutePath("\\\\server\\share"), true);
   assert.equal(isWindowsAbsolutePath("relative/path"), false);
 });
+
+test("filePathFromApiSegments restores Windows drive roots", async () => {
+  const { filePathFromApiSegments } = await loadSubject();
+  assert.equal(filePathFromApiSegments(["D:"]), "D:/");
+  assert.equal(filePathFromApiSegments(["d:"]), "d:/");
+  assert.equal(filePathFromApiSegments(["D:", "repo"]), "D:/repo");
+  assert.equal(filePathFromApiSegments(["tmp", "repo"]), "/tmp/repo");
+});

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -27,6 +27,15 @@ export function isWindowsAbsolutePath(filePath: string): boolean {
   return WINDOWS_ABSOLUTE_RE.test(filePath) || filePath.startsWith("\\\\") || filePath.startsWith("//");
 }
 
+/** Rebuild an absolute filesystem path from Next.js catch-all route segments. */
+export function filePathFromApiSegments(segments: string[]): string {
+  const joined = segments.join("/");
+  const slashJoined = toSlashPath(joined);
+  if (/^[a-zA-Z]:$/.test(slashJoined)) return `${slashJoined}/`;
+  if (isWindowsAbsolutePath(slashJoined)) return slashJoined;
+  return "/" + joined.replace(/^\/+/, "");
+}
+
 /**
  * Convert a path to native separators. Chiefly for git output: git prints
  * POSIX-style absolute paths even on Windows (`D:/repo/sub`), which never


### PR DESCRIPTION
Fixes #702

## Summary

- Treat a bare drive-letter route segment such as `D:` as the corresponding drive root `D:/`.
- Use the reconstructed path for both file reads and uploads.
- Add regression coverage for drive roots while preserving existing Windows subdirectory and POSIX path behavior.

## Security

The reconstructed path still passes through the existing allowed-root and real-path containment checks. This change only corrects the drive-root representation; it does not grant access to additional filesystem locations.

## Verification

- `npm test` — 845 passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint -- --quiet`