### PR TITLE
fix: preserve sessions with extension-owned work

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ list. If no listener cancels the extension event, Pi Web preserves the
 browser's native context menu. This hook is browser-side and independent of
 Pi agent extensions.
 
+### Extension Session Liveness
+
+Server-side Pi extensions with detached work can prevent automatic idle
+session eviction through the versioned global registry:
+
+```js
+const liveness = globalThis[Symbol.for("@agegr/pi-web/session-liveness/v1")];
+const release = liveness?.version === 1
+  ? liveness.register({
+      name: "my-extension",
+      sessionId,
+      sessionFile,
+      isActive: () => detachedJobs.size > 0,
+    })
+  : () => {};
+```
+
+Register once per active extension session and call the returned idempotent
+`release` function on session shutdown, replacement, or reload. `isActive`
+must be synchronous, cheap, and scoped to the supplied exact session id or
+file. Provider errors fail safe by preserving that session. This lease only
+affects automatic idle eviction; explicit shutdown and Stop fallback cleanup
+still take precedence.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ const release = liveness?.version === 1
   ? liveness.register({
       name: "my-extension",
       sessionId,
-      sessionFile,
+      sessionFile: sessionFile || undefined,
       isActive: () => detachedJobs.size > 0,
     })
   : () => {};

--- a/lib/rpc-manager-shutdown.test.mjs
+++ b/lib/rpc-manager-shutdown.test.mjs
@@ -7,6 +7,7 @@ const jiti = createJiti(import.meta.url, {
   moduleCache: false,
 });
 const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
+const { registerSessionLivenessProvider } = await jiti.import("./session-liveness.ts");
 
 const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -495,6 +496,43 @@ test("direct destruction still disposes when session_shutdown throws synchronous
   assert.equal(wrapper.isAlive(), false);
 });
 
+test("idle timer preserves extension-owned session work until it becomes inactive", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const calls = [];
+  let active = true;
+  const inner = makePromptInner(() => Promise.resolve());
+  inner.subscribe = () => () => {};
+  inner.extensionRunner = {
+    async emit(event) {
+      calls.push(["emit", event]);
+    },
+  };
+  inner.dispose = () => calls.push(["dispose"]);
+  const release = registerSessionLivenessProvider({
+    name: "test-extension",
+    sessionId: "session-1",
+    isActive: () => active,
+  });
+  const wrapper = new AgentSessionWrapper(inner);
+  t.after(release);
+  t.after(() => wrapper.destroy());
+  wrapper.start();
+
+  t.mock.timers.tick(10 * 60 * 1000);
+  await nextTurn();
+  assert.equal(wrapper.isAlive(), true);
+  assert.deepEqual(calls, []);
+
+  active = false;
+  t.mock.timers.tick(10 * 60 * 1000);
+  await nextTurn();
+  assert.equal(wrapper.isAlive(), false);
+  assert.deepEqual(calls, [
+    ["emit", { type: "session_shutdown", reason: "quit" }],
+    ["dispose"],
+  ]);
+});
+
 test("idle timer preserves active work but reaps a run stuck after Stop", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const calls = [];
@@ -512,7 +550,13 @@ test("idle timer preserves active work but reaps a run stuck after Stop", async 
     },
   };
   inner.dispose = () => calls.push(["dispose"]);
+  const release = registerSessionLivenessProvider({
+    name: "test-extension",
+    sessionId: "session-1",
+    isActive: () => true,
+  });
   const wrapper = new AgentSessionWrapper(inner);
+  t.after(release);
   t.after(() => wrapper.destroy());
   wrapper.start();
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -16,6 +16,7 @@ import { cacheSessionPath, invalidateSessionListCache, resolveSessionPath } from
 import { getProjectTrustStatus, projectTrustReloadOptions } from "./project-trust";
 import { persistExplicitStartupPreferences } from "./startup-preferences";
 import { notifySessionComplete } from "./web-push";
+import { hasActiveSessionLivenessProvider } from "./session-liveness";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
 import type {
@@ -435,7 +436,10 @@ export class AgentSessionWrapper {
     if (!this._alive) return;
     if (!this.isRunning()) this.forceShutdownOnIdle = false;
     this.idleTimer = setTimeout(() => {
-      if (this.isRunning() && !this.forceShutdownOnIdle) {
+      if (!this.forceShutdownOnIdle && (this.isRunning() || hasActiveSessionLivenessProvider({
+        sessionId: this.sessionId,
+        sessionFile: this.sessionFile || undefined,
+      }))) {
         this.resetIdleTimer();
         return;
       }

--- a/lib/session-liveness.test.mjs
+++ b/lib/session-liveness.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, { moduleCache: false });
+const {
+  hasActiveSessionLivenessProvider,
+  registerSessionLivenessProvider,
+} = await jiti.import("./session-liveness.ts");
+
+test("session liveness providers are matched by exact session id or file", (t) => {
+  const dispose = registerSessionLivenessProvider({
+    name: "test-provider",
+    sessionId: "session-a",
+    sessionFile: "/tmp/session-a.jsonl",
+    isActive: () => true,
+  });
+  t.after(dispose);
+
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-a" }), true);
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "alias", sessionFile: "/tmp/session-a.jsonl" }), true);
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session" }), false);
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-a-suffix" }), false);
+});
+
+test("each registration receives an independent idempotent disposer", () => {
+  const provider = {
+    name: "reloadable-provider",
+    sessionId: "session-reload",
+    isActive: () => true,
+  };
+  const disposeOld = registerSessionLivenessProvider(provider);
+  const disposeReplacement = registerSessionLivenessProvider(provider);
+
+  disposeOld();
+  disposeOld();
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-reload" }), true);
+
+  disposeReplacement();
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-reload" }), false);
+});
+
+test("malformed registrations are rejected", () => {
+  assert.throws(() => registerSessionLivenessProvider({
+    name: "invalid-provider",
+    sessionId: "",
+    isActive: () => true,
+  }), /sessionId must be a non-empty string/);
+});
+
+test("provider failures preserve the matching session", (t) => {
+  const originalError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args.join(" "));
+  t.after(() => { console.error = originalError; });
+  const disposeThrowing = registerSessionLivenessProvider({
+    name: "broken-provider",
+    sessionId: "session-broken",
+    isActive: () => {
+      throw new Error("probe failed");
+    },
+  });
+  const disposeMalformed = registerSessionLivenessProvider({
+    name: "malformed-provider",
+    sessionId: "session-malformed",
+    isActive: () => "yes",
+  });
+  t.after(disposeThrowing);
+  t.after(disposeMalformed);
+
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-broken" }), true);
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-malformed" }), true);
+  assert.match(errors.join("\n"), /broken-provider.*probe failed/);
+  assert.match(errors.join("\n"), /malformed-provider.*must return a boolean/);
+});

--- a/lib/session-liveness.test.mjs
+++ b/lib/session-liveness.test.mjs
@@ -91,3 +91,21 @@ test("provider failures preserve the matching session", (t) => {
   assert.match(errors.join("\n"), /broken-provider.*probe failed/);
   assert.match(errors.join("\n"), /malformed-provider.*must return a boolean/);
 });
+
+test("non-stringifiable provider failures preserve the session until recovery", (t) => {
+  t.mock.method(console, "error", () => {});
+  const error = Object.create(null);
+  let failing = true;
+  t.after(registerSessionLivenessProvider({
+    name: "non-stringifiable-provider",
+    sessionId: "session-non-stringifiable",
+    isActive: () => {
+      if (failing) throw error;
+      return false;
+    },
+  }));
+
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-non-stringifiable" }), true);
+  failing = false;
+  assert.equal(hasActiveSessionLivenessProvider({ sessionId: "session-non-stringifiable" }), false);
+});

--- a/lib/session-liveness.test.mjs
+++ b/lib/session-liveness.test.mjs
@@ -4,9 +4,27 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url, { moduleCache: false });
 const {
+  SESSION_LIVENESS_REGISTRY_KEY,
   hasActiveSessionLivenessProvider,
   registerSessionLivenessProvider,
 } = await jiti.import("./session-liveness.ts");
+
+test("documented global registry contract remains compatible with extensions", (t) => {
+  assert.equal(SESSION_LIVENESS_REGISTRY_KEY, "@agegr/pi-web/session-liveness/v1");
+  const liveness = globalThis[Symbol.for(SESSION_LIVENESS_REGISTRY_KEY)];
+  assert.equal(liveness?.version, 1);
+  assert.equal(typeof liveness?.register, "function");
+  assert.equal(typeof liveness?.hasActiveProvider, "function");
+
+  const release = liveness.register({
+    name: "global-contract-provider",
+    sessionId: "session-global-contract",
+    isActive: () => true,
+  });
+  t.after(release);
+
+  assert.equal(liveness.hasActiveProvider({ sessionId: "session-global-contract" }), true);
+});
 
 test("session liveness providers are matched by exact session id or file", (t) => {
   const dispose = registerSessionLivenessProvider({

--- a/lib/session-liveness.ts
+++ b/lib/session-liveness.ts
@@ -1,0 +1,114 @@
+const SESSION_LIVENESS_PROTOCOL_VERSION = 1;
+export const SESSION_LIVENESS_REGISTRY_KEY = "@agegr/pi-web/session-liveness/v1";
+
+export interface SessionLivenessProvider {
+  name: string;
+  sessionId: string;
+  sessionFile?: string;
+  isActive(): boolean;
+}
+
+interface SessionIdentity {
+  sessionId: string;
+  sessionFile?: string;
+}
+
+interface SessionLivenessRegistry {
+  version: typeof SESSION_LIVENESS_PROTOCOL_VERSION;
+  register(provider: SessionLivenessProvider): () => void;
+  hasActiveProvider(session: SessionIdentity): boolean;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Session liveness provider ${field} must be a non-empty string`);
+  }
+}
+
+function validateProvider(provider: SessionLivenessProvider): void {
+  if (!provider || typeof provider !== "object") {
+    throw new Error("Session liveness provider must be an object");
+  }
+  assertNonEmptyString(provider.name, "name");
+  assertNonEmptyString(provider.sessionId, "sessionId");
+  if (provider.sessionFile !== undefined) {
+    assertNonEmptyString(provider.sessionFile, "sessionFile");
+  }
+  if (typeof provider.isActive !== "function") {
+    throw new Error("Session liveness provider isActive must be a function");
+  }
+}
+
+function createRegistry(): SessionLivenessRegistry {
+  const providers = new Map<symbol, SessionLivenessProvider>();
+
+  return {
+    version: SESSION_LIVENESS_PROTOCOL_VERSION,
+    register(provider) {
+      validateProvider(provider);
+      const token = Symbol(provider.name);
+      providers.set(token, provider);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        providers.delete(token);
+      };
+    },
+    hasActiveProvider(session) {
+      const identities = new Set([session.sessionId, session.sessionFile].filter((value): value is string => Boolean(value)));
+      for (const provider of providers.values()) {
+        if (!identities.has(provider.sessionId) && (!provider.sessionFile || !identities.has(provider.sessionFile))) {
+          continue;
+        }
+        try {
+          const active = provider.isActive();
+          if (typeof active !== "boolean") {
+            throw new Error("isActive() must return a boolean");
+          }
+          if (active) return true;
+        } catch (error) {
+          console.error(`[pi-web] Session liveness provider '${provider.name}' failed; preserving the session: ${describeError(error)}`);
+          return true;
+        }
+      }
+      return false;
+    },
+  };
+}
+
+function isCompatibleRegistry(value: unknown): value is SessionLivenessRegistry {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<SessionLivenessRegistry>;
+  return candidate.version === SESSION_LIVENESS_PROTOCOL_VERSION
+    && typeof candidate.register === "function"
+    && typeof candidate.hasActiveProvider === "function";
+}
+
+function getRegistry(): SessionLivenessRegistry {
+  const store = globalThis as Record<PropertyKey, unknown>;
+  const key = Symbol.for(SESSION_LIVENESS_REGISTRY_KEY);
+  const existing = store[key];
+  if (isCompatibleRegistry(existing)) return existing;
+  const registry = createRegistry();
+  store[key] = registry;
+  return registry;
+}
+
+const registry = getRegistry();
+
+/**
+ * Register session-scoped work that must survive pi-web's automatic idle eviction.
+ * Explicit shutdown and runtime replacement still take precedence.
+ */
+export function registerSessionLivenessProvider(provider: SessionLivenessProvider): () => void {
+  return registry.register(provider);
+}
+
+export function hasActiveSessionLivenessProvider(session: SessionIdentity): boolean {
+  return registry.hasActiveProvider(session);
+}

--- a/lib/session-liveness.ts
+++ b/lib/session-liveness.ts
@@ -19,10 +19,6 @@ interface SessionLivenessRegistry {
   hasActiveProvider(session: SessionIdentity): boolean;
 }
 
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function assertNonEmptyString(value: unknown, field: string): asserts value is string {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error(`Session liveness provider ${field} must be a non-empty string`);
@@ -72,7 +68,7 @@ function createRegistry(): SessionLivenessRegistry {
           }
           if (active) return true;
         } catch (error) {
-          console.error(`[pi-web] Session liveness provider '${provider.name}' failed; preserving the session: ${describeError(error)}`);
+          console.error(`[pi-web] Session liveness provider '${provider.name}' failed; preserving the session:`, error);
           return true;
         }
       }


### PR DESCRIPTION
## Summary

- add a small, versioned registry that lets server-side extensions report exact-session liveness
- consult extension liveness only when the normal 10-minute idle timer would otherwise evict a session
- preserve explicit shutdown, reload/replacement, process exit, and Stop fallback cleanup semantics

## Problem

Pi Web currently decides whether a session is idle from foreground `AgentSession` state only: queued prompts, streaming, compaction, and bash execution. An extension can therefore own detached work after the parent turn has ended while the host sees the session as idle.

At the timeout boundary, Pi Web disposes the session and its extension runtime. Detached work may continue elsewhere, but the extension state or completion notifier that was supposed to wake the parent is gone. This affects long-running background tasks and is the structural limitation described in #629 and #572.

A configurable global timeout such as #665 is useful operationally, but it cannot distinguish a disposable session from one with live extension-owned work. This PR is complementary: extensions opt in per exact session, and the ordinary timeout remains unchanged for every other session.

## Design

The host publishes `Symbol.for("@agegr/pi-web/session-liveness/v1")` with a synchronous provider registry. A provider supplies:

- a name
- the exact `sessionId` and optional `sessionFile`
- a cheap synchronous `isActive()` probe

Each registration receives an independent idempotent release function. Providers are matched only against the wrapper's exact session identity. A matching provider that throws or returns a non-boolean value fails safe by preserving that session and logging the error.

`AgentSessionWrapper.isRunning()` is deliberately unchanged because it is also used for UI state and prompt/session coordination. The registry is consulted only inside the automatic idle-eviction callback, after `forceShutdownOnIdle` has been checked.

## Validation

- `env -u PI_WEB_PASSWORD npm test` — 850 passed
- `npm run lint`
- `npx tsc --noEmit`
- focused session-liveness and shutdown tests — 24 passed
- `git diff --check`

Per the repository development guidance, `next build` was not run.

Related: #629, #572, #665

Companion provider-side integration: nicobailon/pi-subagents#1857 (merged as [`11ea7e9`](https://github.com/nicobailon/pi-subagents/commit/11ea7e929e2b891bb095219317b3a9e6f414bcbb)). Until this host-side registry ships, that integration intentionally degrades to a no-op.



