### PR TITLE
fix(chat): support Home and End in the composer

### DIFF
--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -8,7 +8,7 @@ const jiti = createJiti(import.meta.url, {
 });
 const React = await jiti.import("react");
 const { renderToStaticMarkup } = await jiti.import("react-dom/server");
-const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, compressImageFile, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand, modelSupportsImageInput, shouldCompressImageFile } = await jiti.import("./ChatInput.tsx");
+const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, compressImageFile, filterModelOptions, getTextBoundaryPosition, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand, modelSupportsImageInput, shouldCompressImageFile } = await jiti.import("./ChatInput.tsx");
 const { ModelSelector } = await jiti.import("./ModelSelector.tsx");
 const { clearDraft, getDraft, mergeRestoredSubmissionDraft, mergeRestoredSubmissionText, rekeyDraft, setDraft } = await jiti.import("@/lib/draft-store.ts");
 const { I18nProvider } = await jiti.import("@/hooks/useI18n");
@@ -166,6 +166,24 @@ test("renders the shared field model selector as a disabled gray control", () =>
 test("caps an upward menu to the visible space above its anchor", () => {
   assert.equal(getUpwardMenuMaxHeight(343, 36), 299);
   assert.equal(getUpwardMenuMaxHeight(40, 36), 0);
+});
+
+test("finds Home and End destinations in single-line and multiline input", () => {
+  const text = "first line\nsecond line\nthird";
+
+  assert.equal(getTextBoundaryPosition(text, 17, "Home"), 11);
+  assert.equal(getTextBoundaryPosition(text, 17, "End"), 22);
+  assert.equal(getTextBoundaryPosition(text, 17, "Home", true), 0);
+  assert.equal(getTextBoundaryPosition(text, 17, "End", true), text.length);
+  assert.equal(getTextBoundaryPosition("single line", 4, "Home"), 0);
+  assert.equal(getTextBoundaryPosition("single line", 4, "End"), 11);
+});
+
+test("keeps a caret on its current line at newline boundaries", () => {
+  const text = "first\nsecond";
+
+  assert.equal(getTextBoundaryPosition(text, 5, "End"), 5);
+  assert.equal(getTextBoundaryPosition(text, 6, "Home"), 6);
 });
 
 test("compresses large images while preserving small images and GIFs", async () => {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -101,6 +101,20 @@ const COMPOSITION_END_ENTER_GRACE_MS = 100;
 const TEXT_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 const ANCHORED_MENU_GAP = 8;
 
+type TextBoundaryKey = "Home" | "End";
+
+export function getTextBoundaryPosition(
+  text: string,
+  caret: number,
+  key: TextBoundaryKey,
+  wholeText = false,
+): number {
+  if (wholeText) return key === "Home" ? 0 : text.length;
+  if (key === "Home") return text.lastIndexOf("\n", Math.max(0, caret - 1)) + 1;
+  const lineEnd = text.indexOf("\n", caret);
+  return lineEnd === -1 ? text.length : lineEnd;
+}
+
 export function getUpwardMenuMaxHeight(menuBottom: number, visibleTop: number, gap = ANCHORED_MENU_GAP): number {
   return Math.max(0, Math.floor(menuBottom - visibleTop - gap));
 }
@@ -1145,6 +1159,33 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         return;
       }
 
+      if ((e.key === "Home" || e.key === "End") && !e.altKey && !isComposing) {
+        e.preventDefault();
+        const textarea = e.currentTarget;
+        const selectionStart = textarea.selectionStart;
+        const selectionEnd = textarea.selectionEnd;
+        const focus = textarea.selectionDirection === "backward" ? selectionStart : selectionEnd;
+        const anchor = textarea.selectionDirection === "backward" ? selectionEnd : selectionStart;
+        const target = getTextBoundaryPosition(
+          textarea.value,
+          focus,
+          e.key,
+          e.ctrlKey || e.metaKey,
+        );
+
+        if (e.shiftKey) {
+          textarea.setSelectionRange(
+            Math.min(anchor, target),
+            Math.max(anchor, target),
+            target < anchor ? "backward" : target > anchor ? "forward" : "none",
+          );
+        } else {
+          textarea.setSelectionRange(target, target);
+        }
+        updateAtQuery(textarea.value, target);
+        return;
+      }
+
       if (historyMenuOpen && !isComposing) {
         if (e.key === "ArrowDown") {
           e.preventDefault();
@@ -1265,7 +1306,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
         }
       }
     },
-    [isMobile, isStreaming, onSteer, onFollowUp, onAbort, slashMenuOpen, slashQuery, displayedSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, value]
+    [isMobile, isStreaming, onSteer, onFollowUp, onAbort, slashMenuOpen, slashQuery, displayedSlashCommands, slashActiveIndex, applySlashCommand, sendQueued, handleSend, getNextSlashIndex, atMenuOpen, atQuery, atMatches, atActiveIndex, applyAtCompletion, historyMenuOpen, inputHistory, historyActiveIndex, applyHistoryInput, updateAtQuery, value]
   );
 
   const handleInput = useCallback(() => {


### PR DESCRIPTION
## Summary

- implement consistent `Home` and `End` behavior in the multiline chat composer
- use the current logical line for unmodified shortcuts and the whole input for `Ctrl`/`Cmd` shortcuts
- preserve native Shift selection direction and leave IME composition and `Alt+Home`/`Alt+End` untouched

## Behavior

| Shortcut | Result |
| --- | --- |
| `Home` / `End` | Move to the start / end of the current logical line |
| `Shift+Home` / `Shift+End` | Extend the selection to the current line boundary |
| `Ctrl/Cmd+Home` / `Ctrl/Cmd+End` | Move to the start / end of the full message |
| `Ctrl/Cmd+Shift+Home` / `Ctrl/Cmd+Shift+End` | Extend the selection to the full-message boundary |

## Testing

- `npm test` — 883 tests passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- Chromium browser verification covering multiline caret movement and Shift selection on the rebased commit

## Demo

![Home and End navigation in the composer](https://raw.githubusercontent.com/Zhangs-11/pi-web/assets/pr-demos/pr-demos/home-end-composer.gif)

Recorded from `Zhangs-11/pi-web@60d3908fa72e1c4d2bc1e7ba8f324319f9f82c6c` on the clean rebased branch, served at `http://127.0.0.1:30154` with `next dev` because repository instructions prohibit `next build` during development. The run used a fresh isolated Pi agent directory, workspace, and Chrome profile with the normal application transport. A real GPT-6-Astra round created the displayed session; the demonstrated key presses were normal browser keyboard input with no fixtures, mock transport, DOM-event injection, or test-only hooks.

