### PR TITLE
feat(chat): edit user messages inline

### DIFF
--- a/app/api/sessions/[id]/context/route.ts
+++ b/app/api/sessions/[id]/context/route.ts
@@ -9,7 +9,9 @@ export async function GET(
 ) {
   const { id } = await params;
   const url = new URL(req.url);
-  const leafId = url.searchParams.get("leafId") ?? undefined;
+  const leafId = url.searchParams.has("leafId")
+    ? url.searchParams.get("leafId") || null
+    : undefined;
   const deferThinking = url.searchParams.has("deferThinking");
   const deferToolResultImages = url.searchParams.has("deferMedia");
   // `tail` caps the ancestor chain returned (default 50); `before` rewinds the
@@ -30,7 +32,8 @@ export async function GET(
     const sm = liveRpc?.inner.sessionManager ?? SessionManager.open(filePath!);
     // `before` is the oldest entry already on the client; fetch its ancestors
     // only (excludeLeaf) so prepending the page does not duplicate `before`.
-    const context = buildSessionContext(sm.getEntries() as never, before ?? leafId, {
+    const contextLeafId = before !== undefined ? before : leafId;
+    const context = buildSessionContext(sm.getEntries() as never, contextLeafId, {
       deferThinking,
       deferToolResultImages,
       tail,

--- a/app/api/sessions/context-route.test.mjs
+++ b/app/api/sessions/context-route.test.mjs
@@ -19,7 +19,13 @@ const { buildSessionContext } = await jiti.import("@/lib/session-reader");
 test("context route parses ?tail and ?before, excluding the boundary on paging", () => {
   assert.match(routeSrc, /const tail = Number\.isFinite\(rawTail\) && rawTail > 0 \? Math\.min\(rawTail, 1000\) : 50/);
   assert.match(routeSrc, /const before = url\.searchParams\.get\("before"\)/);
-  assert.match(routeSrc, /buildSessionContext\(sm\.getEntries\(\) as never, before \?\? leafId, \{[^}]*excludeLeaf: Boolean\(before\)/);
+  assert.match(routeSrc, /const contextLeafId = before !== undefined \? before : leafId/);
+  assert.match(routeSrc, /buildSessionContext\(sm\.getEntries\(\) as never, contextLeafId, \{[^}]*excludeLeaf: Boolean\(before\)/);
+});
+
+test("context route distinguishes an explicit root from an omitted leaf", () => {
+  assert.match(routeSrc, /url\.searchParams\.has\("leafId"\)/);
+  assert.match(routeSrc, /url\.searchParams\.get\("leafId"\) \|\| null/);
 });
 
 test("context route: ?before pages upward without duplicating the boundary", () => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -7,7 +7,12 @@ import { asBracketedPaste, toTerminalKeyData } from "@/lib/terminal-input";
 import { countToolCallBlocks, getAssistantErrorMessage, getDisplayableAssistantBlocks, isMessageGroupAnchor, splitFinalAssistantBlocks, splitThinkingBlocks } from "@/lib/message-display";
 import { extractTurnWrittenFiles, type WrittenFile } from "@/lib/turn-written-files";
 import { MessageView, ThinkingBlock } from "./MessageView";
-import { ChatInput, type ChatInputHandle } from "./ChatInput";
+import {
+  ChatInput,
+  getUserMessageDraftImages,
+  getUserMessageText,
+  type ChatInputHandle,
+} from "./ChatInput";
 import { ChatMinimap, useMessageRefs } from "./ChatMinimap";
 import { ExtensionStatusBar } from "./ExtensionStatusBar";
 import { AnsiText } from "./AnsiText";
@@ -249,11 +254,6 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, sessi
     onAgentEnd?.();
   }, [completionNotificationsEnabled, onAgentEnd]);
 
-  // 稳定化 onEditContent 引用，配合 React.memo 防止历史消息重渲染
-  const handleEditContent = useCallback((message: UserMessage) => {
-    chatInputRef?.current?.replaceMessage(message);
-  }, [chatInputRef]);
-
   const {
     loading, error, messages, entryIds, historyCursor, hasEarlierMessages, streamState,
     agentRunning, bashRunning, pendingBash, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
@@ -266,7 +266,7 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, sessi
     isNew,
     sessionIdRef, messagesEndRef, scrollContainerRef,
     lastUserMsgRef, promptAnchorActive,
-    handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
+    handleSend, handleAbort, handleFork, handleEditAndSend, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
     handleRecallQueue,
     handleBuiltinSlashCommand,
@@ -277,6 +277,30 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, sessi
     modelsRefreshKey, chatInputRef, onBranchDataChange, onSystemPromptChange, onSystemToolsChange, onSystemInfoLoaderChange, onSessionStatsPanelOpen,
   });
   const sessionBusy = agentRunning || bashRunning;
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEditingEntryId(null);
+  }, [session?.id, newSessionDraftKey]);
+
+  useEffect(() => {
+    if (sessionBusy) setEditingEntryId(null);
+  }, [sessionBusy]);
+
+  const handleStartEdit = useCallback((entryId: string) => {
+    setEditingEntryId(entryId);
+  }, []);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingEntryId(null);
+  }, []);
+
+  const handleSubmitEdit = useCallback(async (entryId: string, message: UserMessage): Promise<boolean> => {
+    const images = getUserMessageDraftImages(message);
+    const submitted = await handleEditAndSend(entryId, getUserMessageText(message), images);
+    if (submitted) setEditingEntryId(null);
+    return submitted;
+  }, [handleEditAndSend]);
 
   useEffect(() => {
     if (
@@ -743,10 +767,6 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, sessi
 
               const renderMessage = (idx: number, options: { attachRef?: boolean; keyPrefix?: string; messageOverride?: AgentMessage; showTimestamp?: boolean; writtenFiles?: WrittenFile[] } = {}): ReactNode => {
                 const msg = options.messageOverride ?? messages[idx];
-                const prevAssistantEntryId =
-                  msg.role === "user" && idx > 0 && messages[idx - 1].role === "assistant"
-                    ? entryIds[idx - 1]
-                    : undefined;
                 const isVisible = isMessageGroupAnchor(msg) || msg.role === "assistant";
                 const currentRefIdx = visibleRefIndexByMessage.get(idx);
                 const keyPrefix = options.keyPrefix ?? "message";
@@ -778,9 +798,10 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, sessi
                     searchBlock={entryIds[idx] === pendingSearchScroll?.entryId ? searchBlock : undefined}
                     onFork={sessionBusy || isNew || (idx === 0 && msg.role === "user") ? undefined : handleFork}
                     forking={forkingEntryId === entryIds[idx]}
-                    onNavigate={sessionBusy ? undefined : handleNavigate}
-                    prevAssistantEntryId={sessionBusy ? undefined : prevAssistantEntryId}
-                    onEditContent={handleEditContent}
+                    editing={msg.role === "user" && editingEntryId === entryIds[idx]}
+                    onStartEdit={!sessionBusy && !isNew ? handleStartEdit : undefined}
+                    onCancelEdit={handleCancelEdit}
+                    onSubmitEdit={handleSubmitEdit}
                     showTimestamp={showTimestamp}
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp : undefined}
                     sessionId={session?.id ?? sessionIdRef.current ?? undefined}

--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -228,6 +228,48 @@ test("keeps attached images when restoring a compact command for editing", () =>
   ]);
 });
 
+test("renders an inline edit action for the first user message", () => {
+  const html = renderMessage({
+    role: "user",
+    content: "original request",
+  }, {
+    entryId: "user-root",
+    onStartEdit() {},
+    async onSubmitEdit() { return true; },
+  });
+
+  assert.match(html, /aria-label="Edit message"/);
+  assert.ok(html.indexOf("Copy message") < html.indexOf("Edit message"));
+});
+
+test("renders the message text with Cancel and Send inside the inline editor", () => {
+  const html = renderMessage({
+    role: "user",
+    content: "original request",
+  }, {
+    entryId: "user-2",
+    editing: true,
+    onStartEdit() {},
+    onCancelEdit() {},
+    async onSubmitEdit() { return true; },
+  });
+
+  assert.match(html, /<textarea[^>]+aria-label="Edit message"/);
+  assert.match(html, />original request<\/textarea>/);
+  assert.match(html, />Cancel<\/button>/);
+  assert.match(html, />Send<\/button>/);
+  assert.doesNotMatch(html, /title="Copy message"/);
+});
+
+test("does not offer message editing without an idle edit handler", () => {
+  const html = renderMessage({
+    role: "user",
+    content: "running request",
+  }, { entryId: "user-running" });
+
+  assert.doesNotMatch(html, /aria-label="Edit message"/);
+});
+
 test("renders user-message images as buttons that open a larger preview", () => {
   const html = renderMessage({
     role: "user",

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -189,9 +189,10 @@ interface Props {
   searchBlock?: AssistantContentBlock;
   onFork?: (entryId: string) => void;
   forking?: boolean;
-  onNavigate?: (entryId: string) => void;
-  prevAssistantEntryId?: string;
-  onEditContent?: (message: UserMessage) => void;
+  editing?: boolean;
+  onStartEdit?: (entryId: string) => void;
+  onCancelEdit?: () => void;
+  onSubmitEdit?: (entryId: string, message: UserMessage) => Promise<boolean>;
   showTimestamp?: boolean;
   prevTimestamp?: number;
   sessionId?: string;
@@ -250,9 +251,9 @@ function haveSameRelevantToolResults(
   return true;
 }
 
-export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, onOpenSession, entryId, searchBlock, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp, sessionId, writtenFiles }: Props) {
+export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, onOpenSession, entryId, searchBlock, onFork, forking, editing, onStartEdit, onCancelEdit, onSubmitEdit, showTimestamp, prevTimestamp, sessionId, writtenFiles }: Props) {
   if (message.role === "user") {
-    return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
+    return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} editing={editing} onStartEdit={onStartEdit} onCancelEdit={onCancelEdit} onSubmitEdit={onSubmitEdit} />;
   }
   if (message.role === "assistant") {
     return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} onOpenSession={onOpenSession} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} searchBlock={searchBlock} writtenFiles={writtenFiles} />;
@@ -283,24 +284,26 @@ export const MessageView = memo(function MessageView({ message, isStreaming, too
     && prev.searchBlock === next.searchBlock
     && prev.onFork === next.onFork
     && prev.forking === next.forking
-    && prev.onNavigate === next.onNavigate
-    && prev.prevAssistantEntryId === next.prevAssistantEntryId
-    && prev.onEditContent === next.onEditContent
+    && prev.editing === next.editing
+    && prev.onStartEdit === next.onStartEdit
+    && prev.onCancelEdit === next.onCancelEdit
+    && prev.onSubmitEdit === next.onSubmitEdit
     && prev.showTimestamp === next.showTimestamp
     && prev.prevTimestamp === next.prevTimestamp
     && prev.sessionId === next.sessionId;
 });
 
-function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {
+function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, editing, onStartEdit, onCancelEdit, onSubmitEdit }: {
   message: UserMessage;
   cwd?: string;
   onOpenFile?: (filePath: string) => void;
   entryId?: string;
   onFork?: (entryId: string) => void;
   forking?: boolean;
-  onNavigate?: (entryId: string) => void;
-  prevAssistantEntryId?: string;
-  onEditContent?: (message: UserMessage) => void;
+  editing?: boolean;
+  onStartEdit?: (entryId: string) => void;
+  onCancelEdit?: () => void;
+  onSubmitEdit?: (entryId: string, message: UserMessage) => Promise<boolean>;
 }) {
   const { t } = useI18n();
   const [hovered, setHovered] = useState(false);
@@ -332,7 +335,6 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
   const time = formatTime(message.timestamp);
   const canFork = !!entryId && !!onFork;
   const copyTarget = commandText ?? content;
-  const editTarget = commandText ? replaceUserMessageText(message, commandText) : message;
 
   const imageBlocksNode = imageBlocks.length > 0 && (
     <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: content ? 8 : 0 }}>
@@ -360,7 +362,25 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
       })}
     </div>
   );
-  const canNavigate = !!prevAssistantEntryId && !!onNavigate;
+  const editableText = commandText ?? content;
+  const [editValue, setEditValue] = useState(editableText);
+  const [editSubmitting, setEditSubmitting] = useState(false);
+  const canEdit = !!entryId && !!onStartEdit && !!onSubmitEdit;
+  const canSubmitEdit = editValue.trim().length > 0 || imageBlocks.length > 0;
+
+  useEffect(() => {
+    if (editing) setEditValue(editableText);
+  }, [editableText, editing]);
+
+  const submitEdit = async () => {
+    if (!entryId || !onSubmitEdit || !canSubmitEdit || editSubmitting) return;
+    setEditSubmitting(true);
+    try {
+      await onSubmitEdit(entryId, replaceUserMessageText(message, editValue));
+    } finally {
+      setEditSubmitting(false);
+    }
+  };
 
   const copyContent = () => {
     copyText(copyTarget).then(() => {
@@ -375,7 +395,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <div style={{ display: "flex", alignItems: "flex-end", gap: 6, maxWidth: "85%" }}>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 6, width: editing ? "85%" : undefined, maxWidth: "85%" }}>
         <div
           style={{
             flex: 1,
@@ -388,11 +408,79 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
             lineHeight: 1.6,
             color: "var(--text)",
             wordBreak: "break-word",
-            maxHeight: USER_BUBBLE_MAX_HEIGHT,
+            maxHeight: editing ? "none" : USER_BUBBLE_MAX_HEIGHT,
             overflowY: "auto",
           }}
         >
-          {commandText ? (
+          {editing ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 0 }}>
+              {imageBlocksNode}
+              <textarea
+                autoFocus
+                value={editValue}
+                onChange={(event) => setEditValue(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    onCancelEdit?.();
+                  } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                    event.preventDefault();
+                    void submitEdit();
+                  }
+                }}
+                aria-label={t("i18n.editMessage")}
+                rows={3}
+                style={{
+                  width: "100%",
+                  minHeight: 72,
+                  maxHeight: 240,
+                  padding: 0,
+                  resize: "none",
+                  border: "none",
+                  outline: "none",
+                  background: "transparent",
+                  color: "var(--text)",
+                  font: "inherit",
+                  lineHeight: 1.6,
+                }}
+              />
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 6 }}>
+                <button
+                  type="button"
+                  onClick={onCancelEdit}
+                  disabled={editSubmitting}
+                  style={{
+                    padding: "5px 10px",
+                    border: "1px solid var(--border)",
+                    borderRadius: 6,
+                    background: "var(--bg)",
+                    color: "var(--text-muted)",
+                    cursor: editSubmitting ? "not-allowed" : "pointer",
+                    fontSize: 12,
+                  }}
+                >
+                  {t("i18n.cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void submitEdit()}
+                  disabled={!canSubmitEdit || editSubmitting}
+                  style={{
+                    padding: "5px 10px",
+                    border: "none",
+                    borderRadius: 6,
+                    background: canSubmitEdit && !editSubmitting ? "var(--accent)" : "var(--bg-panel)",
+                    color: canSubmitEdit && !editSubmitting ? "#fff" : "var(--text-dim)",
+                    cursor: canSubmitEdit && !editSubmitting ? "pointer" : "not-allowed",
+                    fontSize: 12,
+                    fontWeight: 600,
+                  }}
+                >
+                  {t("chat.send")}
+                </button>
+              </div>
+            </div>
+          ) : commandText ? (
             <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
               {imageBlocksNode}
               <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
@@ -452,28 +540,29 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
               )}
             </div>
           ) : (
-          <>
-          {imageBlocksNode}
-          {content && <SafeMarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</SafeMarkdownBody>}
-          </>
+            <>
+              {imageBlocksNode}
+              {content && <SafeMarkdownBody className="markdown-user-message" cwd={cwd} onOpenFile={onOpenFile}>{content}</SafeMarkdownBody>}
+            </>
           )}
         </div>
 
       </div>
 
       {/* Bottom row: action buttons + timestamp */}
-      {(time || canFork || canNavigate || true) && (
+      {(time || canFork || canEdit || true) && (
         <div style={{
           display: "flex", alignItems: "center", justifyContent: "flex-end",
           gap: 6, marginTop: 3,
         }}>
-          <div style={{
-            display: "flex", gap: 3,
-            opacity: hovered ? 1 : 0,
-            pointerEvents: hovered ? "auto" : "none",
-            transition: "opacity 0.12s",
-          }}>
-            <button
+          {!editing && (
+            <div style={{
+              display: "flex", gap: 3,
+              opacity: hovered ? 1 : 0,
+              pointerEvents: hovered ? "auto" : "none",
+              transition: "opacity 0.12s",
+            }}>
+              <button
               onClick={copyContent}
                title={t("i18n.copyMessage")}
               style={{
@@ -502,45 +591,47 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
               )}
                {copied ? t("i18n.copied") : t("i18n.copy")}
             </button>
-          </div>
-          {(canFork || canNavigate) && (
+            {canEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditValue(editableText);
+                  onStartEdit!(entryId!);
+                }}
+                title={t("i18n.editMessageTitle")}
+                aria-label={t("i18n.editMessage")}
+                style={{
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  width: 26, height: 22, padding: 0,
+                  background: "none", border: "none",
+                  borderRadius: 5,
+                  color: "var(--text-dim)",
+                  cursor: "pointer",
+                  transition: "color 0.12s",
+                }}
+                onMouseEnter={(event) => { event.currentTarget.style.color = "var(--accent)"; }}
+                onMouseLeave={(event) => { event.currentTarget.style.color = "var(--text-dim)"; }}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+              </button>
+              )}
+            </div>
+          )}
+          {canFork && !editing && (
             <div style={{
               display: "flex", gap: 3,
-              opacity: (hovered || forking) ? 1 : 0,
-              pointerEvents: (hovered || forking) ? "auto" : "none",
+              opacity: hovered || forking ? 1 : 0,
+              pointerEvents: hovered || forking ? "auto" : "none",
               transition: "opacity 0.12s",
             }}>
-              {canNavigate && (
-                <button
-                  onClick={() => { onNavigate!(prevAssistantEntryId!); onEditContent?.(editTarget); }}
-                   title={t("i18n.editFromHereTitle")}
-                  style={{
-                    display: "flex", alignItems: "center", gap: 4,
-                    padding: "3px 8px", height: 22,
-                    background: "none", border: "none",
-                    borderRadius: 5,
-                    color: "var(--text-dim)",
-                    cursor: "pointer",
-                    fontSize: 11, fontWeight: 400,
-                    whiteSpace: "nowrap",
-                    transition: "color 0.12s",
-                  }}
-                  onMouseEnter={(e) => { e.currentTarget.style.color = "var(--accent)"; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-dim)"; }}
-                >
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                    <polyline points="15 10 20 15 15 20" />
-                    <path d="M4 4v7a4 4 0 0 0 4 4h12" />
-                  </svg>
-                   {t("i18n.editFromHere")}
-                </button>
-              )}
-              {canFork && (
-                <button
-                  onClick={() => { onFork!(entryId!); }}
-                  disabled={forking}
-                   title={forking ? t("i18n.creatingSession") : t("i18n.newSessionTitle")}
-                  style={{
+              <button
+                onClick={() => { onFork!(entryId!); }}
+                disabled={forking}
+                title={forking ? t("i18n.creatingSession") : t("i18n.newSessionTitle")}
+                style={{
                     display: "flex", alignItems: "center", gap: 4,
                     padding: "3px 8px", height: 22,
                     background: "none", border: "none",
@@ -551,18 +642,17 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
                     whiteSpace: "nowrap",
                     transition: "color 0.12s",
                   }}
-                  onMouseEnter={(e) => { if (!forking) e.currentTarget.style.color = "var(--accent)"; }}
-                  onMouseLeave={(e) => { if (!forking) e.currentTarget.style.color = "var(--text-dim)"; }}
-                >
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                    <line x1="6" y1="3" x2="6" y2="15" />
-                    <circle cx="18" cy="6" r="3" />
-                    <circle cx="6" cy="18" r="3" />
-                    <path d="M18 9a9 9 0 0 1-9 9" />
-                  </svg>
-                   {forking ? t("i18n.creating") : t("i18n.newSession")}
-                </button>
-              )}
+                onMouseEnter={(e) => { if (!forking) e.currentTarget.style.color = "var(--accent)"; }}
+                onMouseLeave={(e) => { if (!forking) e.currentTarget.style.color = "var(--text-dim)"; }}
+              >
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="6" y1="3" x2="6" y2="15" />
+                  <circle cx="18" cy="6" r="3" />
+                  <circle cx="6" cy="18" r="3" />
+                  <path d="M18 9a9 9 0 0 1-9 9" />
+                </svg>
+                {forking ? t("i18n.creating") : t("i18n.newSession")}
+              </button>
             </div>
           )}
           {time && <span style={{ fontSize: 10, color: "var(--text-dim)" }}>{time}</span>}

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -51,7 +51,7 @@ test("keeps the session event stream open through the idle grace window", () => 
   assert.match(promptDoneSource, /scheduleEventStreamClose\(sid\)/);
   assert.match(sendSource, /const definitivelyRejected = !promptRequestStarted/);
   assert.match(sendSource, /if \(!definitivelyRejected && sentSessionId\) \{[\s\S]*?waitForPromptSettlement/);
-  assert.match(sendSource, /restoreSubmission\(message, images, composerDraftKey\);[\s\S]*?if \(sentSessionId\) \{[\s\S]*?reconcileAgentState\(sentSessionId\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?closeEvents\(\)/);
+  assert.match(sendSource, /restoreSubmission\(message, images, composerDraftKey\);[\s\S]*?if \(sentSessionId\) \{[\s\S]*?reconcileAgentState\(sentSessionId\);[\s\S]*?return false;[\s\S]*?\}[\s\S]*?closeEvents\(\)/);
   assert.doesNotMatch(
     sendSource,
     /rpcPromptPendingRef\.current = false;\s*agentRunningRef\.current = false;\s*closeEvents\(\)/,
@@ -140,6 +140,20 @@ test("fresh sessions use the preference while persisted and live sessions restor
   assert.match(changeSource, /\(sid, \{ type: "set_tools", toolNames \}\)/);
   assert.match(changeSource, /sessionIdRef\.current = activeSessionId/);
   assert.doesNotMatch(loadToolsSource, /setPreferredToolPreset/);
+});
+
+test("editing navigates to the selected user entry before resending", () => {
+  const editSource = source.slice(
+    source.indexOf("  const handleEditAndSend = useCallback"),
+    source.indexOf("  const handleLeafChange = useCallback"),
+  );
+
+  assert.match(editSource, /agentRunningRef\.current \|\| bashRunningRef\.current/);
+  assert.match(editSource, /type: "navigate_tree",\s*targetId: entryId/);
+  assert.match(editSource, /const leafId = result\?\.leafId \?\? null/);
+  assert.ok(editSource.indexOf("await loadContext(sid, leafId)") < editSource.indexOf("await handleSend(message, images)"));
+  assert.match(editSource, /return false;[\s\S]*?addNotice/);
+  assert.match(chatWindowSource, /if \(sessionBusy\) setEditingEntryId\(null\)/);
 });
 
 test("existing-session prompts rely on the persisted tool selection", () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -248,7 +248,6 @@ export interface ChatInputHandle {
 export interface AttachedImage {
   data: string;
   mimeType: string;
-  previewUrl: string;
 }
 
 type SelectedModel = { provider: string; modelId: string };
@@ -521,7 +520,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const loadContext = useCallback(async (sid: string, leafId: string | null, before?: string | null, options?: { tail?: number; signal?: AbortSignal }) => {
     try {
       const params = new URLSearchParams({ deferThinking: "1", deferMedia: "1" });
-      if (leafId) params.set("leafId", leafId);
+      if (leafId !== undefined) params.set("leafId", leafId ?? "");
       // Page upward: ask the server for the `tail` ancestors preceding `before`,
       // then prepend them. Omitting `before` fetches the most-recent `tail`.
       if (before) params.set("before", before);
@@ -1278,12 +1277,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [addNotice, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, scrollToBottom, settleUiStage]);
   handleAgentEventRef.current = handleAgentEvent;
 
-  const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
+  const handleSend = useCallback(async (message: string, images?: AttachedImage[]): Promise<boolean> => {
     const trimmedMessage = message.trim();
-    if (!trimmedMessage && !images?.length) return;
+    if (!trimmedMessage && !images?.length) return false;
     if (agentRunningRef.current || bashRunningRef.current) {
       restoreSubmission(message, images, composerDraftKey);
-      return;
+      return false;
     }
     const isSlashCommandPrompt = !images?.length && trimmedMessage.startsWith("/");
 
@@ -1293,10 +1292,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const bashCmd = (isExcluded ? trimmedMessage.slice(2) : trimmedMessage.slice(1)).trim();
       if (!bashCmd) {
         restoreSubmission(message, images, composerDraftKey);
-        return;
+        return false;
       }
       await executeBashRef.current?.(bashCmd, isExcluded);
-      return;
+      return true;
     }
 
     const promptRunId = promptRunIdRef.current + 1;
@@ -1362,6 +1361,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       if (isSlashCommandPrompt && sentSessionId) {
         void waitForPromptSettlement(sentSessionId, promptRunId);
       }
+      return true;
     } catch (e) {
       console.error("Failed to send message:", e);
       const definitivelyRejected = !promptRequestStarted || isPromptRejectedError(e);
@@ -1370,7 +1370,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // until server state confirms the run is idle.
       if (!definitivelyRejected && sentSessionId) {
         void waitForPromptSettlement(sentSessionId, promptRunId);
-        return;
+        return true;
       }
       rpcPromptPendingRef.current = false;
       setMessages((prev) => {
@@ -1387,13 +1387,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // its SSE connection until server state says the wrapper is idle.
       if (sentSessionId) {
         void reconcileAgentState(sentSessionId);
-        return;
+        return false;
       }
       agentRunningRef.current = false;
       closeEvents();
       setAgentRunning(false);
       setAgentPhase(null);
       dispatch({ type: "end" });
+      return false;
     }
   }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, composerDraftKey, reconcileAgentState, restoreSubmission]);
 
@@ -1472,6 +1473,33 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     setActiveLeafId(entryId);
     await loadContext(sid, entryId);
   }, [loadContext]);
+
+  const handleEditAndSend = useCallback(async (
+    entryId: string,
+    message: string,
+    images?: AttachedImage[],
+  ): Promise<boolean> => {
+    if (agentRunningRef.current || bashRunningRef.current) return false;
+    const sid = sessionIdRef.current;
+    if (!sid) return false;
+
+    try {
+      const result = await sendAgentCommand<{ cancelled?: boolean; leafId?: string | null }>(sid, {
+        type: "navigate_tree",
+        targetId: entryId,
+      });
+      if (result?.cancelled) return false;
+
+      const leafId = result?.leafId ?? null;
+      setActiveLeafId(leafId);
+      await loadContext(sid, leafId);
+      return await handleSend(message, images);
+    } catch (e) {
+      console.error("Failed to edit message:", e);
+      addNotice({ type: "error", message: e instanceof Error ? e.message : String(e) });
+      return false;
+    }
+  }, [addNotice, handleSend, loadContext]);
 
   const handleLeafChange = useCallback(async (leafId: string | null) => {
     if (bashRunningRef.current) return;
@@ -2041,7 +2069,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     sessionIdRef, messagesEndRef, scrollContainerRef,
     lastUserMsgRef, pendingScrollToUserRef, initialScrollDoneRef,
     // Actions
-    handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
+    handleSend, handleAbort, handleFork, handleNavigate, handleEditAndSend, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
     handleRecallQueue,
     handleBuiltinSlashCommand,

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -574,6 +574,8 @@ export const enLocale: LocalePlugin = {
     "i18n.largeMessageReveal": "Message content is very large ({size}). Click to view as plain text — markdown rendering is disabled to keep the page responsive.",
     "i18n.loadingThinking": "Loading thinking...",
     "i18n.copyMessage": "Copy message",
+    "i18n.editMessage": "Edit message",
+    "i18n.editMessageTitle": "Edit and resend this message",
     "i18n.editFromHere": "Edit from here",
     "i18n.editFromHereTitle": "Edit from here — branches within this session",
     "i18n.newSession": "New session",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -574,6 +574,8 @@ export const zhCNLocale: LocalePlugin = {
     "i18n.largeMessageReveal": "消息内容过大（{size}）。点击以纯文本查看 — 已禁用 markdown 渲染以避免页面卡顿。",
     "i18n.loadingThinking": "正在加载思考内容...",
     "i18n.copyMessage": "复制消息",
+    "i18n.editMessage": "编辑消息",
+    "i18n.editMessageTitle": "编辑并重新发送此消息",
     "i18n.editFromHere": "从此处编辑",
     "i18n.editFromHereTitle": "从此处编辑，此会话内创建分支",
     "i18n.newSession": "新会话",

--- a/lib/i18n/messages/zh-TW.ts
+++ b/lib/i18n/messages/zh-TW.ts
@@ -574,6 +574,8 @@ export const zhTWLocale: LocalePlugin = {
     "i18n.largeMessageReveal": "訊息內容過大（{size}）。點選即可用純文字查看；為保持頁面流暢，已停用 Markdown 轉譯。",
     "i18n.loadingThinking": "正在載入思考內容...",
     "i18n.copyMessage": "複製訊息",
+    "i18n.editMessage": "編輯訊息",
+    "i18n.editMessageTitle": "編輯並重新傳送此訊息",
     "i18n.editFromHere": "從此處編輯",
     "i18n.editFromHereTitle": "從此處編輯，並在這個工作階段中建立分支",
     "i18n.newSession": "新增工作階段",

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -170,6 +170,17 @@ test("clone copies the requested leaf into a child session", async () => {
   assert.match(cloneSource, /return \{ cancelled: false, newSessionId \}/);
 });
 
+test("tree navigation returns the active leaf for inline message editing", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const navigateSource = source.slice(
+    source.indexOf('case "navigate_tree"'),
+    source.indexOf('case "set_thinking_level"'),
+  );
+
+  assert.match(navigateSource, /await this\.inner\.navigateTree\(command\.targetId as string, \{\}\)/);
+  assert.match(navigateSource, /leafId: this\.inner\.sessionManager\.getLeafId\(\)/);
+});
+
 test("session replacement rejects active work and clone writes one reopenable child", async () => {
   const root = await mkdtemp(join(tmpdir(), "pi-web-clone-"));
   const sessionDir = join(root, "sessions");

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -758,7 +758,10 @@ export class AgentSessionWrapper {
           throw new Error("Cannot navigate while a shell command is running");
         }
         const result = await this.inner.navigateTree(command.targetId as string, {});
-        return { cancelled: result.cancelled };
+        return {
+          cancelled: result.cancelled,
+          leafId: this.inner.sessionManager.getLeafId(),
+        };
       }
 
       case "set_thinking_level": {


### PR DESCRIPTION
## Summary

- add a pencil action beside Copy for editing a sent user message in place
- replace the message bubble with an inline editor containing Cancel and Send actions
- navigate to the point immediately before the selected message and resend the revised prompt on a new branch of the same session
- support the first user message, text plus image messages, `Escape` to cancel, and `Ctrl`/`Cmd+Enter` to submit
- expose editing only while the session is idle, so an active run must be stopped explicitly first

The session JSONL remains append-only. Older branches stay available through the existing branch navigator, while the active chat view shows only the revised message and its new response. No additional sidebar session is created.

This addresses the editing portion of #628.

## Implementation notes

- `navigate_tree` returns the resulting active leaf so the client can reload the exact parent context before resending
- the context endpoint distinguishes an omitted leaf from an explicit root position, enabling edits to the first message without leaking pagination state from the previous branch
- English, Simplified Chinese, and Traditional Chinese labels are included

## Testing

- `npm test` — 892 tests passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- real browser QA on the rebased commit: editing and resending the first message hides the old active path and returns a fresh model response in the same session

## Demo

The demo edits the first active user message and reruns it through the real model flow.

![Edit and resend a user message inline](https://raw.githubusercontent.com/Zhangs-11/pi-web/assets/pr-demos/pr-demos/inline-message-edit.gif)

Recorded from `Zhangs-11/pi-web@9596cd11e895d44e908fca2d9655f224c10ca93d` on the clean rebased branch, served at `http://127.0.0.1:30159` with `next dev` because repository instructions prohibit `next build` during development. The run used a fresh isolated Pi agent directory, workspace, and headless Chrome profile with the normal application transport; the repository-declared Playwright CDP fallback was used after agent-browser could not connect to its configured CDP endpoint. Real GPT-6-Astra rounds produced both the original and updated answers; no fixtures, mock transport, DOM-event injection, or test-only hooks were used.


