### PR TITLE
feat(sessions): add drag-and-drop ordering

### DIFF
--- a/components/SessionSidebar.test.mjs
+++ b/components/SessionSidebar.test.mjs
@@ -128,3 +128,22 @@ test("hides subagent rows and aggregates their state into the main session row",
   assert.match(source, /familySessions\.some\(\(session\) => runningSessionIds\.has\(session\.id\)\)/);
   assert.doesNotMatch(source, /function SessionTreeItem/);
 });
+
+test("persists manual ordering per project while moving whole session families", () => {
+  assert.match(source, /const storedSessionOrder = selectedProjectKey \? sessionOrders\[selectedProjectKey\]/);
+  assert.match(source, /getSessionListIndices\(\s*orderedSessionFamilies\.length/);
+  assert.match(source, /family\.root\.id === \(draggedSessionId \?\? focusedSessionId\)/);
+  assert.match(source, /const family = orderedSessionFamilies\[index\]/);
+  assert.match(source, /moveSessionId\(currentIds, sourceId, targetId, position\)/);
+  assert.match(source, /persistSessionOrder\(\s*selectedProjectKey/);
+  assert.match(source, /filter\(\(family\) => !family\.root\.transient\)/);
+});
+
+test("uses native row dragging without hijacking rename or delete controls", () => {
+  assert.match(sessionItemSource, /draggable=\{draggable\}/);
+  assert.match(sessionItemSource, /dragBlockedRef\.current = Boolean\(\(event\.target as HTMLElement\)\.closest\("button, input"\)\)/);
+  assert.match(sessionItemSource, /if \(dragBlockedRef\.current\) \{\s*event\.preventDefault\(\)/);
+  assert.match(sessionItemSource, /onDragOver=\{draggable \? onDragOver : undefined\}/);
+  assert.match(sessionItemSource, /boxShadow: dropPosition === "before"/);
+  assert.match(sessionItemSource, /opacity: deleting \? 0\.5 : isDragging \? 0\.45 : 1/);
+});

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -4,6 +4,14 @@ import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, typ
 import type { SessionInfo } from "@/lib/types";
 import { listSessionFamilies } from "@/lib/session-family";
 import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
+import {
+  loadSessionOrders,
+  moveSessionId,
+  orderSessionIds,
+  saveSessionOrders,
+  withProjectSessionOrder,
+  type SessionOrders,
+} from "@/lib/session-order-state";
 import { dispatchSessionRowContextMenu } from "@/lib/session-row-context-menu";
 import { skillExpansionToCommand } from "@/lib/slash-display";
 import { getProjectActivity, getRecentProjects, sessionsForProject } from "@/lib/project-groups";
@@ -407,6 +415,10 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const sessionSearchActive = sessionSearchOpen && Boolean(sessionSearchQuery.trim());
   const [changesCount, setChangesCount] = useState(0);
   const [changesCollapsed, setChangesCollapsed] = useState(true);
+  const [sessionOrders, setSessionOrders] = useState<SessionOrders>({});
+  const [draggedSessionId, setDraggedSessionId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: string; position: "before" | "after" } | null>(null);
+  const draggedSessionIdRef = useRef<string | null>(null);
   const [explorerRefreshDone, setExplorerRefreshDone] = useState(false);
   const [runningSessionIds, setRunningSessionIds] = useState<Set<string>>(() => new Set());
   const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(() => loadUnreadSessionIds());
@@ -502,6 +514,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   // preference after hydration so a collapsed explorer stays collapsed on reload.
   useEffect(() => {
     setExplorerOpen(loadExplorerOpen());
+    setSessionOrders(loadSessionOrders());
   }, []);
 
   // Persist unread markers so they survive a browser refresh before the user
@@ -944,6 +957,14 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     onNewSession?.(tempId, selectedCwd);
   }, [selectedCwd, onNewSession]);
 
+  const persistSessionOrder = useCallback((projectKey: string, ids: readonly string[]) => {
+    setSessionOrders((previous) => {
+      const next = withProjectSessionOrder(previous, projectKey, ids);
+      saveSessionOrders(next);
+      return next;
+    });
+  }, []);
+
   const recentProjects = getRecentProjects(allSessions);
   const showProjectFilter = recentProjects.length > 8;
   const visibleProjects = projectFilter.trim()
@@ -1003,12 +1024,87 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       : null);
 
   const sessionFamilies = listSessionFamilies(filteredSessions);
+  const selectedProjectKey = selectedProject?.key;
+  const storedSessionOrder = selectedProjectKey ? sessionOrders[selectedProjectKey] : undefined;
+  const orderedSessionIds = orderSessionIds(
+    sessionFamilies.map((family) => family.root.id),
+    storedSessionOrder,
+  );
+  const sessionFamiliesById = new Map(
+    sessionFamilies.map((family) => [family.root.id, family]),
+  );
+  const orderedSessionFamilies = orderedSessionIds
+    .map((id) => sessionFamiliesById.get(id))
+    .filter((family) => family !== undefined);
+  const persistentFamilyIds = sessionFamilies
+    .filter((family) => !family.root.transient)
+    .map((family) => family.root.id);
+
+  useEffect(() => {
+    if (!selectedProjectKey || !storedSessionOrder || loading || error) return;
+    const reconciled = orderSessionIds(persistentFamilyIds, storedSessionOrder);
+    if (
+      reconciled.length === storedSessionOrder.length
+      && reconciled.every((id, index) => id === storedSessionOrder[index])
+    ) return;
+    persistSessionOrder(selectedProjectKey, reconciled);
+  }, [error, loading, persistSessionOrder, persistentFamilyIds, selectedProjectKey, storedSessionOrder]);
+
+  const clearSessionDrag = useCallback(() => {
+    draggedSessionIdRef.current = null;
+    setDraggedSessionId(null);
+    setDropTarget(null);
+  }, []);
+
+  const handleSessionDragStart = useCallback((event: React.DragEvent<HTMLDivElement>, sessionId: string) => {
+    draggedSessionIdRef.current = sessionId;
+    setDraggedSessionId(sessionId);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", "");
+  }, []);
+
+  const handleSessionDragOver = useCallback((event: React.DragEvent<HTMLDivElement>, targetId: string) => {
+    const sourceId = draggedSessionIdRef.current;
+    if (!sourceId || sourceId === targetId) {
+      setDropTarget(null);
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const position = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    setDropTarget((previous) => (
+      previous?.id === targetId && previous.position === position
+        ? previous
+        : { id: targetId, position }
+    ));
+  }, []);
+
+  const handleSessionDrop = useCallback((event: React.DragEvent<HTMLDivElement>, targetId: string) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const sourceId = draggedSessionIdRef.current;
+    if (!selectedProjectKey || !sourceId || sourceId === targetId) {
+      clearSessionDrag();
+      return;
+    }
+    const rect = event.currentTarget.getBoundingClientRect();
+    const position = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    const currentIds = orderedSessionFamilies
+      .filter((family) => !family.root.transient)
+      .map((family) => family.root.id);
+    persistSessionOrder(
+      selectedProjectKey,
+      moveSessionId(currentIds, sourceId, targetId, position),
+    );
+    clearSessionDrag();
+  }, [clearSessionDrag, orderedSessionFamilies, persistSessionOrder, selectedProjectKey]);
 
   const virtualIndices = getSessionListIndices(
-    sessionFamilies.length,
+    orderedSessionFamilies.length,
     listScrollTop,
     listViewportH,
-    sessionFamilies.findIndex((family) => family.root.id === focusedSessionId),
+    orderedSessionFamilies.findIndex((family) => family.root.id === (draggedSessionId ?? focusedSessionId)),
   );
 
   return (
@@ -1688,25 +1784,25 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             {error}
           </div>
         )}
-        {!loading && !error && sessionFamilies.length === 0 && (
+        {!loading && !error && orderedSessionFamilies.length === 0 && (
           <div style={{ padding: "16px 14px", color: "var(--text-muted)", fontSize: 12 }}>
             {t("sidebar.noSessions")}
           </div>
         )}
-        {sessionFamilies.length > 0 && (
+        {orderedSessionFamilies.length > 0 && (
           <div
             style={{
               position: "relative",
-              height: sessionFamilies.length * SESSION_LIST_ITEM_HEIGHT,
+              height: orderedSessionFamilies.length * SESSION_LIST_ITEM_HEIGHT,
             }}
           >
             {virtualIndices.map((index) => {
-              const family = sessionFamilies[index];
+              const family = orderedSessionFamilies[index];
               const familySessions = [family.root, ...family.subagents];
               const displaySession = family.latestModified === family.root.modified
                 ? family.root
                 : { ...family.root, modified: family.latestModified };
-              // Bubble blur after the input's save handler before unpinning the row.
+              // Bubble blur after the input's save handler before discarding the row.
               return (
                 <div
                   key={family.root.id}
@@ -1719,7 +1815,13 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                     isSelected={familySessions.some((session) => session.id === selectedSessionId)}
                     isRunning={familySessions.some((session) => runningSessionIds.has(session.id))}
                     isUnread={familySessions.some((session) => unreadSessionIds.has(session.id))}
+                    isDragging={draggedSessionId === family.root.id}
+                    dropPosition={dropTarget?.id === family.root.id ? dropTarget.position : null}
                     onClick={() => handleSelectSessionFromList(family.root)}
+                    onDragStart={(event) => handleSessionDragStart(event, family.root.id)}
+                    onDragOver={(event) => handleSessionDragOver(event, family.root.id)}
+                    onDrop={(event) => handleSessionDrop(event, family.root.id)}
+                    onDragEnd={clearSessionDrag}
                     onRenamed={loadSessions}
                     onDeleted={(id) => {
                       onSessionDeleted?.(id);
@@ -1984,7 +2086,13 @@ function SessionItem({
   isSelected,
   isRunning,
   isUnread,
+  isDragging,
+  dropPosition,
   onClick,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
   onRenamed,
   onDeleted,
   depth = 0,
@@ -1996,7 +2104,13 @@ function SessionItem({
   isSelected: boolean;
   isRunning?: boolean;
   isUnread?: boolean;
+  isDragging?: boolean;
+  dropPosition?: "before" | "after" | null;
   onClick: () => void;
+  onDragStart?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: () => void;
   onRenamed?: () => void;
   onDeleted?: (id: string) => void;
   depth?: number;
@@ -2011,6 +2125,7 @@ function SessionItem({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dragBlockedRef = useRef(false);
 
   // Select the whole name once the rename input is mounted (startRename's
   // immediate setTimeout can fire before the input exists).
@@ -2101,10 +2216,29 @@ function SessionItem({
   }, [onRenamed, session.cwd, session.id, session.name, session.path]);
 
   // Fixed-height outer wrapper — content swaps in place so the list never reflows
+  const draggable = !session.transient && !confirmDelete && !renaming && !deleting;
   return (
     <div
+      draggable={draggable}
       onClick={confirmDelete || renaming ? undefined : onClick}
       onContextMenu={confirmDelete || renaming ? undefined : handleContextMenu}
+      onMouseDownCapture={(event) => {
+        dragBlockedRef.current = Boolean((event.target as HTMLElement).closest("button, input"));
+      }}
+      onMouseUpCapture={() => { dragBlockedRef.current = false; }}
+      onDragStart={draggable ? (event) => {
+        if (dragBlockedRef.current) {
+          event.preventDefault();
+          return;
+        }
+        onDragStart?.(event);
+      } : undefined}
+      onDragOver={draggable ? onDragOver : undefined}
+      onDrop={draggable ? onDrop : undefined}
+      onDragEnd={() => {
+        dragBlockedRef.current = false;
+        onDragEnd?.();
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => { setHovered(false); }}
       style={{
@@ -2113,15 +2247,18 @@ function SessionItem({
         alignItems: "center",
         paddingLeft: depth > 0 ? depth * 12 + 14 : 14,
         paddingRight: 8,
-        cursor: confirmDelete || renaming ? "default" : "pointer",
+        cursor: confirmDelete || renaming ? "default" : draggable ? (isDragging ? "grabbing" : "grab") : "pointer",
         background: confirmDelete
           ? "rgba(239,68,68,0.06)"
           : isSelected ? "var(--bg-selected)" : hovered ? "var(--bg-hover)" : "transparent",
         borderLeft: confirmDelete
           ? "2px solid #ef4444"
           : isSelected ? "2px solid var(--accent)" : "2px solid transparent",
-        transition: "background 0.1s",
-        opacity: deleting ? 0.5 : 1,
+        boxShadow: dropPosition === "before"
+          ? "inset 0 2px var(--accent)"
+          : dropPosition === "after" ? "inset 0 -2px var(--accent)" : "none",
+        transition: "background 0.1s, opacity 0.1s, box-shadow 0.1s",
+        opacity: deleting ? 0.5 : isDragging ? 0.45 : 1,
         gap: 6,
         overflow: "hidden",
       }}

--- a/lib/session-order-state.test.mjs
+++ b/lib/session-order-state.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const {
+  loadSessionOrders,
+  moveSessionId,
+  orderSessionIds,
+  saveSessionOrders,
+  withProjectSessionOrder,
+} = await createJiti(import.meta.url).import("./session-order-state.ts");
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+    values,
+  };
+}
+
+test("loads only valid per-project session orders", () => {
+  const storage = memoryStorage({
+    "pi-web:session-orders:v1": JSON.stringify({
+      "/repo": ["a", "a", "", 1, "b"],
+      "": ["ignored"],
+      "/empty": [],
+      "/invalid": "nope",
+    }),
+  });
+
+  assert.deepEqual(loadSessionOrders(storage), { "/repo": ["a", "b"] });
+});
+
+test("saves normalized orders and removes empty state", () => {
+  const storage = memoryStorage();
+  saveSessionOrders({ "/repo": ["a", "a", "b"], "/empty": [] }, storage);
+  assert.equal(storage.values.get("pi-web:session-orders:v1"), JSON.stringify({ "/repo": ["a", "b"] }));
+
+  saveSessionOrders({}, storage);
+  assert.equal(storage.values.has("pi-web:session-orders:v1"), false);
+});
+
+test("falls back safely when stored state is malformed or unavailable", () => {
+  assert.deepEqual(loadSessionOrders(memoryStorage({ "pi-web:session-orders:v1": "{" })), {});
+  assert.deepEqual(loadSessionOrders(undefined), {});
+  assert.doesNotThrow(() => saveSessionOrders({ "/repo": ["a"] }, undefined));
+});
+
+test("keeps recent order until a project has a manual order", () => {
+  assert.deepEqual(orderSessionIds(["newest", "older"], undefined), ["newest", "older"]);
+});
+
+test("keeps manually ordered sessions fixed and inserts new sessions first", () => {
+  assert.deepEqual(
+    orderSessionIds(["new", "b", "a"], ["a", "deleted", "b"]),
+    ["new", "a", "b"],
+  );
+});
+
+test("moves a session before or after a target without duplicating ids", () => {
+  assert.deepEqual(moveSessionId(["a", "b", "c"], "c", "a", "before"), ["c", "a", "b"]);
+  assert.deepEqual(moveSessionId(["a", "b", "c"], "a", "b", "after"), ["b", "a", "c"]);
+  assert.deepEqual(moveSessionId(["a", "b"], "a", "a", "before"), ["a", "b"]);
+});
+
+test("updates one project without changing another", () => {
+  const orders = { "/one": ["a"], "/two": ["b"] };
+  assert.deepEqual(withProjectSessionOrder(orders, "/one", ["c", "a"]), {
+    "/one": ["c", "a"],
+    "/two": ["b"],
+  });
+  assert.deepEqual(withProjectSessionOrder(orders, "/one", []), { "/two": ["b"] });
+});

--- a/lib/session-order-state.ts
+++ b/lib/session-order-state.ts
@@ -1,0 +1,97 @@
+const SESSION_ORDERS_STORAGE_KEY = "pi-web:session-orders:v1";
+
+export type SessionOrders = Record<string, string[]>;
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function browserStorage(): StorageLike | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function uniqueIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((id): id is string => typeof id === "string" && id.length > 0))];
+}
+
+export function loadSessionOrders(storage: StorageLike | undefined = browserStorage()): SessionOrders {
+  if (!storage) return {};
+  try {
+    const parsed = JSON.parse(storage.getItem(SESSION_ORDERS_STORAGE_KEY) ?? "null") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([projectKey, ids]) => [projectKey, uniqueIds(ids)] as const)
+        .filter(([projectKey, ids]) => projectKey.length > 0 && ids.length > 0),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function saveSessionOrders(
+  orders: Readonly<SessionOrders>,
+  storage: StorageLike | undefined = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const normalized = Object.fromEntries(
+      Object.entries(orders)
+        .map(([projectKey, ids]) => [projectKey, uniqueIds(ids)] as const)
+        .filter(([projectKey, ids]) => projectKey.length > 0 && ids.length > 0),
+    );
+    if (Object.keys(normalized).length === 0) storage.removeItem(SESSION_ORDERS_STORAGE_KEY);
+    else storage.setItem(SESSION_ORDERS_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // Persistence is best-effort when storage is blocked or full.
+  }
+}
+
+export function withProjectSessionOrder(
+  orders: Readonly<SessionOrders>,
+  projectKey: string,
+  ids: readonly string[],
+): SessionOrders {
+  const next = { ...orders };
+  const normalized = uniqueIds(ids);
+  if (normalized.length === 0) delete next[projectKey];
+  else next[projectKey] = normalized;
+  return next;
+}
+
+export function orderSessionIds(
+  currentIds: readonly string[],
+  storedOrder: readonly string[] | undefined,
+): string[] {
+  const current = uniqueIds(currentIds);
+  if (!storedOrder) return current;
+
+  const currentSet = new Set(current);
+  const stored = uniqueIds(storedOrder).filter((id) => currentSet.has(id));
+  const storedSet = new Set(stored);
+  const newIds = current.filter((id) => !storedSet.has(id));
+  return [...newIds, ...stored];
+}
+
+export function moveSessionId(
+  ids: readonly string[],
+  sourceId: string,
+  targetId: string,
+  position: "before" | "after",
+): string[] {
+  const current = uniqueIds(ids);
+  if (sourceId === targetId || !current.includes(sourceId) || !current.includes(targetId)) return current;
+
+  const next = current.filter((id) => id !== sourceId);
+  const targetIndex = next.indexOf(targetId);
+  next.splice(position === "after" ? targetIndex + 1 : targetIndex, 0, sourceId);
+  return next;
+}


### PR DESCRIPTION
## Summary

- make session families draggable in the current project's sidebar
- preserve the manual order per project in browser storage
- keep new sessions at the top and remove stale IDs after sessions are deleted
- keep transient sessions and row actions out of drag handling

## Behavior

Dragging a main session moves its whole family, including subagents. Once a project has a manual order, later activity does not reshuffle it; projects without a manual order keep the existing recent-activity ordering.

## Demo

![Drag a session family to a new position and keep the order after refresh](https://github.com/Zhangs-11/pi-web/blob/pi-web-session-order-assets/session-order.gif?raw=true)

Recorded from `Zhangs-11/pi-web@f532449321a15b6490cfbe852249fe6fbf5e237b` on the clean rebased `feat/draggable-session-order` tree, served at `http://127.0.0.1:30157` with `next dev` because repository instructions prohibit `next build` during development. The run used a fresh isolated Pi agent directory, workspace, and headless Chrome profile; the repository-declared Playwright CDP fallback was used after agent-browser control became unavailable. Three real GPT-6-Astra rounds created the displayed sessions; no fixture transport, mock response, DOM-event injection, or test-only hook was used.

## Testing

- `npm test` — 890 tests passed
- `tsc --noEmit`
- `npm run lint`
- `git diff --check`
- browser QA: before/after insertion, action-button isolation, selected-session preservation, session refresh, and page-reload persistence

