### PR TITLE
fix: keep model selector visible when loading fails

### DIFF
--- a/hooks/model-loading.test.mjs
+++ b/hooks/model-loading.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { Script } from "node:vm";
+import ts from "typescript";
+
+const source = ts.createSourceFile(
+  "useAgentSession.ts",
+  await readFile(new URL("./useAgentSession.ts", import.meta.url), "utf8"),
+  ts.ScriptTarget.Latest,
+  true,
+);
+const nodes = [];
+function visit(node) {
+  nodes.push(node);
+  ts.forEachChild(node, visit);
+}
+visit(source);
+const loader = nodes.find((node) => ts.isVariableDeclaration(node) && node.name.getText(source) === "loadModels");
+const schedule = nodes.find((node) => ts.isVariableDeclaration(node) && node.name.getText(source) === "MODELS_RETRY_DELAYS_MS");
+const effect = nodes.find((node) => ts.isCallExpression(node)
+  && node.expression.getText(source) === "useEffect"
+  && node.arguments[1]?.getText(source) === "[loadModels, modelsRefreshKey]");
+const retry = effect.arguments[0].body.statements.find(ts.isExpressionStatement).expression;
+function script(text) {
+  return new Script(ts.transpileModule(text, { compilerOptions: { target: ts.ScriptTarget.ESNext } }).outputText);
+}
+const loadScript = script(`(${loader.initializer.arguments[0].getText(source)})`);
+const retryScript = script(retry.getText(source));
+
+function setup(fetchImpl) {
+  const writes = [];
+  const delays = [];
+  const context = {
+    Error, DOMException,
+    controller: new AbortController(),
+    newSessionCwd: "/project", session: null, isNew: true,
+    sessionIdRef: { current: null }, thinkingLevelOverrideRef: { current: null },
+    fetch: fetchImpl,
+    MODELS_RETRY_DELAYS_MS: script(schedule.initializer.getText(source)).runInNewContext(),
+    delay: async (ms) => { delays.push(ms); },
+  };
+  for (const name of ["ModelError", "ModelNames", "ModelScopeWarnings", "ModelThinkingLevels", "ModelThinkingLevelMaps", "ModelList", "NewSessionDefaultModel", "ThinkingLevel"]) {
+    context[`set${name}`] = (value) => writes.push([name, value]);
+  }
+  context.loadModels = loadScript.runInNewContext(context);
+  return { context, writes, delays, run: () => retryScript.runInNewContext(context) };
+}
+
+test("model-load failures stay visible through bounded retries and clear on recovery", async () => {
+  for (const [fetchImpl, expected] of [
+    [async () => { throw new TypeError("Failed to fetch"); }, "Failed to fetch"],
+    [async () => Response.json({ error: "Access denied" }, { status: 403 }), "Access denied"],
+    [async () => new Response("Unavailable", { status: 503 }), "Failed to load models (HTTP 503)"],
+    [async () => ({ ok: true, json: async () => { throw new SyntaxError("Invalid JSON"); } }), "Invalid JSON"],
+  ]) {
+    const state = setup(fetchImpl);
+    await state.run();
+    assert.deepEqual(state.delays, [2_000, 5_000, 10_000]);
+    assert.deepEqual(state.writes, Array.from({ length: 4 }, () => ["ModelError", expected]));
+  }
+
+  let attempts = 0;
+  const recovered = setup(async () => {
+    if (++attempts === 1) throw new TypeError("Failed to fetch");
+    return Response.json({
+      models: { "custom:test": "Test" },
+      modelList: [{ provider: "custom", id: "test", name: "Test" }],
+      defaultModel: { provider: "custom", modelId: "test" },
+      thinkingLevelPins: { "custom/test": "high" },
+    });
+  });
+  await recovered.run();
+  assert.equal(attempts, 2);
+  assert.deepEqual(recovered.delays, [2_000]);
+  assert.deepEqual(recovered.writes.filter(([name]) => name === "ModelError"), [["ModelError", "Failed to fetch"], ["ModelError", null]]);
+  assert.ok(recovered.writes.some(([name, value]) => name === "ModelList" && value[0].id === "test"));
+  assert.ok(recovered.writes.some(([name, value]) => name === "NewSessionDefaultModel" && value.modelId === "test"));
+  assert.ok(recovered.writes.some(([name, value]) => name === "ThinkingLevel" && value === "high"));
+});
+
+test("cancelling model loads prevents state writes and further retries", async () => {
+  for (const status of [200, 403]) {
+    const reading = Promise.withResolvers();
+    const state = setup(async (_url, { signal }) => ({
+      ok: status === 200, status,
+      json: () => new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        reading.resolve();
+      }),
+    }));
+    const completed = state.run();
+    await reading.promise;
+    state.context.controller.abort();
+    await completed;
+    assert.deepEqual(state.writes, []);
+    assert.deepEqual(state.delays, []);
+  }
+
+  const late = setup(async (_url, { signal }) => ({
+    ok: true,
+    json: async () => {
+      late.context.controller.abort();
+      assert.equal(signal.aborted, true);
+      return { models: {}, modelList: [] };
+    },
+  }));
+  await late.run();
+  assert.deepEqual(late.writes, []);
+
+  let attempts = 0;
+  const waiting = setup(async () => { attempts++; throw new TypeError("Failed to fetch"); });
+  waiting.context.delay = async () => waiting.context.controller.abort();
+  await waiting.run();
+  assert.equal(attempts, 1);
+});

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -168,6 +168,10 @@ const AGENT_STATE_RECONCILE_MS = 15_000;
 const BASH_STATE_RECONCILE_MS = 1_000;
 const EVENT_STREAM_READY_TIMEOUT_MS = 60_000;
 const EVENT_STREAM_RECONNECT_DELAY_MS = 1_000;
+// Backoff schedule for /api/models load failures. The first dev-server hit can
+// take many seconds (route compile) and a restarted server can transiently 403
+// until the cwd allow-list catches up, so retry before giving up visibly.
+const MODELS_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 const MAX_NOTICES = 5;
 const NOTICE_VISIBLE_MS = 5000;
 const NOTICE_EXIT_ANIMATION_MS = 180;
@@ -1546,7 +1550,22 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const modelCwd = newSessionCwd ?? session?.cwd ?? "";
     const modelsUrl = modelCwd ? `/api/models?cwd=${encodeURIComponent(modelCwd)}` : "/api/models";
     const res = await fetch(modelsUrl, signal ? { signal } : undefined);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) {
+      // 400/403 bodies carry a plain { error } message; surface it so the UI
+      // degrades to an error state instead of silently hiding the selector.
+      let detail = "";
+      try {
+        const body: unknown = await res.json();
+        if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
+          detail = body.error;
+        }
+      } catch {
+        // non-JSON error body — fall through to the status message
+      }
+      const message = detail || `Failed to load models (HTTP ${res.status})`;
+      setModelError(message);
+      throw new Error(message);
+    }
     const d = await res.json() as ModelsResponse;
     setModelNames(d.models);
     setModelError(d.modelError ?? null);
@@ -1939,12 +1958,25 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [messages.length, agentRunning, scrollToBottom, scrollUserMsgToTop]);
 
-  // Load model list
+  // Load model list. Failures are transient on purpose (dev cold route
+  // compile, server restart races the cwd allow-list), so retry with backoff
+  // before leaving the selector in its error state.
   useEffect(() => {
     const controller = new AbortController();
-    loadModels(controller.signal).catch((e) => {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-    });
+    (async () => {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await loadModels(controller.signal);
+          return;
+        } catch (e) {
+          if (controller.signal.aborted) return;
+          if (e instanceof DOMException && e.name === "AbortError") return;
+          if (attempt >= MODELS_RETRY_DELAYS_MS.length) return;
+          await delay(MODELS_RETRY_DELAYS_MS[attempt]);
+          if (controller.signal.aborted) return;
+        }
+      }
+    })();
     return () => controller.abort();
   }, [loadModels, modelsRefreshKey]);
 

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -168,9 +168,7 @@ const AGENT_STATE_RECONCILE_MS = 15_000;
 const BASH_STATE_RECONCILE_MS = 1_000;
 const EVENT_STREAM_READY_TIMEOUT_MS = 60_000;
 const EVENT_STREAM_RECONNECT_DELAY_MS = 1_000;
-// Backoff schedule for /api/models load failures. The first dev-server hit can
-// take many seconds (route compile) and a restarted server can transiently 403
-// until the cwd allow-list catches up, so retry before giving up visibly.
+// Retry temporary model-list failures without requiring a page refresh.
 const MODELS_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 const MAX_NOTICES = 5;
 const NOTICE_VISIBLE_MS = 5000;
@@ -1549,24 +1547,30 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const loadModels = useCallback(async (signal?: AbortSignal) => {
     const modelCwd = newSessionCwd ?? session?.cwd ?? "";
     const modelsUrl = modelCwd ? `/api/models?cwd=${encodeURIComponent(modelCwd)}` : "/api/models";
-    const res = await fetch(modelsUrl, signal ? { signal } : undefined);
-    if (!res.ok) {
-      // 400/403 bodies carry a plain { error } message; surface it so the UI
-      // degrades to an error state instead of silently hiding the selector.
-      let detail = "";
-      try {
-        const body: unknown = await res.json();
-        if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
-          detail = body.error;
+    let d: ModelsResponse;
+    try {
+      const res = await fetch(modelsUrl, signal ? { signal } : undefined);
+      if (!res.ok) {
+        let detail = "";
+        try {
+          const body: unknown = await res.json();
+          if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
+            detail = body.error;
+          }
+        } catch (e) {
+          if (e instanceof DOMException && e.name === "AbortError") throw e;
+          // Non-JSON error responses fall back to the HTTP status.
         }
-      } catch {
-        // non-JSON error body — fall through to the status message
+        throw new Error(detail || `Failed to load models (HTTP ${res.status})`);
       }
-      const message = detail || `Failed to load models (HTTP ${res.status})`;
-      setModelError(message);
-      throw new Error(message);
+      d = await res.json() as ModelsResponse;
+      signal?.throwIfAborted();
+    } catch (e) {
+      if (!signal?.aborted && !(e instanceof DOMException && e.name === "AbortError")) {
+        setModelError(e instanceof Error ? e.message : String(e));
+      }
+      throw e;
     }
-    const d = await res.json() as ModelsResponse;
     setModelNames(d.models);
     setModelError(d.modelError ?? null);
     setModelScopeWarnings(d.modelScopeWarnings ?? []);
@@ -1958,9 +1962,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [messages.length, agentRunning, scrollToBottom, scrollUserMsgToTop]);
 
-  // Load model list. Failures are transient on purpose (dev cold route
-  // compile, server restart races the cwd allow-list), so retry with backoff
-  // before leaving the selector in its error state.
+  // Load the model list with bounded retries; loadModels exposes each failure.
   useEffect(() => {
     const controller = new AbortController();
     (async () => {


### PR DESCRIPTION
### 摘要

当 `/api/models` 请求失败时，模型选择器现在会保留在界面中，并显示具体错误信息。对于开发服务器冷启动、服务重启或 cwd allow-list 尚未同步等瞬时故障，前端会按退避策略自动重试，避免模型选择器静默隐藏。

### 变更内容

- 为模型列表请求增加重试退避间隔：2 秒、5 秒、10 秒。
- 解析非成功响应中的 JSON `error` 字段，并将具体错误展示给用户。
- 对非 JSON 错误响应回退到包含 HTTP 状态码的错误信息。
- 请求被取消时立即停止重试，避免组件卸载后继续更新状态。
- 模型加载成功后保持原有模型列表和模型错误状态更新逻辑。

### 影响范围

- 文件：`hooks/useAgentSession.ts`
- 用户可见行为：模型列表加载失败时，模型选择器不再被静默隐藏；临时失败会自动恢复。

### 验证

  - `npm 测试 — 844 tests 通过`。
  - `tsc --noEmit`。
  - `npm run lint`。
  - `git diff --check`。

## English

### Title

Fix the model selector being hidden when model loading fails

### Summary

When `/api/models` fails, the model selector now remains visible and displays a useful error message. For transient failures caused by a dev-server cold start, server restart, or a cwd allow-list race, the client retries with backoff instead of leaving the selector hidden prematurely.

### Changes

- Added model-list retry backoff delays of 2 seconds, 5 seconds, and 10 seconds.
- Extracted the `error` field from non-success JSON responses and surfaced it to the UI.
- Falls back to an HTTP-status-based message for non-JSON error responses.
- Stops retries immediately when the request is aborted, preventing updates after component unmount.
- Preserved the existing model-list and model-error state updates after successful loading.

### Scope

- File: `hooks/useAgentSession.ts`
- User-visible behavior: the model selector is no longer silently hidden when model loading fails; transient failures can recover automatically.

### Verification

  - `npm test — 844 tests passed`。
  - `tsc --noEmit`。
  - `npm run lint`。
  - `git diff --check`。