### PR TITLE
feat: support sidebar=collapsed query param for embedded launches

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -136,7 +136,7 @@ export function AppShell() {
   const [projectTrustDialogOpen, setProjectTrustDialogOpen] = useState(false);
   const [projectTrustBusy, setProjectTrustBusy] = useState(false);
   const [projectTrustError, setProjectTrustError] = useState<string | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(() => !initialNavigation.sidebarCollapsed);
   const [rightPanelOpen, setRightPanelOpen] = useState(false);
   const [mobileToolbarMoreOpen, setMobileToolbarMoreOpen] = useState(false);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);

--- a/lib/initial-navigation.test.mjs
+++ b/lib/initial-navigation.test.mjs
@@ -7,14 +7,17 @@ async function loadSubject() {
 
 test("uses cwd instead of session when both parameters are present", async () => {
   const { getInitialNavigation } = await loadSubject();
-  const result = getInitialNavigation(new URLSearchParams({
-    cwd: " /work/project ",
-    session: "saved-session",
-  }));
+  const result = getInitialNavigation(
+    new URLSearchParams({
+      cwd: " /work/project ",
+      session: "saved-session",
+    }),
+  );
 
   assert.deepEqual(result, {
     requestedCwd: "/work/project",
     sessionId: null,
+    sidebarCollapsed: false,
   });
 });
 
@@ -23,7 +26,7 @@ test("restores session when cwd is absent", async () => {
 
   assert.deepEqual(
     getInitialNavigation(new URLSearchParams({ session: "saved-session" })),
-    { requestedCwd: null, sessionId: "saved-session" },
+    { requestedCwd: null, sessionId: "saved-session", sidebarCollapsed: false },
   );
 });
 
@@ -31,8 +34,10 @@ test("treats an empty cwd as absent", async () => {
   const { getInitialNavigation } = await loadSubject();
 
   assert.deepEqual(
-    getInitialNavigation(new URLSearchParams({ cwd: "  ", session: "saved-session" })),
-    { requestedCwd: null, sessionId: "saved-session" },
+    getInitialNavigation(
+      new URLSearchParams({ cwd: "  ", session: "saved-session" }),
+    ),
+    { requestedCwd: null, sessionId: "saved-session", sidebarCollapsed: false },
   );
 });
 
@@ -41,6 +46,89 @@ test("preserves a URL-encoded Windows path", async () => {
 
   assert.deepEqual(
     getInitialNavigation(new URLSearchParams("cwd=C%3A%5CProjects%5Cpi-web")),
-    { requestedCwd: "C:\\Projects\\pi-web", sessionId: null },
+    {
+      requestedCwd: "C:\\Projects\\pi-web",
+      sessionId: null,
+      sidebarCollapsed: false,
+    },
+  );
+});
+
+test("keeps the sidebar open when no sidebar parameter is present", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(getInitialNavigation(new URLSearchParams()), {
+    requestedCwd: null,
+    sessionId: null,
+    sidebarCollapsed: false,
+  });
+});
+
+test("collapses the sidebar for sidebar=collapsed", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(
+    getInitialNavigation(new URLSearchParams({ sidebar: "collapsed" })),
+    {
+      requestedCwd: null,
+      sessionId: null,
+      sidebarCollapsed: true,
+    },
+  );
+});
+
+test("collapses the sidebar when combined with a cwd parameter", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(
+    getInitialNavigation(
+      new URLSearchParams({ cwd: "/work/project", sidebar: "collapsed" }),
+    ),
+    {
+      requestedCwd: "/work/project",
+      sessionId: null,
+      sidebarCollapsed: true,
+    },
+  );
+});
+
+test("collapses the sidebar when combined with a session parameter", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(
+    getInitialNavigation(
+      new URLSearchParams({ session: "saved-session", sidebar: "collapsed" }),
+    ),
+    {
+      requestedCwd: null,
+      sessionId: "saved-session",
+      sidebarCollapsed: true,
+    },
+  );
+});
+
+test("ignores any other sidebar value", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(
+    getInitialNavigation(new URLSearchParams({ sidebar: "expanded" })),
+    {
+      requestedCwd: null,
+      sessionId: null,
+      sidebarCollapsed: false,
+    },
+  );
+});
+
+test("parses a URL-encoded sidebar parameter", async () => {
+  const { getInitialNavigation } = await loadSubject();
+
+  assert.deepEqual(
+    getInitialNavigation(new URLSearchParams("sidebar=collapsed%20")),
+    {
+      requestedCwd: null,
+      sessionId: null,
+      sidebarCollapsed: false,
+    },
   );
 });

--- a/lib/initial-navigation.ts
+++ b/lib/initial-navigation.ts
@@ -1,13 +1,17 @@
 export interface InitialNavigation {
   requestedCwd: string | null;
   sessionId: string | null;
+  sidebarCollapsed: boolean;
 }
 
-export function getInitialNavigation(searchParams: Pick<URLSearchParams, "get">): InitialNavigation {
+export function getInitialNavigation(
+  searchParams: Pick<URLSearchParams, "get">,
+): InitialNavigation {
   const requestedCwd = searchParams.get("cwd")?.trim() || null;
 
   return {
     requestedCwd,
     sessionId: requestedCwd ? null : searchParams.get("session"),
+    sidebarCollapsed: searchParams.get("sidebar") === "collapsed",
   };
 }


### PR DESCRIPTION
## What

Adds an opt-in `sidebar=collapsed` query parameter that opens the app with
the session sidebar collapsed on desktop. All other values are ignored and
keep the current default (sidebar open).

- `lib/initial-navigation.ts`: parses the param alongside the existing
  `cwd` / `session` params
- `components/AppShell.tsx`: initial `sidebarOpen` state respects the flag
  on first render only; no persistence, no settings entry

## Why

Embedders (e.g. launching pi-web in an iframe from Spinup Dev Portal)
want the chat to be the primary surface on open. Today the sidebar always
starts expanded on desktop and there is no supported way to change that
from the launching URL.

## Behavior

| URL | Sidebar on load (desktop) |
|---|---|
| `/` or `/?session=x` or `/?cwd=x` | open (unchanged) |
| `/?sidebar=collapsed` | collapsed |
| `/?cwd=x&sidebar=collapsed` | collapsed |
| `/?session=x&sidebar=collapsed` | collapsed |
| `/?sidebar=anything-else` | open (param ignored) |

Mobile behavior is unchanged: the sidebar still auto-collapses once the
breakpoint resolves. The top-bar toggle works exactly as before in both
states.

For embedders: `sidebar=collapsed` contains only URL-safe characters, so
it survives both plain string concatenation and `URLSearchParams`-based
URL building. The app reads it with `searchParams.get()`, which decodes
one round of standard percent-encoding; only double-encoding the param
into another param's value would break detection.

## Testing

- `node --test` unit tests for `getInitialNavigation` covering all cases
  above plus a URL-encoded value; the four pre-existing assertions gained
  `sidebarCollapsed: false` (strict `deepEqual`)
- `tsc --noEmit` clean
- `npm run lint`: 15 errors, all pre-existing on main, none in changed
  files
- `next build` intentionally not run locally per project convention
  (pollutes `.next/` during dev); typecheck covers the change surface
- Manually verified on a desktop viewport (1400x900): `/?sidebar=collapsed`
  loads with the sidebar closed and the top-bar toggle re-expands it;
  loading without the param or with `sidebar=bogus` is unchanged