### PR TITLE
fix(mobile): stop streaming scroll follow from shifting the document layer

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -289,7 +289,7 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
     isAutoModelSelection,
     agentPhase,
     isNew,
-    sessionIdRef, messagesEndRef, scrollContainerRef,
+    sessionIdRef, scrollContainerRef,
     lastUserMsgRef, promptAnchorActive,
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handlePromptWithStreamingBehavior, handleAbortCompaction,
@@ -945,8 +945,6 @@ export function ChatWindow({ session, sessionRunning, newSessionCwd, newSessionD
             )}
 
             <div ref={promptAnchorSpacerRef} aria-hidden="true" />
-
-            <div ref={messagesEndRef} />
             </div>
           </div>
         </div>

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -421,7 +421,9 @@ test("keeps live following cancellable when the user scrolls away from the tail"
   assert.match(source, /const wasAttached = isNearBottomRef\.current;[\s\S]*?const isAttached = getLiveFollowAttached\([\s\S]*?wasAttached,[\s\S]*?previousScrollTopRef\.current,[\s\S]*?scrollTop,[\s\S]*?clientHeight,[\s\S]*?scrollHeight/);
   assert.match(scrollHandlerSource, /const isAgentRunning = agentRunningRef\.current;[\s\S]*?isAgentRunning\s*\? CHAT_SCROLL_REATTACH_TOLERANCE\s*:\s*CHAT_SCROLL_TAIL_TOLERANCE/);
   assert.match(source, /previousScrollTopRef\.current = scrollTop/);
-  assert.match(scrollToBottomSource, /messagesEndRef\.current\?\.scrollIntoView\(\{ behavior \}\);\s*if \(container\) previousScrollTopRef\.current = container\.scrollTop/);
+  assert.match(scrollToBottomSource, /const container = scrollContainerRef\.current;\s*if \(!container\) return;/);
+  assert.match(scrollToBottomSource, /container\.scrollTo\(\{ top: container\.scrollHeight, behavior \}\);\s*previousScrollTopRef\.current = container\.scrollTop;/);
+  assert.doesNotMatch(scrollToBottomSource, /scrollIntoView/);
   assert.match(streamUpdateSource, /liveFollowFrameRef\.current === null/);
   assert.match(streamUpdateSource, /requestAnimationFrame\(\(\) => \{[\s\S]*?liveFollowFrameRef\.current = null;[\s\S]*?if \(isNearBottomRef\.current\) scrollToBottom\("auto"\)/);
   assert.match(scrollHandlerSource, /!wasAttached && isAttached && isAgentRunning[\s\S]*?scrollToBottom\("auto"\)/);
@@ -495,7 +497,7 @@ test("keeps prompt anchor measurement outside the React update cycle", () => {
 });
 
 test("uses the prompt anchor as the only trailing message spacer", () => {
-  assert.match(chatWindowSource, /<div ref=\{promptAnchorSpacerRef\} aria-hidden="true" \/>[\s\S]*?<div ref=\{messagesEndRef\} \/>/);
+  assert.match(chatWindowSource, /<div ref=\{promptAnchorSpacerRef\} aria-hidden="true" \/>[\s\S]*?<\/div>/);
   assert.doesNotMatch(chatWindowSource, /bottomComposer(?:Ref|Height|ScrollFrameRef)/);
   assert.doesNotMatch(chatWindowSource, /new ResizeObserver\(updateBottomComposerHeight\)/);
 });

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -341,7 +341,6 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const previousScrollTopRef = useRef(0);
   const liveFollowFrameRef = useRef<number | null>(null);
   const executeBashRef = useRef<(command: string, excludeFromContext: boolean) => Promise<void> | undefined>(undefined);
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const ensuringNewSessionRef = useRef<Promise<string | null> | null>(null);
   const newSessionPromotedRef = useRef(false);
@@ -387,8 +386,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     const container = scrollContainerRef.current;
-    messagesEndRef.current?.scrollIntoView({ behavior });
-    if (container) previousScrollTopRef.current = container.scrollTop;
+    if (!container) return;
+    // Scroll the chat container itself instead of scrolling a sentinel element
+    // into view: that propagates to every scrollable ancestor, and on mobile
+    // the keyboard-shifted document layer visibly jumps the whole app while
+    // streaming content follows the tail.
+    container.scrollTo({ top: container.scrollHeight, behavior });
+    previousScrollTopRef.current = container.scrollTop;
   }, []);
 
   const currentModel = currentModelOverride ?? data?.context.model ?? pendingModel ?? null;
@@ -2015,7 +2019,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     isNew,
     promptAnchorActive,
     // Refs
-    sessionIdRef, messagesEndRef, scrollContainerRef,
+    sessionIdRef, scrollContainerRef,
     lastUserMsgRef, pendingScrollToUserRef, initialScrollDoneRef,
     // Actions
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,


### PR DESCRIPTION
Fixes #714

## Summary

On mobile, invoking the keyboard while the agent is streaming made the whole app visibly flash/jump (roughly on every streamed chunk). The live-follow scroll used `scrollIntoView()` on the `messagesEndRef` sentinel, which propagates to every scrollable ancestor — including the keyboard-shifted document layer that mobile browsers (WebKit in particular) keep moving while the keyboard is up. This change scrolls the chat container directly, so programmatic follow-scrolls can never touch the document layer.

## What changed

- `hooks/useAgentSession.ts`: `scrollToBottom` now calls `container.scrollTo({ top: container.scrollHeight, behavior })` on the chat container itself instead of `scrollIntoView()` on the sentinel; also returns early when the container is missing. Live-follow attach/detach logic, the prompt anchor, and scroll-position restoration are unchanged.
- `components/ChatWindow.tsx`: removed the now-unused `messagesEndRef` sentinel `<div>` and its destructured ref.
- `hooks/useAgentSession.test.mjs`: updated the three structural assertions that matched the old implementation (container-scroll assertions + a `doesNotMatch` guard against re-introducing `scrollIntoView` here).

## Testing

- `node --experimental-strip-types --test hooks/useAgentSession.test.mjs lib/chat-lazy-load.test.mjs`: 37/37 pass
- Direct consumer suites (`ChatWindow.notices`, `ChatWindow.process-details`, `MobilePwaLayout`, `model-scope-startup`, `model-switching`): 15/15 pass
- Full suite: 843/844 — the single failure (`lib/worktree.test.mjs` "main and linked worktrees share one canonical project root") also fails on unmodified `main` in this environment and is unrelated to this change
- `tsc --noEmit`: clean; `npm run lint`: clean
- Real device (iOS Safari + installed PWA): with this patch, invoking the keyboard during streaming no longer flashes/jumps the app; streaming follow, prompt anchor, and manual scroll-away behavior all still work as before
