### PR TITLE
ci: add checks and isolated session history E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - run: npm run test:e2e
+        env:
+          E2E_SERVER_MODE: start
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-failure
+          path: test-results/e2e/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+/test-results/
 
 # next.js
 /.next/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,37 @@
+# CI and browser regression tests
+
+Adapted from @Nuctori's CI/E2E proposal in #617 and #599. The performance
+scanner, reverse reader, sidebar changes, and timing benchmarks are not included.
+
+```sh
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+The script starts and stops its own Turbopack dev server on an available
+loopback port. Run it in a checkout without an active dev server; Next.js
+shares `.next/dev/lock` within a checkout. All fixtures are created before
+startup in a temporary `PI_CODING_AGENT_DIR` and removed on completion.
+No model credentials or existing Pi sessions are needed.
+
+CI runs lint, type checking, and unit tests in one job. A separate job builds
+the application in a clean checkout and runs the same browser tests with
+`E2E_SERVER_MODE=start` against `next start`. Do not build in a checkout used
+for development.
+
+Coverage:
+
+- A 5,000-message session opens with exactly the last 50 entries, bounded
+  detail/context responses, and no browser errors.
+- Desktop and mobile scrolling load two consecutive older pages. Each response
+  has the expected IDs, no gaps or duplicates, and the messages appear once in
+  the chat. A small session checks pagination through the root.
+- Branch context follows the selected leaf and excludes the other branch.
+- Markdown, code blocks, and real tool-call/tool-result blocks render.
+- Unknown sessions and paths outside the fixture project are rejected.
+
+Sending prompts, live streaming, and agent execution are outside this suite.
+Failures save a screenshot, Playwright trace, and server log under
+`test-results/e2e/`; CI uploads that directory. Open a trace with
+`npx playwright show-trace test-results/e2e/trace.zip`.

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -1,0 +1,218 @@
+// Adapted from @Nuctori's script-style CI/E2E fixtures in PR #617 (issue #599).
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createWriteStream, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const mode = process.env.E2E_SERVER_MODE || "dev";
+assert.ok(mode === "dev" || mode === "start", "E2E_SERVER_MODE must be dev or start");
+assert.ok(mode !== "dev" || !existsSync(join(root, ".next/dev/lock")), "Use a checkout without an active dev server");
+const artifacts = join(root, "test-results/e2e");
+mkdirSync(artifacts, { recursive: true });
+const agentDir = mkdtempSync(join(tmpdir(), "pi-web-e2e-"));
+const project = join(agentDir, "project");
+const sessionDir = join(agentDir, "sessions", "e2e");
+mkdirSync(project);
+mkdirSync(sessionDir, { recursive: true });
+const timestamp = "2026-08-23T00:00:00.000Z";
+const LONG = "e2e-long-session";
+const BRANCH = "e2e-branch-session";
+const RICH = "e2e-rich-session";
+const text = (i) => `E2E message ${String(i).padStart(4, "0")}`;
+const ids = (start, end) => Array.from({ length: end - start }, (_, i) => `e${start + i}`);
+
+function message(id, parentId, role, content) {
+  return { type: "message", id, parentId, timestamp, message: { role, content } };
+}
+
+function writeSession(id, entries) {
+  const header = { type: "session", version: 3, id, timestamp, cwd: project };
+  writeFileSync(join(sessionDir, `2026-08-23T00-00-00-000Z_${id}.jsonl`),
+    [header, ...entries].map((entry) => JSON.stringify(entry)).join("\n") + "\n");
+}
+
+let server;
+let serverExited;
+let browser;
+let page;
+let context;
+let serverError;
+const serverLog = createWriteStream(join(artifacts, "server.log"));
+const interrupt = () => {
+  process.exitCode = 1;
+  server?.kill("SIGTERM");
+  void browser?.close().catch(() => {});
+};
+process.once("SIGINT", interrupt);
+process.once("SIGTERM", interrupt);
+
+try {
+  // Seed before startup so the first catalogue scan sees every fixture.
+  writeSession(LONG, Array.from({ length: 5000 }, (_, i) =>
+    message(`e${i}`, i ? `e${i - 1}` : null, i % 2 ? "assistant" : "user", text(i))));
+  writeSession(BRANCH, [
+    message("root", null, "user", "Branch root"),
+    message("old", "root", "assistant", "Inactive branch answer"),
+    message("new", "root", "assistant", "Active branch answer"),
+  ]);
+  const toolResult = message("result", "call", "toolResult", [{ type: "text", text: "E2E tool output" }]);
+  Object.assign(toolResult.message, { toolCallId: "t1", toolName: "bash", isError: false });
+  writeSession(RICH, [
+    message("user", null, "user", "Render **E2E markdown**"),
+    message("call", "user", "assistant", [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo E2E tool output" } }]),
+    toolResult,
+    message("answer", "result", "assistant", [{ type: "text", text: "E2E final answer\n```js\nconsole.log('E2E code');\n```" }]),
+  ]);
+
+  const probe = createServer();
+  probe.listen(0, "127.0.0.1");
+  await once(probe, "listening");
+  const port = probe.address().port;
+  await new Promise((resolve, reject) => probe.close((error) => error ? reject(error) : resolve()));
+  const base = `http://127.0.0.1:${port}`;
+  server = spawn(process.execPath, [join(root, "node_modules/next/dist/bin/next"), mode, "-H", "127.0.0.1", "-p", String(port)], {
+    cwd: root,
+    env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_WEB_PASSWORD: "", NEXT_TELEMETRY_DISABLED: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  server.once("error", (error) => { serverError = error; });
+  serverExited = once(server, "exit");
+  server.stdout.pipe(serverLog, { end: false });
+  server.stderr.pipe(serverLog, { end: false });
+
+  async function api(path, status = 200) {
+    const response = await fetch(`${base}${path}`, { signal: AbortSignal.timeout(30_000) });
+    assert.equal(response.status, status, path);
+    return response.json();
+  }
+
+  const deadline = Date.now() + 120_000;
+  while (true) {
+    if (serverError) throw serverError;
+    assert.equal(server.exitCode, null, "Server exited before readiness; see server.log");
+    const response = await fetch(`${base}/api/sessions`, { signal: AbortSignal.timeout(5000) }).catch(() => null);
+    if (response?.ok) {
+      const { sessions } = await response.json();
+      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH].sort());
+      break;
+    }
+    assert.ok(Date.now() < deadline, "Server readiness timed out; see server.log");
+    await delay(250);
+  }
+
+  const detail = await api(`/api/sessions/${LONG}?deferThinking=1&deferMedia=1`);
+  assert.deepEqual(detail.context.entryIds, ids(4950, 5000));
+  assert.equal(detail.context.messages.length, 50);
+  assert.equal(detail.context.hasMore, true);
+  assert.ok(JSON.stringify(detail).length < 100_000, "Detail transferred unbounded history");
+  const tail = await api(`/api/sessions/${LONG}/context?tail=50`);
+  assert.deepEqual(tail.context.entryIds, ids(4950, 5000));
+  assert.equal(tail.context.messages.length, 50);
+  const selectedBranch = await api(`/api/sessions/${BRANCH}/context?leafId=old`);
+  assert.deepEqual(selectedBranch.context.entryIds, ["root", "old"]);
+  const rootPage = await api(`/api/sessions/${BRANCH}/context?before=old&tail=1`);
+  assert.deepEqual(rootPage.context.entryIds, ["root"]);
+  assert.equal(rootPage.context.hasMore, false);
+  const beforeRoot = await api(`/api/sessions/${BRANCH}/context?before=root`);
+  assert.deepEqual(beforeRoot.context.entryIds, []);
+  assert.equal(beforeRoot.context.hasMore, false);
+  await api("/api/sessions/e2e-does-not-exist", 404);
+  await api("/api/files/..%2F..%2Fetc%2Fpasswd?type=read", 403);
+  console.log("PASS: bounded history, branch context, pagination root, and API errors");
+
+  browser = await chromium.launch();
+  for (const viewport of [{ width: 1280, height: 800 }, { width: 390, height: 844 }]) {
+    context = await browser.newContext({ viewport, locale: "en-US" });
+    await context.tracing.start({ screenshots: true, snapshots: true });
+    page = await context.newPage();
+    page.setDefaultTimeout(30_000);
+    const errors = [];
+    const olderResponses = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (event) => { if (event.type() === "error") errors.push(event.text()); });
+    page.on("response", (response) => {
+      if (response.url().startsWith(base) && response.status() >= 500) errors.push(`${response.status()} ${response.url()}`);
+      const url = new URL(response.url());
+      if (url.pathname === `/api/sessions/${LONG}/context` && url.searchParams.has("before")) olderResponses.push(response);
+    });
+    const stateReady = page.waitForResponse((response) => new URL(response.url()).pathname === `/api/sessions/${LONG}/state`);
+    await page.goto(`${base}/?session=${LONG}`, { waitUntil: "domcontentloaded" });
+    assert.equal((await stateReady).status(), 200);
+    await page.getByText(text(4999), { exact: true }).waitFor();
+    const sentinel = page.getByText("Scroll up to load earlier messages", { exact: true });
+    await sentinel.waitFor({ state: "attached" });
+    assert.equal(await page.getByText(text(4949), { exact: true }).count(), 0);
+
+    // Exercise the real IntersectionObserver and prepend path, twice.
+    for (let turn = 0; turn < 2; turn++) {
+      const responsePromise = page.waitForResponse((response) =>
+        new URL(response.url()).pathname === `/api/sessions/${LONG}/context`);
+      await sentinel.evaluate((element) => element.scrollIntoView({ block: "start", behavior: "instant" }));
+      const response = await responsePromise;
+      const older = (await response.json()).context;
+      const firstMessage = older.messages[0]?.content;
+      assert.equal(typeof firstMessage, "string", "Older page must contain user messages");
+      await page.getByText(firstMessage, { exact: true }).waitFor({ state: "attached" });
+      await page.getByText(text(4999), { exact: true }).evaluate((element) => element.scrollIntoView({ block: "end", behavior: "instant" }));
+    }
+    assert.ok(olderResponses.length >= 2, "Scrolling must fetch consecutive older pages");
+    let oldest = 4950;
+    for (const response of olderResponses) {
+      assert.equal(response.status(), 200);
+      assert.equal(new URL(response.url()).searchParams.get("before"), `e${oldest}`);
+      const older = (await response.json()).context;
+      assert.deepEqual(older.entryIds, ids(oldest - 50, oldest));
+      assert.equal(older.messages.length, 50);
+      oldest -= 50;
+      assert.equal(older.oldestEntryId, `e${oldest}`);
+      assert.equal(older.hasMore, true);
+    }
+    const rendered = await page.getByText(/^E2E message \d{4}$/).allTextContents();
+    // The sidebar also displays the first message as the session title.
+    assert.deepEqual(rendered.filter((value) => value !== text(0)),
+      Array.from({ length: 5000 - oldest }, (_, i) => text(oldest + i)), "Missing, reordered, or duplicate chat messages");
+    await page.screenshot({ path: join(artifacts, `history-${viewport.width}.png`) });
+
+    await page.goto(`${base}/?session=${BRANCH}`, { waitUntil: "domcontentloaded" });
+    await page.getByText("Active branch answer", { exact: true }).waitFor();
+    assert.equal(await page.getByText("Inactive branch answer", { exact: true }).count(), 0);
+    await page.goto(`${base}/?session=${RICH}`, { waitUntil: "domcontentloaded" });
+    await page.locator("strong").filter({ hasText: "E2E markdown" }).waitFor();
+    await page.locator("pre").filter({ hasText: "console.log('E2E code');" }).waitFor();
+    await page.getByText("E2E final answer", { exact: true }).waitFor();
+    await page.getByRole("button", { name: /process/i }).click();
+    await page.getByText("echo E2E tool output", { exact: true }).waitFor();
+    await page.getByRole("button", { name: /bash.*echo E2E tool output/ }).click();
+    await page.getByText("E2E tool output", { exact: true }).waitFor();
+    assert.deepEqual(errors, [], `Browser errors at width ${viewport.width}`);
+    console.log(`PASS: ${viewport.width}px browser pagination, branch, markdown, code, and tool call`);
+    await context.tracing.stop();
+    await context.close();
+    context = undefined;
+    page = undefined;
+  }
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+  if (page) await page.screenshot({ path: join(artifacts, "failure.png") }).catch(() => {});
+  if (context) await context.tracing.stop({ path: join(artifacts, "trace.zip") }).catch(() => {});
+} finally {
+  await browser?.close().catch(() => {});
+  if (server && server.exitCode === null && server.signalCode === null) {
+    server.kill("SIGTERM");
+    const forceKill = setTimeout(() => server.kill("SIGKILL"), 10_000);
+    await serverExited;
+    clearTimeout(forceKill);
+  }
+  serverLog.end();
+  rmSync(agentDir, { recursive: true, force: true });
+  process.off("SIGINT", interrupt);
+  process.off("SIGTERM", interrupt);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "katex": "^0.16.47",
         "mammoth": "^1.12.0",
         "mermaid": "^11.16.1",
+        "playwright": "^1.62.1",
         "postcss": "^8.5.26",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
@@ -11522,6 +11523,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/points-on-curve": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start": "next start -H 127.0.0.1 -p 30141",
     "start:lan": "next start -H 0.0.0.0 -p 30141",
     "lint": "eslint .",
+    "test:e2e": "node e2e/run.mjs",
     "test": "node --experimental-strip-types --test \"app/**/*.test.mjs\" \"components/**/*.test.mjs\" \"hooks/**/*.test.mjs\" \"lib/**/*.test.mjs\" \"public/**/*.test.mjs\"",
     "release": "npm version patch --no-git-tag-version && npm run build && npm publish --access public"
   },
@@ -69,6 +70,7 @@
     "katex": "^0.16.47",
     "mammoth": "^1.12.0",
     "mermaid": "^11.16.1",
+    "playwright": "^1.62.1",
     "postcss": "^8.5.26",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",


### PR DESCRIPTION
Adds GitHub Actions checks for pull requests and pushes to main: lint, TypeScript, the existing unit tests, a production build, and Chromium browser tests. This gives the session-history regressions from #509 and #555 an automatic browser gate.

The E2E script starts its own Next.js server with a temporary `PI_CODING_AGENT_DIR`, seeds fixtures before the first catalogue scan, and cleans up its server and fixtures. It needs no model credentials. Desktop and mobile checks open a 5,000-message session, verify the bounded tail, scroll through consecutive older pages, and assert complete, ordered messages without duplicates. The suite also checks branch selection, pagination at the root, markdown/code/tool-result rendering, and rejected API requests. Failures retain a screenshot, trace, and server log as CI artifacts.

This is the CI/E2E portion of @Nuctori's proposal in #617 and #599. It leaves the runtime scanner, reverse reader, sidebar virtualization, and performance benchmarks out of this PR. Sending prompts and live agent execution remain outside this suite.

Validation:
- `npm run lint` and `tsc --noEmit` passed.
- All 860 unit tests passed on Node 22.19.0.
- `npm run test:e2e` passed against Turbopack at 1280x800 and 390x844, including tool-result expansion.
- GitHub Actions [run 33950246499](https://github.com/agegr/pi-web/actions/runs/33950246499) passed both jobs, including Linux unit tests, the production build, and desktop/mobile E2E against `next start`.

Related: #617, #599. Fixture and workflow approach adapted from @Nuctori's contribution.
