### PR TITLE
feat(ui): render extension dialog titles with highlighted code fences and a pinned head line

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -3,6 +3,7 @@ import { registerAbortHandler } from "@/hooks/useKeyboardShortcuts";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AgentMessage, AssistantContentBlock, AssistantMessage, BashExecutionMessage, BlockingExtensionUiRequest, ExtensionUiRequest, SessionInfo, SessionTreeNode, ToolResultMessage, UserMessage } from "@/lib/types";
 import { normalizeCustomPanelLines } from "@/lib/ansi";
+import { splitDialogTitle, splitDialogTitleCode } from "@/lib/dialog-title";
 import { asBracketedPaste, toTerminalKeyData } from "@/lib/terminal-input";
 import { countToolCallBlocks, getAssistantErrorMessage, getDisplayableAssistantBlocks, isMessageGroupAnchor, splitFinalAssistantBlocks } from "@/lib/message-display";
 import { extractTurnWrittenFiles, type WrittenFile } from "@/lib/turn-written-files";
@@ -1103,6 +1104,47 @@ function getExtensionDialogSummary(request: ExtensionDialogRequest): string | un
   return undefined;
 }
 
+/**
+ * Render the scrollable portion of a dialog title: ```sh / ```bash code fences are
+ * rendered as highlighted code blocks (red border + red tint to flag risky commands),
+ * and all other text keeps pre-wrap multi-line rendering.
+ */
+function renderDialogTitle(title: string): ReactNode {
+  const segments = splitDialogTitleCode(title);
+  if (segments.length === 1 && !segments[0].isCode) return title;
+  return segments.map((seg, i) => {
+    if (seg.isCode) {
+      return (
+        <pre
+          key={i}
+          style={{
+            margin: "6px 0",
+            padding: "8px 10px",
+            borderRadius: 6,
+            background: "rgba(239,68,68,0.10)",
+            border: "1px solid rgba(239,68,68,0.35)",
+            borderLeft: "3px solid #ef4444",
+            fontFamily: "var(--font-mono)",
+            fontSize: 12.5,
+            lineHeight: 1.5,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+            overflowX: "auto",
+            color: "var(--text)",
+          }}
+        >
+          {seg.text}
+        </pre>
+      );
+    }
+    return (
+      <span key={i} style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+        {seg.text}
+      </span>
+    );
+  });
+}
+
 function ExtensionDialog({
   request,
   onRespond,
@@ -1115,6 +1157,7 @@ function ExtensionDialog({
   const [collapsed, setCollapsed] = useState(false);
   const [now, setNow] = useState(() => Date.now());
   const summary = getExtensionDialogSummary(request);
+  const { head: titleHead, rest: titleRest } = splitDialogTitle(request.title);
   const remainingSeconds = request.expiresAt === undefined
     ? null
     : Math.max(0, Math.ceil((request.expiresAt - now) / 1000));
@@ -1216,7 +1259,7 @@ function ExtensionDialog({
       >
         <div style={{ flexShrink: 0, display: "flex", alignItems: "flex-start", gap: 8, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ color: "var(--text)", fontSize: 14, fontWeight: 650 }}>{request.title}</div>
+            <div style={{ color: "var(--text)", fontSize: 14, fontWeight: 650, lineHeight: 1.4, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{titleHead}</div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 3, color: "var(--text-dim)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
               <span>{t("chat.extensionRequest")}</span>
               {countdown}
@@ -1253,6 +1296,11 @@ function ExtensionDialog({
             flex: "1 1 auto", minHeight: 0, overflowY: "auto",
           }}
         >
+          {titleRest && (
+            <div style={{ marginBottom: 12, color: "var(--text-muted)", fontSize: 13, lineHeight: 1.55 }}>
+              {renderDialogTitle(titleRest)}
+            </div>
+          )}
           {request.method === "confirm" && (
             <div style={{ color: "var(--text-muted)", fontSize: 13, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{request.message}</div>
           )}

--- a/lib/dialog-title.test.mjs
+++ b/lib/dialog-title.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const {
+  splitDialogTitle,
+  splitDialogTitleCode,
+} = await jiti.import("./dialog-title.ts");
+const { renderToStaticMarkup } = await jiti.import("react-dom/server");
+const React = await jiti.import("react");
+
+test("splitDialogTitle keeps a one-line title entirely in the head", () => {
+  assert.deepEqual(splitDialogTitle("Approve command"), {
+    head: "Approve command",
+    rest: "",
+  });
+});
+
+test("splitDialogTitle splits on the first newline only", () => {
+  assert.deepEqual(splitDialogTitle("Run this\ncommand here\nmore"), {
+    head: "Run this",
+    rest: "command here\nmore",
+  });
+});
+
+test("splitDialogTitle keeps a blank title intact", () => {
+  assert.deepEqual(splitDialogTitle(""), { head: "", rest: "" });
+});
+
+test("splitDialogTitleCode leaves text with no code fence as a single text segment", () => {
+  assert.deepEqual(splitDialogTitleCode("Approve command"), [
+    { text: "Approve command", isCode: false },
+  ]);
+});
+
+test("splitDialogTitleCode highlights a ```bash code fence", () => {
+  const segments = splitDialogTitleCode("Confirm running:\n```bash\nrm -rf /\n```");
+  assert.equal(segments.length, 3);
+  assert.deepEqual(segments[0], { text: "Confirm running:\n", isCode: false });
+  assert.deepEqual(segments[1], { text: "rm -rf /", isCode: true });
+  assert.deepEqual(segments[2], { text: "", isCode: false });
+});
+
+test("splitDialogTitleCode highlights a plain ```sh code fence", () => {
+  const segments = splitDialogTitleCode("Run:\n```sh\ndocker system prune -a\n```");
+  assert.equal(segments[1].isCode, true);
+  assert.equal(segments[1].text, "docker system prune -a");
+});
+
+test("splitDialogTitleCode highlights multiple consecutive code fences", () => {
+  const segments = splitDialogTitleCode("A\n```sh\na\n```\nB\n```bash\nb\n```\nC");
+  assert.deepEqual(
+    segments.map((s) => s.isCode),
+    [false, true, false, true, false],
+  );
+});
+
+test("renderDialogTitle renders code segments inside <pre> and text as pre-wrap spans", () => {
+  // A small inline reimplementation of the ChatWindow renderDialogTitle mapping to
+  // assert the segment contract the component relies on.
+  const segments = splitDialogTitleCode("Run:\n```sh\nrm -rf /\n```");
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      React.Fragment,
+      null,
+      segments.map((seg, i) =>
+        seg.isCode
+          ? React.createElement("pre", { key: i }, seg.text)
+          : React.createElement("span", { key: i, style: { whiteSpace: "pre-wrap", wordBreak: "break-word" } }, seg.text),
+      ),
+    ),
+  );
+  assert.match(markup, /<pre>rm -rf \/<\/pre>/);
+  assert.match(markup, /<span[^>]*white-space:pre-wrap[^>]*>Run:\n<\/span>/);
+});

--- a/lib/dialog-title.ts
+++ b/lib/dialog-title.ts
@@ -1,0 +1,38 @@
+/**
+ * Dialog-title rendering helpers for the extension request dialog.
+ *
+ * A dialog title can be long and may embed a risky command inside a ```sh / ```bash
+ * code fence. We split the title into a one-line "head" (pinned in the dialog header)
+ * and the remaining "rest" (shown in the scrollable body), and render any code fences
+ * in the rest as highlighted code blocks.
+ */
+
+/** Split a dialog title at its first newline into a one-line head and the rest. */
+export function splitDialogTitle(title: string): { head: string; rest: string } {
+  const firstNewline = title.indexOf("\n");
+  return {
+    head: firstNewline === -1 ? title : title.slice(0, firstNewline),
+    rest: firstNewline === -1 ? "" : title.slice(firstNewline + 1),
+  };
+}
+
+export type DialogTitleSegment = { text: string; isCode: boolean };
+
+/**
+ * Split dialog-title text into alternating text / code segments. A ```sh or ```bash
+ * code fence (with an optional trailing newline) toggles into a code segment; all
+ * other content is plain text. The first segment is always text, and code segments
+ * are the ones that get highlighted.
+ */
+export function splitDialogTitleCode(title: string): DialogTitleSegment[] {
+  const parts = title.split(/```(?:sh|bash)?\s*\n?/);
+  if (parts.length === 1) {
+    return [{ text: parts[0], isCode: false }];
+  }
+  return parts.map((text, i) => {
+    // Drop the single newline that precedes the closing fence so the highlighted
+    // code block does not end with a stray blank line.
+    const value = i % 2 === 1 ? text.replace(/\n$/, "") : text;
+    return { text: value, isCode: i % 2 === 1 };
+  });
+}


### PR DESCRIPTION
## Summary

Splits out the dialog-title rendering improvement from the closed #667, per the upstream request ("The dialog-title rendering improvement is independently useful and can be proposed in a separate PR with focused tests").

When an extension raises a blocking dialog, the `title` can be long and can embed a risky command inside a ```sh / ```bash code fence. Today the whole title is rendered as a single truncated line in the header.

This PR:
1. **Pins the head line**: the title is split at its first newline — the one-line head stays in the dialog header (pre-wrap / break-word), the rest moves into the already-scrollable body, so buttons stay visible for long titles.
2. **Highlights code fences**: ```sh / ```bash segments in the body render as red-bordered highlighted code blocks (red tint + left border), flagging risky commands at a glance; other text keeps pre-wrap multi-line rendering.

Pure split logic is extracted to `lib/dialog-title.ts` so it is testable in isolation.

## Changes

- `lib/dialog-title.ts` — new: `splitDialogTitle` (head/rest) and `splitDialogTitleCode` (text/code segment splitting with focused unit tests in `lib/dialog-title.test.mjs`)
- `components/ChatWindow.tsx` — `renderDialogTitle` + head/rest wiring in `ExtensionDialog`

## Tests

- 8 new unit tests for the split/serialization logic
- Full suite: 914/914 passing