### PR TITLE
perf(sessions): gzip large JSON responses

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -19,6 +19,7 @@ import { computeSessionStats } from "@/lib/session-stats";
 import type { SessionEntry } from "@/lib/types";
 import { readSubagentRun, readSubagentSessionResources, SUBAGENT_META_TYPE } from "@/lib/subagents";
 import { readSessionToolSelection } from "@/lib/session-tool-selection";
+import { jsonResponse } from "@/lib/json-response";
 
 export async function GET(
   req: Request,
@@ -92,17 +93,20 @@ export async function GET(
       transient: !filePath || !existsSync(filePath),
     }]))[0] : null;
 
-    return NextResponse.json({
-      sessionId: id,
-      filePath,
-      info,
-      leafId,
-      tree,
-      context,
-      stats,
-      totalActiveMs,
-      ...(toolNames !== undefined ? { toolNames } : {}),
-    });
+    return jsonResponse(
+      req,
+      {
+        sessionId: id,
+        filePath,
+        info,
+        leafId,
+        tree,
+        context,
+        stats,
+        totalActiveMs,
+        ...(toolNames !== undefined ? { toolNames } : {}),
+      },
+    );
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
   }

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { jsonResponse } from "@/lib/json-response";
 import {
   attachSessionProjectInfo,
   getSessionListVersion,
@@ -24,7 +25,8 @@ export async function GET(req: Request) {
       attachSessionProjectInfo(getRpcSessionInfos()),
     ]);
     const sessions = mergeSessionLists(persistedSessions, runtimeSessions);
-    return NextResponse.json(
+    return jsonResponse(
+      req,
       {
         sessions,
         sessionListVersion,

--- a/app/api/sessions/runtime-route.test.mjs
+++ b/app/api/sessions/runtime-route.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 import test from "node:test";
 import { createJiti } from "jiti";
 
@@ -73,6 +74,35 @@ test("list versions expose idle session creation, rename and deletion to other w
   assert.ok(deleted.sessionListVersion > updated.sessionListVersion);
   assert.deepEqual(deleted.sessions, []);
   assert.equal((await (await getRunningSessions()).json()).sessionListVersion, deleted.sessionListVersion);
+});
+
+test("session listing returns a gzip-compressed response when the client accepts it", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-web-list-gzip-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = dir;
+  invalidateSessionListCache();
+  t.after(async () => {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    invalidateSessionListCache();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const firstMessage = "compressible session content ".repeat(500);
+  const manager = SessionManager.create(dir);
+  manager.appendMessage({ role: "user", content: firstMessage, timestamp: Date.now() });
+  manager.appendMessage({ role: "assistant", content: [{ type: "text", text: "done" }], timestamp: Date.now() });
+  invalidateSessionListCache();
+
+  const response = await getSessionList(new Request("http://localhost/api/sessions", {
+    headers: { "Accept-Encoding": "gzip" },
+  }));
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Encoding"), "gzip");
+  assert.match(response.headers.get("Vary") ?? "", /(?:^|,\s*)Accept-Encoding(?:\s*,|$)/i);
+  const payload = JSON.parse(gunzipSync(Buffer.from(await response.arrayBuffer())).toString("utf8"));
+  assert.equal(payload.sessions[0].firstMessage, firstMessage);
 });
 
 test("session listing merges live registry snapshots and honors force refresh", () => {
@@ -212,4 +242,49 @@ test("live detail and state routes work without a persisted JSONL file", async (
     running: true,
     state: { isStreaming: true },
   });
+});
+
+test("session detail returns a gzip-compressed response when the client accepts it", async (t) => {
+  const previousRegistry = globalThis.__piSessions;
+  const id = "live-route-gzip-test";
+  const timestamp = "2026-09-05T00:00:00.000Z";
+  const firstMessage = "large session detail content ".repeat(500);
+  const entry = {
+    type: "message",
+    id: "u1",
+    parentId: null,
+    timestamp,
+    message: { role: "user", content: firstMessage },
+  };
+  const sessionManager = {
+    getHeader: () => ({ type: "session", id, cwd: "/tmp", timestamp }),
+    getEntries: () => [entry],
+    getLeafId: () => entry.id,
+    getTree: () => [],
+    getSessionName: () => undefined,
+    getSessionFile: () => `/tmp/pi-web-live-route-gzip-${process.pid}.jsonl`,
+  };
+  globalThis.__piSessions = new Map([[id, {
+    isAlive: () => true,
+    isRunning: () => false,
+    inner: { sessionManager },
+    sessionFile: sessionManager.getSessionFile(),
+    sessionId: id,
+    cwd: "/tmp",
+  }]]);
+  t.after(() => {
+    globalThis.__piSessions = previousRegistry;
+  });
+
+  const response = await getSessionDetail(
+    new Request(`http://localhost/api/sessions/${id}`, {
+      headers: { "Accept-Encoding": "gzip" },
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Encoding"), "gzip");
+  const payload = JSON.parse(gunzipSync(Buffer.from(await response.arrayBuffer())).toString("utf8"));
+  assert.equal(payload.info.firstMessage, firstMessage);
 });

--- a/lib/json-response.test.mjs
+++ b/lib/json-response.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  jsx: { runtime: "automatic" },
+  tsconfigPaths: true,
+});
+const { jsonResponse } = await jiti.import("./json-response.ts");
+
+test("does not gzip a large JSON response when the client disables gzip", async () => {
+  const response = jsonResponse(
+    new Request("http://localhost/test", { headers: { "Accept-Encoding": "gzip;q=0, br" } }),
+    { value: "large payload ".repeat(200) },
+  );
+
+  assert.equal(response.headers.get("Content-Encoding"), null);
+  assert.match(response.headers.get("Vary") ?? "", /(?:^|,\s*)Accept-Encoding(?:\s*,|$)/i);
+  assert.equal((await response.json()).value, "large payload ".repeat(200));
+});
+
+test("does not gzip when the gzip quality value is invalid", async () => {
+  const response = jsonResponse(
+    new Request("http://localhost/test", { headers: { "Accept-Encoding": "gzip;q=invalid, *;q=1" } }),
+    { value: "large payload ".repeat(200) },
+  );
+
+  assert.equal(response.headers.get("Content-Encoding"), null);
+  assert.equal((await response.json()).value, "large payload ".repeat(200));
+});
+
+test("leaves small JSON responses uncompressed", async () => {
+  const response = jsonResponse(
+    new Request("http://localhost/test", { headers: { "Accept-Encoding": "gzip" } }),
+    { ok: true },
+  );
+
+  assert.equal(response.headers.get("Content-Encoding"), null);
+  assert.deepEqual(await response.json(), { ok: true });
+});

--- a/lib/json-response.ts
+++ b/lib/json-response.ts
@@ -1,0 +1,56 @@
+const MIN_GZIP_BYTES = 1024;
+
+function acceptedEncodingQuality(header: string, encoding: string): number {
+  let wildcardQuality: number | undefined;
+  for (const item of header.split(",")) {
+    const [rawName, ...rawParameters] = item.trim().split(";");
+    const name = rawName.trim().toLowerCase();
+    let quality = 1;
+    for (const rawParameter of rawParameters) {
+      const match = /^\s*q\s*=\s*(.*?)\s*$/i.exec(rawParameter);
+      if (!match) continue;
+      const value = match[1];
+      quality = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/.test(value) ? Number(value) : 0;
+    }
+    if (name === encoding) return quality;
+    if (name === "*") wildcardQuality = quality;
+  }
+  return wildcardQuality ?? 0;
+}
+
+function appendVary(headers: Headers, value: string): void {
+  const current = headers.get("Vary");
+  if (!current) {
+    headers.set("Vary", value);
+    return;
+  }
+  if (!current.split(",").some((entry) => entry.trim().toLowerCase() === value.toLowerCase())) {
+    headers.set("Vary", `${current}, ${value}`);
+  }
+}
+
+export function jsonResponse(
+  request: Request,
+  data: unknown,
+  init: ResponseInit = {},
+): Response {
+  const body = JSON.stringify(data);
+  const isLargeEnough = Buffer.byteLength(body) >= MIN_GZIP_BYTES;
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json; charset=utf-8");
+
+  if (isLargeEnough) {
+    appendVary(headers, "Accept-Encoding");
+  }
+
+  if (
+    isLargeEnough
+    && acceptedEncodingQuality(request.headers.get("Accept-Encoding") ?? "", "gzip") > 0
+  ) {
+    headers.set("Content-Encoding", "gzip");
+    const compressed = new Blob([body]).stream().pipeThrough(new CompressionStream("gzip"));
+    return new Response(compressed, { ...init, headers });
+  }
+
+  return new Response(body, { ...init, headers });
+}


### PR DESCRIPTION
## Summary

- gzip large `/api/sessions` and `/api/sessions/[id]` JSON responses when clients support it
- keep small responses and clients opting out with `gzip;q=0` uncompressed
- preserve payload semantics and cache negotiation with `Vary: Accept-Encoding`
- use streaming compression to avoid synchronous gzip work on the request thread

Closes #651

## Why this approach

This keeps `firstMessage` intact because it participates in skill title extraction and sidebar search. It also avoids relying on Next.js global compression for dynamic route handlers.

The helper validates gzip quality values, compresses only responses of at least 1 KiB, and leaves error responses unchanged.

## Testing

- `node --test app/api/sessions/runtime-route.test.mjs lib/json-response.test.mjs` — 12 passed
- `env PI_CODING_AGENT_DIR=/private/tmp/pi-web-test-agent-651-merge npm test` — 958 passed
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

The branch includes the latest `main`. The conflict in `app/api/sessions/runtime-route.test.mjs` was resolved by retaining both the upstream unpersisted-session deletion coverage and this PR's gzip route coverage.
