### PR TITLE
feat: preview image attachments in the chat composer

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -23,6 +23,7 @@ import {
   type AtQueryMatch, type FileIndexEntry,
 } from "@/lib/file-fuzzy";
 import { FolderIcon, getFileIcon } from "./FileIcons";
+import { ImagePreview } from "./ImagePreview";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useI18n } from "@/hooks/useI18n";
 import { useChatAppearance } from "@/hooks/useChatAppearance";
@@ -1620,13 +1621,16 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
           <div style={{ display: "flex", gap: 6, marginBottom: 6, flexWrap: "wrap" }}>
             {attachedImages.map((img, i) => (
               <div key={i} style={{ position: "relative", flexShrink: 0 }}>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={img.previewUrl}
-                  alt=""
-                  style={{ width: 56, height: 56, objectFit: "cover", borderRadius: 6, border: "1px solid var(--border)", display: "block" }}
-                />
+                <ImagePreview key={img.previewUrl} src={img.previewUrl}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={img.previewUrl}
+                    alt=""
+                    style={{ width: 56, height: 56, objectFit: "cover", borderRadius: 6, border: "1px solid var(--border)", display: "block" }}
+                  />
+                </ImagePreview>
                 <button
+                  type="button"
                   onClick={() => removeImage(i)}
                   style={{
                     position: "absolute", top: -4, right: -4,

--- a/components/ImagePreview.test.mjs
+++ b/components/ImagePreview.test.mjs
@@ -5,6 +5,15 @@ import test from "node:test";
 const source = await readFile(new URL("./ImagePreview.tsx", import.meta.url), "utf8");
 const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
+test("composer attachments open in the shared preview with a separate remove button", async () => {
+  const inputSource = await readFile(new URL("./ChatInput.tsx", import.meta.url), "utf8");
+  assert.match(inputSource, /import \{ ImagePreview \} from "\.\/ImagePreview"/);
+  assert.match(
+    inputSource,
+    /<ImagePreview key=\{img\.previewUrl\} src=\{img\.previewUrl\}>[\s\S]*?<img[\s\S]*?src=\{img\.previewUrl\}[\s\S]*?<\/ImagePreview>\s*<button\s*type="button"\s*onClick=\{\(\) => removeImage\(i\)\}/,
+  );
+});
+
 test("uses a native modal dialog and restores focus to its trigger", () => {
   assert.match(source, /useRef<HTMLDialogElement>\(null\)/);
   assert.match(source, /dialog\.showModal\(\)/);


### PR DESCRIPTION
## Summary
- Reuse the existing ImagePreview modal for attachments in the chat composer, before sending.
- Preserve thumbnail sizing and keep the remove button separate from the preview trigger.
- Reuse keyboard activation, Escape/backdrop dismissal, and focus restoration from the shared component.

## Testing
- Shared image-preview regression tests pass.
- `npm run lint` and TypeScript `tsc --noEmit` pass in the development checkout.
- Ran `npm test` on Windows and compared it with an untouched upstream/main checkout at 0d1df12: both have the same 14 failing tests (including Windows symlink/shell limitations and existing component assertions). No additional failing tests were observed.
- Production build and browser E2E were not run locally.

## Manual verification
1. Paste, drag, or attach an image in the composer.
2. Click the thumbnail to open the modal; close with Escape, backdrop, or the close button.
3. Use the remove button and confirm it removes the attachment without opening the modal.

This PR is independent of the local-path preview feature.