### PR TITLE
feat: preview verified local files and directories from chat

### DIFF
--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -496,6 +496,9 @@ export async function GET(
     }
 
     if (type === "meta") {
+      if (stat?.isDirectory()) {
+        return NextResponse.json({ isDirectory: true });
+      }
       if (!stat?.isFile()) {
         return NextResponse.json({ error: "Not a file" }, { status: 400 });
       }

--- a/app/globals.css
+++ b/app/globals.css
@@ -533,6 +533,43 @@ pre, code {
   font-size: 0.92em;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 70%, transparent);
 }
+.markdown-body a.markdown-local-file-link,
+.markdown-body a.markdown-local-file-link:hover {
+  color: var(--text);
+  text-decoration: none;
+  cursor: pointer;
+  background: var(--bg-subtle);
+  border-radius: 5px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 70%, transparent);
+}
+.markdown-body a.markdown-local-file-link .markdown-inline-code {
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  font-size: inherit;
+}
+.markdown-body a.markdown-local-file-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+.directory-viewer-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+.directory-viewer-entry:hover { background: var(--bg-hover); }
 .markdown-body .contains-task-list {
   padding-left: 0;
   list-style: none;

--- a/components/DirectoryViewer.test.mjs
+++ b/components/DirectoryViewer.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const route = await readFile(new URL("../app/api/files/[...path]/route.ts", import.meta.url), "utf8");
+const viewer = await readFile(new URL("./FileViewer.tsx", import.meta.url), "utf8");
+const directory = await readFile(new URL("./DirectoryViewer.tsx", import.meta.url), "utf8");
+
+test("metadata recognizes directories after existing authorization checks", () => {
+  const meta = route.indexOf('if (type === "meta")');
+  assert.ok(route.indexOf("isExistingFilePathAllowed(existingAuthorizationPath, allowedRoots)") < meta);
+  assert.match(route.slice(meta), /stat\?\.isDirectory\(\)[\s\S]*?isDirectory: true/);
+});
+
+test("right panel dispatches directories by metadata rather than filename extension", () => {
+  assert.match(viewer, /data\.isDirectory \? "directory" : "file"/);
+  assert.match(viewer, /kind === "directory"[\s\S]*?<DirectoryViewer/);
+  assert.match(directory, /\?type=list/);
+  assert.match(directory, /onOpenFile\?\.\(childPath\)/);
+  assert.match(directory, /controller\.abort\(\)/);
+});

--- a/components/DirectoryViewer.tsx
+++ b/components/DirectoryViewer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { encodeFilePathForApi } from "@/lib/file-paths";
+import { FolderIcon, getFileIcon } from "./FileIcons";
+import { useI18n } from "@/hooks/useI18n";
+
+interface Entry { name: string; isDir: boolean }
+
+export function DirectoryViewer({ filePath, onOpenFile }: {
+  filePath: string;
+  onOpenFile?: (path: string) => void;
+}) {
+  const { t } = useI18n();
+  const [result, setResult] = useState<{ path: string; entries?: Entry[]; error?: string } | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(`/api/files/${encodeFilePathForApi(filePath)}?type=list`, { signal: controller.signal })
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error ?? response.statusText);
+        if (!controller.signal.aborted) setResult({ path: filePath, entries: data.entries });
+      })
+      .catch((error) => {
+        if (!controller.signal.aborted) setResult({ path: filePath, error: String(error) });
+      });
+    return () => controller.abort();
+  }, [filePath]);
+
+  return (
+    <div style={{ height: "100%", overflow: "auto", padding: 16 }}>
+      <div style={{ fontFamily: "var(--font-mono)", overflowWrap: "anywhere", marginBottom: 16 }} title={filePath}>{filePath}</div>
+      {result?.path !== filePath ? <div>{t("files.loading")}</div> : result.error ? (
+        <div role="alert" style={{ color: "var(--text-muted)" }}>{result.error}</div>
+      ) : (
+        <div>
+          {result.entries?.length === 0 && <div style={{ color: "var(--text-muted)" }}>{t("files.noFiles")}</div>}
+          {result.entries?.map((entry) => {
+            const childPath = `${filePath.replace(/[\\/]+$/, "")}/${entry.name}`;
+            return (
+              <button key={entry.name} type="button" className="directory-viewer-entry" title={childPath}
+                disabled={!onOpenFile} onClick={() => onOpenFile?.(childPath)}>
+                {entry.isDir ? <FolderIcon size={16} /> : getFileIcon(entry.name, 16)}
+                <span>{entry.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -24,6 +24,7 @@ import { parseFrontmatter } from "@/lib/frontmatter";
 import { markdownPreviewRehypePlugins, markdownPreviewRemarkPlugins, markdownUrlTransform, normalizeDisplayMath } from "@/lib/markdown";
 import { CodeBlock, MermaidBlock } from "./MermaidBlock";
 import { FrontmatterCard } from "./FrontmatterCard";
+import { DirectoryViewer } from "./DirectoryViewer";
 import { parseUnifiedPatch } from "@/lib/patch";
 import type { GitFileDiffResponse } from "@/lib/git-types";
 import { useI18n } from "@/hooks/useI18n";
@@ -1076,7 +1077,34 @@ function DocumentViewer({ filePath, cwd, sourceSessionId, watchEnabled = true }:
   );
 }
 
-export function FileViewer({
+export function FileViewer(props: Props) {
+  return <PathViewer key={`${props.sourceSessionId ?? ""}:${props.filePath}`} {...props} />;
+}
+
+function PathViewer(props: Props) {
+  const { t } = useI18n();
+  const [kind, setKind] = useState<"file" | "directory" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(getFileApiUrl(props.filePath, "meta", props.sourceSessionId), { signal: controller.signal })
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error ?? response.statusText);
+        if (!controller.signal.aborted) setKind(data.isDirectory ? "directory" : "file");
+      })
+      .catch((error) => {
+        if (!controller.signal.aborted) setError(String(error));
+      });
+    return () => controller.abort();
+  }, [props.filePath, props.sourceSessionId]);
+  if (error) return <div role="alert" style={{ padding: 16 }}>{error}</div>;
+  if (!kind) return <div style={{ padding: 16 }}>{t("files.loading")}</div>;
+  if (kind === "directory") return <DirectoryViewer filePath={props.filePath} onOpenFile={props.onOpenFile} />;
+  return <FileContentViewer {...props} />;
+}
+
+function FileContentViewer({
   filePath,
   cwd,
   sourceSessionId,

--- a/components/LocalFileLink.tsx
+++ b/components/LocalFileLink.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState, type ReactNode, type MouseEvent } from "react";
+import { shouldOpenLocalFileInApp } from "@/lib/file-links";
+import { validateFileLink } from "@/lib/file-link-validation";
+
+interface Props {
+  filePath: string;
+  href?: string;
+  title?: string;
+  target?: string;
+  children: ReactNode;
+  fullPathLabel?: string;
+  onOpenFile: (path: string) => void;
+}
+
+export function LocalFileLink({ filePath, href, target, children, fullPathLabel, onOpenFile }: Props) {
+  const [verifiedPath, setVerifiedPath] = useState<string | null>(null);
+  useEffect(() => {
+    let active = true;
+    const check = () => {
+      void validateFileLink(filePath).then((exists) => {
+        if (active) setVerifiedPath(exists ? filePath : null);
+      });
+    };
+    check();
+    // Recheck files created/deleted by the agent, including previously missing paths.
+    const timer = setInterval(() => {
+      if (document.visibilityState === "visible") check();
+    }, 15000);
+    return () => { active = false; clearInterval(timer); };
+  }, [filePath]);
+
+  if (verifiedPath !== filePath) return <>{children}</>;
+
+  const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!shouldOpenLocalFileInApp(event)) return;
+    if (target && target !== "_self") return;
+    event.preventDefault();
+    // A file may have disappeared since the initial check.
+    if (await validateFileLink(filePath)) onOpenFile(filePath);
+    else setVerifiedPath(null);
+  };
+
+  return (
+    <a className="markdown-local-file-link" href={href} title={fullPathLabel ?? filePath} target={target} onClick={handleClick}>
+      {children}
+    </a>
+  );
+}

--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -9,7 +10,9 @@ const jiti = createJiti(import.meta.url, {
   tsconfigPaths: true,
 });
 const { MarkdownBody } = await jiti.import("./MarkdownBody.tsx");
-const { normalizeDisplayMath } = await jiti.import("../lib/markdown.ts");
+const { normalizeDisplayMath, markdownRemarkPlugins, markdownRehypePlugins } = await jiti.import("../lib/markdown.ts");
+const { remarkFileLinks } = await jiti.import("../lib/remark-file-links.ts");
+const { default: ReactMarkdown } = await import("react-markdown");
 const { I18nProvider } = await jiti.import("@/hooks/useI18n");
 
 function renderMarkdown(markdown, props = {}) {
@@ -26,6 +29,49 @@ function renderMarkdown(markdown, props = {}) {
   );
 }
 
+test("full-path metadata survives sanitization while the original label remains intact", () => {
+  let label;
+  const html = renderToStaticMarkup(React.createElement(ReactMarkdown, {
+    remarkPlugins: [...markdownRemarkPlugins, [remarkFileLinks, { cwd: "D:/project" }]],
+    rehypePlugins: markdownRehypePlugins,
+    components: { a({ node, children }) {
+      label = node.properties.dataFilePathLabel;
+      return React.createElement("span", null, children);
+    } },
+  }, "`src/main.ts`"));
+  assert.equal(label, "D:/project/src/main.ts");
+  assert.match(html, /<code>src\/main.ts<\/code>/);
+});
+
+test("local path links retain neutral code styling without an underline", async () => {
+  const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+  assert.match(css, /a\.markdown-local-file-link:hover \{[^}]*color: var\(--text\);[^}]*text-decoration: none;[^}]*background: var\(--bg-subtle\);/);
+  const link = await readFile(new URL("./LocalFileLink.tsx", import.meta.url), "utf8");
+  assert.match(link, /title=\{fullPathLabel \?\? filePath\}/);
+  assert.match(link, /onClick=\{handleClick\}>\s*\{children\}/);
+  assert.doesNotMatch(link, /\{fullPathLabel \?\? children\}/);
+});
+
+test("keeps original inline-code path labels until filesystem validation succeeds", () => {
+  const html = renderMarkdown("`components/MarkdownBody.tsx:12` 和 `D:\\My Project\\报告.md`", { cwd: "D:/repo" });
+  assert.match(html, /<code[^>]*>components\/MarkdownBody.tsx:12<\/code>/);
+  assert.ok(html.includes("D:\\My Project\\报告.md"));
+  assert.doesNotMatch(html, /<a |D:\/repo/);
+});
+
+test("preserves plain paths and punctuation while validation is pending", () => {
+  const html = renderMarkdown("文件： /home/me/project/report.md，另见 components/MarkdownBody.tsx。");
+  assert.ok(html.includes("文件： /home/me/project/report.md，另见 components/MarkdownBody.tsx。"));
+  assert.doesNotMatch(html, /<a /);
+});
+
+test("does not autolink code blocks, ordinary inline code, or paths without a handler", () => {
+  assert.doesNotMatch(renderMarkdown("```text\n/home/me/project/report.md\n```\n\n`hello`"), /<a /);
+  assert.doesNotMatch(renderMarkdown("`src/index.ts` /home/me/project/report.md", { onOpenFile: undefined }), /<a /);
+  const html = renderMarkdown("[report](/home/me/project/report.md)");
+  assert.doesNotMatch(html, /<a /);
+});
+
 test("opens non-file markdown links in a safe new tab", () => {
   const html = renderMarkdown("[docs](https://example.com/docs)");
 
@@ -36,14 +82,13 @@ test("opens non-file markdown links in a safe new tab", () => {
   assert.doesNotMatch(html, /\snode=/);
 });
 
-test("keeps local file markdown links in the app", () => {
+test("also requires validation for explicit local markdown links", () => {
   const relativeHtml = renderMarkdown("[file](components/MarkdownBody.tsx)");
   const fileUrlHtml = renderMarkdown("[report](file:///home/me/project/report.html)");
 
-  assert.match(relativeHtml, /<a href="components\/MarkdownBody\.tsx">file<\/a>/);
-  assert.doesNotMatch(relativeHtml, /target=|rel=|\snode=/);
-  assert.match(fileUrlHtml, /<a href="file:\/\/\/home\/me\/project\/report\.html">report<\/a>/);
-  assert.doesNotMatch(fileUrlHtml, /target=|rel=|\snode=/);
+  assert.match(relativeHtml, />file<\/p>/);
+  assert.match(fileUrlHtml, />report<\/p>/);
+  assert.doesNotMatch(relativeHtml + fileUrlHtml, /<a |target=|rel=|\snode=/);
 });
 
 test("keeps file URLs inert without an in-app file handler", () => {

--- a/components/MarkdownBody.tsx
+++ b/components/MarkdownBody.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo, type MouseEvent } from "react";
+import { useMemo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
-import { resolveLocalFileHref, shouldOpenLocalFileInApp } from "@/lib/file-links";
+import { resolveLocalFileHref } from "@/lib/file-links";
+import { LocalFileLink } from "./LocalFileLink";
 import { encodeFilePathForApi } from "@/lib/file-paths";
+import { remarkFileLinks } from "@/lib/remark-file-links";
 import { markdownRehypePlugins, markdownRemarkPlugins, markdownUrlTransform, normalizeDisplayMath } from "@/lib/markdown";
 import { MermaidBlock, CodeBlock } from "./MermaidBlock";
 
@@ -17,6 +19,9 @@ interface MarkdownBodyProps {
 
 export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile }: MarkdownBodyProps) {
   const normalizedMarkdown = useMemo(() => normalizeDisplayMath(children), [children]);
+  const remarkPlugins = useMemo(() => onOpenFile
+    ? [...(markdownRemarkPlugins ?? []), [remarkFileLinks, { cwd }] as [typeof remarkFileLinks, { cwd?: string }]]
+    : markdownRemarkPlugins, [cwd, onOpenFile]);
   // Stable renderer identities keep stateful blocks mounted across message hover updates.
   const components = useMemo<Components>(() => ({
     code({ className, children, ...props }) {
@@ -48,6 +53,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
       return <>{children}</>;
     },
     a({ href, children, ...props }) {
+      const fullPathLabel = props.node?.properties.dataFilePathLabel;
       // `node` is react-markdown metadata, not a DOM attribute.
       delete props.node;
       const filePath = onOpenFile ? resolveLocalFileHref(href, cwd) : null;
@@ -60,18 +66,18 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
         );
       }
 
-      const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-        if (!shouldOpenLocalFileInApp(event)) return;
-        const target = event.currentTarget.getAttribute("target");
-        if (target && target !== "_self") return;
-        event.preventDefault();
-        openFile(filePath);
-      };
-
       return (
-        <a href={href} {...props} onClick={handleClick}>
+        <LocalFileLink
+          key={filePath}
+          href={href}
+          filePath={filePath}
+          title={props.title}
+          target={props.target}
+          fullPathLabel={typeof fullPathLabel === "string" ? fullPathLabel : undefined}
+          onOpenFile={openFile}
+        >
           {children}
-        </a>
+        </LocalFileLink>
       );
     },
     img({ src, alt, ...props }) {
@@ -96,7 +102,7 @@ export function MarkdownBody({ children, className, isStreaming, cwd, onOpenFile
   return (
     <div className={["markdown-body", className].filter(Boolean).join(" ")}>
       <ReactMarkdown
-        remarkPlugins={markdownRemarkPlugins}
+        remarkPlugins={remarkPlugins}
         rehypePlugins={markdownRehypePlugins}
         urlTransform={onOpenFile ? markdownUrlTransform : undefined}
         components={components}

--- a/lib/file-link-validation.test.mjs
+++ b/lib/file-link-validation.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+const jiti = createJiti(import.meta.url);
+const { validateFileLink } = await jiti.import("./file-link-validation.ts");
+const { remarkFileLinks } = await jiti.import("./remark-file-links.ts");
+
+test("only successful authorized metadata requests validate a file; failures are retried", async (t) => {
+  let status = 404;
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async (url) => {
+    calls++;
+    assert.match(url, /^\/api\/files\/.*\?type=meta$/);
+    return new Response(null, { status });
+  });
+  for (const code of [404, 403, 400, 500]) {
+    status = code;
+    assert.equal(await validateFileLink("/project/foo.ts"), false);
+  }
+  status = 200;
+  assert.equal(await validateFileLink("/project/foo.ts"), true);
+  assert.equal(calls, 5);
+});
+
+test("deduplicates concurrent validation and fails closed on network errors", async (t) => {
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => { calls++; throw new Error("offline"); });
+  assert.deepEqual(await Promise.all([validateFileLink("/p/a"), validateFileLink("/p/a")]), [false, false]);
+  assert.equal(calls, 1);
+});
+
+test("candidate links preserve original text, with full labels stored separately", () => {
+  const tree = { type: "root", children: [{ type: "paragraph", children: [
+    { type: "inlineCode", value: "on/start/input" },
+    { type: "inlineCode", value: "src/main.ts:12" },
+  ] }] };
+  remarkFileLinks({ cwd: "D:/project" })(tree);
+  const nodes = tree.children[0].children;
+  assert.equal(nodes[0].children[0].value, "on/start/input");
+  assert.equal(nodes[1].children[0].value, "src/main.ts:12");
+  assert.equal(nodes[1].data.hProperties.dataFilePathLabel, "D:/project/src/main.ts:12");
+});

--- a/lib/file-link-validation.ts
+++ b/lib/file-link-validation.ts
@@ -1,0 +1,36 @@
+import { encodeFilePathForApi } from "./file-paths";
+
+// Share in-flight requests across repeated references, but do not cache missing
+// files: an agent may create them later in the same conversation.
+const pending = new Map<string, Promise<boolean>>();
+const waiters: Array<() => void> = [];
+let activeRequests = 0;
+
+async function checkMetadata(filePath: string): Promise<boolean> {
+  // Long histories can contain hundreds of candidates; avoid flooding the server.
+  if (activeRequests >= 6) await new Promise<void>((resolve) => waiters.push(resolve));
+  else activeRequests++;
+  try {
+    const response = await fetch(`/api/files/${encodeFilePathForApi(filePath)}?type=meta`, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(10000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    const next = waiters.shift();
+    if (next) next();
+    else activeRequests--;
+  }
+}
+
+export function validateFileLink(filePath: string): Promise<boolean> {
+  const existing = pending.get(filePath);
+  if (existing) return existing;
+  const request = checkMetadata(filePath).finally(() => {
+    pending.delete(filePath);
+  });
+  pending.set(filePath, request);
+  return request;
+}

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -10,6 +10,7 @@ const markdownSanitizeSchema = {
   ...defaultSchema,
   attributes: {
     ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes?.a ?? []), "dataFilePathLabel"],
     code: [["className", /^language-./, "math-inline", "math-display"]],
   },
   protocols: {

--- a/lib/remark-file-links.ts
+++ b/lib/remark-file-links.ts
@@ -1,0 +1,62 @@
+import { resolveLocalFileHref } from "./file-links";
+
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  url?: string;
+  data?: { hProperties: { dataFilePathLabel: string } };
+  children?: MarkdownNode[];
+}
+
+function fileLink(value: string, cwd?: string, inlineCode = false): MarkdownNode | null {
+  // Be conservative: do not turn commands, URLs, or arbitrary inline code into links.
+  if (/\r|\n/.test(value) || !/^(?:[a-zA-Z]:[\\/]|\\\\|\/(?!\/)|\.\.?\/|[\w.@-]+\/|[\w@-]+\.[\w-]+$)/.test(value)) return null;
+  if (!inlineCode && /\s/.test(value)) return null;
+  const path = resolveLocalFileHref(value, cwd);
+  if (!path) return null;
+  const suffix = value.match(/(:\d+(?::\d+)?|#L\d+(?:-L?\d+)?)$/)?.[0] ?? "";
+  // file: URLs survive markdown sanitization and preserve spaces and URL delimiters.
+  const url = path.startsWith("//")
+    ? `file://${path.slice(2).split("/").map(encodeURIComponent).join("/")}`
+    : `file://${path.startsWith("/") ? "" : "/"}${path.split("/").map(encodeURIComponent).join("/")}`;
+  return {
+    type: "link",
+    url,
+    data: { hProperties: { dataFilePathLabel: path + suffix } },
+    children: [{ type: inlineCode ? "inlineCode" : "text", value }],
+  };
+}
+
+/** Link filesystem references without rewriting fenced code, math, or existing links. */
+export function remarkFileLinks({ cwd }: { cwd?: string } = {}) {
+  return (tree: MarkdownNode) => {
+    const walk = (parent: MarkdownNode) => {
+      if (!parent.children || ["link", "linkReference", "code", "html", "image", "imageReference"].includes(parent.type)) return;
+      parent.children = parent.children.flatMap((node): MarkdownNode[] => {
+        if (node.type === "inlineCode") return [fileLink(node.value ?? "", cwd, true) ?? node];
+        if (node.type !== "text") {
+          walk(node);
+          return [node];
+        }
+        const text = node.value ?? "";
+        const result: MarkdownNode[] = [];
+        // Plain paths cannot contain whitespace; use backticks for paths with spaces.
+        const pattern = /(^|[\s:：,，;；(（【「“"'])((?:[a-zA-Z]:[\\/]|\\\\|\/(?!\/)|\.\.?\/|[\w.@-]+\/)[^\s<>"'`，。；！？、（）【】「」“”]+)/g;
+        let offset = 0;
+        for (const match of text.matchAll(pattern)) {
+          const start = match.index! + match[1].length;
+          const value = match[2].replace(/[.,;!:)\]}]+$/, "");
+          const link = fileLink(value, cwd);
+          if (!link) continue;
+          if (start > offset) result.push({ type: "text", value: text.slice(offset, start) });
+          result.push(link);
+          offset = start + value.length;
+        }
+        if (!result.length) return [node];
+        if (offset < text.length) result.push({ type: "text", value: text.slice(offset) });
+        return result;
+      });
+    };
+    walk(tree);
+  };
+}


### PR DESCRIPTION
## Summary
- Recognize local path references in Markdown text and inline code, without rewriting fenced code, math, or existing links.
- Validate candidates using the existing authorized file metadata API before making them clickable. Nonexistent/inaccessible paths retain their original text.
- Keep the original path label and neutral code-style background; show the resolved full path on hover and open it in the right-hand panel.
- Support directory metadata and a right-panel directory listing, with navigation into child directories and files.
- Recheck before opening, periodically refresh validation, deduplicate concurrent checks, and cap metadata request concurrency.
- Keep the existing allowed-root and realpath checks; do not broaden filesystem access.

## Testing
- Markdown rendering, path validation, directory dispatch, and existing file-viewer regression tests pass.
- `npm run lint` and TypeScript `tsc --noEmit` pass in the development checkout.
- Ran `npm test` on Windows and compared it with an untouched upstream/main checkout at 0d1df12: both have the same 14 failing tests (including Windows symlink/shell limitations and existing component assertions). No additional failing tests were observed.
- Production build and browser E2E were not run locally.

## Manual verification
1. Include an existing relative path or Windows absolute path in a chat response.
2. Verify the original label remains visible, the full path appears on hover, and clicking opens the right panel.
3. Include a nonexistent path or slash-separated function names and verify they remain plain text/code.
4. Click an existing directory and navigate through its entries in the right panel.

This PR is independent of the composer image-preview feature.