### PR TITLE
fix: serialize extension service loading

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,6 +1,6 @@
 import { stat } from "fs/promises";
 import { resolve } from "path";
-import { createAgentSessionServices, getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, type SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import {
   loadModelsWithCache,
@@ -11,6 +11,7 @@ import {
 import { resolveVisibleModels, selectInitialModelScope } from "@/lib/model-scope";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
 import { projectTrustReloadOptions } from "@/lib/project-trust";
+import { createPiWebAgentSessionServices } from "@/lib/agent-session-services";
 
 export const dynamic = "force-dynamic";
 
@@ -37,11 +38,11 @@ async function loadModels(cwd: string): Promise<ModelsData> {
   // runs a repository's .pi/extensions factories, so honor project trust here
   // too (see lib/project-trust.ts, #236).
   const trustReloadOptions = projectTrustReloadOptions(cwd, agentDir);
-  const services = await createAgentSessionServices({
+  const services = await createPiWebAgentSessionServices({
     cwd,
     agentDir,
     ...(trustReloadOptions ? { resourceLoaderReloadOptions: trustReloadOptions } : {}),
-  });
+  }, { transientExtensions: true });
   const modelError = services.modelRuntime.getError();
   const settings: SettingsManager = services.settingsManager;
   // `enabledModels` supports globs and fuzzy patterns, so resolve it the same

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -10,8 +10,9 @@ import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-acces
 export const dynamic = "force-dynamic";
 
 // GET /api/skills?cwd=<path>
-// Uses DefaultResourceLoader (same logic as AgentSession startup) so settings.json
-// skill paths, package skills, and .agents/skills directories are all included.
+// Uses DefaultResourceLoader for settings paths, package skills, and
+// .agents/skills, but disables extensions because this request has no session
+// lifecycle in which to dispatch resources_discover or session_shutdown.
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const cwd = searchParams.get("cwd");

--- a/lib/agent-session-services.test.mjs
+++ b/lib/agent-session-services.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runAgentServiceLoad } from "./agent-session-services.ts";
+
+const SINGLETON_KEY = "__piChromeProfileBridgeLoaded__";
+
+function clearSingleton() {
+  delete globalThis[SINGLETON_KEY];
+}
+
+test.afterEach(clearSingleton);
+
+test("transient model discovery releases a pi-chrome singleton it created", async () => {
+  clearSingleton();
+  const token = { token: Symbol("model-discovery") };
+
+  const result = await runAgentServiceLoad(async () => {
+    globalThis[SINGLETON_KEY] = token;
+    return "models";
+  }, { transientExtensions: true });
+
+  assert.equal(result, "models");
+  assert.equal(globalThis[SINGLETON_KEY], undefined);
+});
+
+test("transient model discovery preserves an existing session singleton", async () => {
+  const existing = { token: Symbol("active-session") };
+  globalThis[SINGLETON_KEY] = existing;
+
+  await runAgentServiceLoad(async () => {
+    assert.equal(globalThis[SINGLETON_KEY], existing);
+  }, { transientExtensions: true });
+
+  assert.equal(globalThis[SINGLETON_KEY], existing);
+});
+
+test("session service creation keeps the pi-chrome singleton", async () => {
+  clearSingleton();
+  const token = { token: Symbol("session") };
+
+  await runAgentServiceLoad(async () => {
+    globalThis[SINGLETON_KEY] = token;
+  });
+
+  assert.equal(globalThis[SINGLETON_KEY], token);
+});
+
+test("service loads are serialized so discovery cannot race session startup", async () => {
+  clearSingleton();
+  const order = [];
+  let releaseDiscovery;
+
+  const discovery = runAgentServiceLoad(async () => {
+    order.push("discovery:start");
+    globalThis[SINGLETON_KEY] = { token: Symbol("discovery") };
+    await new Promise((resolve) => { releaseDiscovery = resolve; });
+    order.push("discovery:end");
+  }, { transientExtensions: true });
+
+  await Promise.resolve();
+  const session = runAgentServiceLoad(async () => {
+    order.push("session:start");
+    assert.equal(globalThis[SINGLETON_KEY], undefined);
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(order, ["discovery:start"]);
+  releaseDiscovery();
+  await Promise.all([discovery, session]);
+  assert.deepEqual(order, ["discovery:start", "discovery:end", "session:start"]);
+});

--- a/lib/agent-session-services.ts
+++ b/lib/agent-session-services.ts
@@ -1,0 +1,70 @@
+import {
+  createAgentSessionServices as createSdkAgentSessionServices,
+  type AgentSessionServices,
+  type CreateAgentSessionServicesOptions,
+} from "@earendil-works/pi-coding-agent";
+
+const PI_CHROME_SINGLETON_KEY = "__piChromeProfileBridgeLoaded__";
+
+type ServiceLoadState = {
+  tail: Promise<void>;
+};
+
+const globalState = globalThis as typeof globalThis & {
+  __piWebAgentServiceLoads?: ServiceLoadState;
+  [PI_CHROME_SINGLETON_KEY]?: unknown;
+};
+
+const serviceLoadState = globalState.__piWebAgentServiceLoads ??= {
+  tail: Promise.resolve(),
+};
+
+async function serializeServiceLoad<T>(load: () => Promise<T>): Promise<T> {
+  const previous = serviceLoadState.tail;
+  let release!: () => void;
+  serviceLoadState.tail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await load();
+  } finally {
+    release();
+  }
+}
+
+export async function runAgentServiceLoad<T>(
+  load: () => Promise<T>,
+  options: { transientExtensions?: boolean } = {},
+): Promise<T> {
+  return serializeServiceLoad(async () => {
+    if (!options.transientExtensions) return load();
+
+    const hadPiChromeSingleton = Object.prototype.hasOwnProperty.call(globalState, PI_CHROME_SINGLETON_KEY);
+    const previousPiChromeSingleton = globalState[PI_CHROME_SINGLETON_KEY];
+    try {
+      return await load();
+    } finally {
+      // Service-only model discovery evaluates extension factories without ever
+      // creating a session, so session_shutdown cannot release pi-chrome's
+      // process singleton. Restore the pre-discovery state so the real session
+      // can register /chrome and chrome_* tools normally.
+      if (hadPiChromeSingleton) {
+        globalState[PI_CHROME_SINGLETON_KEY] = previousPiChromeSingleton;
+      } else {
+        delete globalState[PI_CHROME_SINGLETON_KEY];
+      }
+    }
+  });
+}
+
+export function createPiWebAgentSessionServices(
+  options: CreateAgentSessionServicesOptions,
+  lifecycle: { transientExtensions?: boolean } = {},
+): Promise<AgentSessionServices> {
+  return runAgentServiceLoad(
+    () => createSdkAgentSessionServices(options),
+    lifecycle,
+  );
+}

--- a/lib/project-trust.test.mjs
+++ b/lib/project-trust.test.mjs
@@ -91,7 +91,10 @@ test("all project resource loaders and reloads enforce project trust", async () 
 
   assert.match(modelsSource, /projectTrustReloadOptions\(cwd, agentDir\)/);
   assert.match(modelsSource, /resourceLoaderReloadOptions: trustReloadOptions/);
+  assert.match(skillsSource, /noExtensions: true/);
+  assert.match(skillsSource, /runAgentServiceLoad\(/);
   assert.match(skillsSource, /loader\.reload\(projectTrustReloadOptions\(cwd, agentDir\)\)/);
+  assert.match(skillsSource, /transientExtensions: true/);
   assert.match(pluginsSource, /projectTrusted: projectTrust\.trusted/);
   assert.match(
     skillsInstallSource,

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -25,7 +25,7 @@ test("RPC session startup preloads extension-registered providers before restori
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const startupSource = source.slice(source.indexOf("export async function startRpcSession"));
 
-  assert.match(startupSource, /createAgentSessionServices\(/);
+  assert.match(startupSource, /createPiWebAgentSessionServices\(/);
   assert.match(startupSource, /createAgentSessionFromServices\(/);
   assert.doesNotMatch(startupSource, /await createAgentSession\(/);
 });

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -476,7 +476,7 @@ test("normal sessions restore persisted tool selections before loading resources
   assert.match(startupSource, /readSessionToolSelection\(sessionManager\.getEntries\(\)/);
   assert.match(startupSource, /const selectedToolNames = subagentResources\?\.tools \?\? persistedToolNames \?\? requestedToolNames/);
   assert.match(startupSource, /appendSessionToolSelection\(sessionManager, requestedToolNames\)/);
-  assert.ok(startupSource.indexOf("const chatOnly") < startupSource.indexOf("createAgentSessionServices("));
+  assert.ok(startupSource.indexOf("const chatOnly") < startupSource.indexOf("createPiWebAgentSessionServices("));
   assert.match(startupSource, /chatOnly\s*\? CHAT_ONLY_RESOURCE_LOADER_OPTIONS/);
   assert.match(startupSource, /const trustReloadOptions = subagentResources[\s\S]*?subagentLoadsResources[\s\S]*?projectTrustReloadOptions\(sessionCwd, agentDir\)/);
   assert.match(registrationSource, /if \(!wrapper\.isChatOnly\(\)\) wrapper\.beginExtensionBinding\(\)/);

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,5 +1,5 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { createAgentSessionFromServices, createAgentSessionServices, getAgentDir, initTheme, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { createAgentSessionFromServices, getAgentDir, initTheme, SessionManager, SettingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager as TuiKeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
 import { existsSync, realpathSync, writeFileSync } from "fs";
@@ -15,6 +15,7 @@ import {
 import { cacheSessionPath, invalidateSessionListCache, resolveSessionPath } from "./session-reader";
 import { getProjectTrustStatus, projectTrustReloadOptions } from "./project-trust";
 import { persistExplicitStartupPreferences } from "./startup-preferences";
+import { createPiWebAgentSessionServices } from "./agent-session-services";
 import { notifySessionComplete } from "./web-push";
 import { hasActiveSessionLivenessProvider } from "./session-liveness";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
@@ -1997,7 +1998,7 @@ export async function startRpcSession(
         ? undefined
         : projectTrustReloadOptions(sessionCwd, agentDir);
     const settingsManager = SettingsManager.create(sessionCwd, agentDir);
-    const services = await createAgentSessionServices({
+    const services = await createPiWebAgentSessionServices({
       cwd: sessionCwd,
       agentDir,
       settingsManager,

--- a/lib/skills-service.ts
+++ b/lib/skills-service.ts
@@ -1,12 +1,20 @@
 import { DefaultResourceLoader, getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { SkillInfo, SkillsResponse } from "@/lib/api-types";
 import { annotateSkillsWithInstallInfo } from "@/lib/skill-lock";
+import { runAgentServiceLoad } from "@/lib/agent-session-services";
 import { getProjectTrustStatus, projectTrustReloadOptions } from "@/lib/project-trust";
 
 export async function loadSkillsWithInstallInfo(cwd: string): Promise<SkillsResponse> {
   const agentDir = getAgentDir();
-  const loader = new DefaultResourceLoader({ cwd, agentDir });
-  await loader.reload(projectTrustReloadOptions(cwd, agentDir));
+  // This endpoint only enumerates static skills. It has no session runtime to
+  // dispatch resources_discover or session_shutdown, so evaluating extension
+  // factories here can only leak factory-level state such as pi-chrome's
+  // process singleton into the next real AgentSession.
+  const loader = new DefaultResourceLoader({ cwd, agentDir, noExtensions: true });
+  await runAgentServiceLoad(
+    () => loader.reload(projectTrustReloadOptions(cwd, agentDir)),
+    { transientExtensions: true },
+  );
   const { skills, diagnostics } = loader.getSkills();
   return {
     skills: annotateSkillsWithInstallInfo(skills as SkillInfo[], { cwd, agentDir }),


### PR DESCRIPTION
## Summary

- Serialize Pi SDK service construction so concurrent model discovery and session startup cannot race extension factories.
- Route Pi Web model discovery and RPC session startup through the shared lifecycle-aware service loader.
- Restore transient extension state after service-only model discovery so extensions such as `pi-chrome` do not consume a singleton without receiving `session_shutdown`.
- Keep the change focused: personal UI customizations, LAN defaults, planning documents, and unresolved background-race changes are not included.

## Why

Pi Web can evaluate extension factories from multiple entry points. A service-only model discovery request may overlap with real session startup, and transient extension loading has no session lifecycle callback to release resources. Serializing these loads and cleaning up transient state prevents missing extension tools and makes startup behavior deterministic.

## Validation

- `npm test` — 954 passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`

## Scope

This PR is based on the latest `upstream/main` (`v0.9.0`) and contains only the focused, independently validated changes from the `upstream/agent-lifecycle` branch.