### PR TITLE
fix: default terminal shells to a UTF-8 locale

### DIFF
--- a/lib/terminal-manager.test.mjs
+++ b/lib/terminal-manager.test.mjs
@@ -30,6 +30,46 @@ test("native module load failures are deferred until creation and include repair
   });
 });
 
+test("shell environment defaults to UTF-8 locale when the host has none", async () => {
+  const require = createRequire(import.meta.url);
+  const paths = await jiti.import("./paths.ts");
+  const source = readFileSync(new URL("./terminal-manager.ts", import.meta.url), "utf8");
+  const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } });
+  const spawnCalls = [];
+  const fakePty = { onData() {}, onExit() {}, write() {}, resize() {}, kill() {} };
+  const fakeRequire = (id) => {
+    if (id === "node-pty") return { spawn: (...args) => { spawnCalls.push(args); return fakePty; } };
+    if (id === "./paths") return paths;
+    return require(id);
+  };
+  const envWithoutLocale = Object.fromEntries(Object.entries(process.env).filter(([k]) => !["LANG", "LC_ALL", "LC_CTYPE"].includes(k)));
+  const exports = {};
+  runInNewContext(outputText, { exports, process: { ...process, env: envWithoutLocale, once() {}, platform: process.platform }, require: fakeRequire, setTimeout, clearTimeout, console });
+  exports.createTerminal(process.cwd(), 80, 24);
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0][2].env.LANG, "C.UTF-8");
+});
+
+test("shell environment preserves an explicit user locale", async () => {
+  const require = createRequire(import.meta.url);
+  const paths = await jiti.import("./paths.ts");
+  const source = readFileSync(new URL("./terminal-manager.ts", import.meta.url), "utf8");
+  const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } });
+  const spawnCalls = [];
+  const fakePty = { onData() {}, onExit() {}, write() {}, resize() {}, kill() {} };
+  const fakeRequire = (id) => {
+    if (id === "node-pty") return { spawn: (...args) => { spawnCalls.push(args); return fakePty; } };
+    if (id === "./paths") return paths;
+    return require(id);
+  };
+  const envWithLocale = { ...process.env, LANG: "zh_CN.UTF-8" };
+  const exports = {};
+  runInNewContext(outputText, { exports, process: { ...process, env: envWithLocale, once() {}, platform: process.platform }, require: fakeRequire, setTimeout, clearTimeout, console });
+  exports.createTerminal(process.cwd(), 80, 24);
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0][2].env.LANG, "zh_CN.UTF-8");
+});
+
 test("native PTY starts after install and repeated creation reuses the same workspace process", (t) => {
   const id = createTerminal(process.cwd(), 80, 24);
   t.after(() => killTerminal(id));

--- a/lib/terminal-manager.test.mjs
+++ b/lib/terminal-manager.test.mjs
@@ -50,7 +50,7 @@ test("shell environment defaults to UTF-8 locale when the host has none", async 
   assert.equal(spawnCalls[0][2].env.LANG, "C.UTF-8");
 });
 
-test("shell environment preserves an explicit user locale", async () => {
+test("shell environment preserves a case-insensitive Windows locale", async () => {
   const require = createRequire(import.meta.url);
   const paths = await jiti.import("./paths.ts");
   const source = readFileSync(new URL("./terminal-manager.ts", import.meta.url), "utf8");
@@ -62,12 +62,21 @@ test("shell environment preserves an explicit user locale", async () => {
     if (id === "./paths") return paths;
     return require(id);
   };
-  const envWithLocale = { ...process.env, LANG: "zh_CN.UTF-8" };
+  const rawEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => !["lang", "lc_all", "lc_ctype"].includes(key.toLowerCase())));
+  rawEnv.lang = "zh_CN.UTF-8";
+  const envWithLocale = new Proxy(rawEnv, {
+    get(target, key) {
+      if (typeof key !== "string") return Reflect.get(target, key);
+      const match = Object.keys(target).find((candidate) => candidate.toLowerCase() === key.toLowerCase());
+      return match ? target[match] : undefined;
+    },
+  });
   const exports = {};
   runInNewContext(outputText, { exports, process: { ...process, env: envWithLocale, once() {}, platform: process.platform }, require: fakeRequire, setTimeout, clearTimeout, console });
   exports.createTerminal(process.cwd(), 80, 24);
   assert.equal(spawnCalls.length, 1);
-  assert.equal(spawnCalls[0][2].env.LANG, "zh_CN.UTF-8");
+  assert.equal(spawnCalls[0][2].env.lang, "zh_CN.UTF-8");
+  assert.equal("LANG" in spawnCalls[0][2].env, false);
 });
 
 test("native PTY starts after install and repeated creation reuses the same workspace process", (t) => {

--- a/lib/terminal-manager.ts
+++ b/lib/terminal-manager.ts
@@ -51,7 +51,7 @@ function shellEnvironment(): Record<string, string> {
   env.COLORTERM = "truecolor";
   // Windows shells (Git Bash / MSYS2, cmd, PowerShell) otherwise inherit the
   // system ANSI codepage (e.g. GBK on zh-CN) and mangle non-ASCII filenames.
-  if (!env.LANG && !env.LC_ALL && !env.LC_CTYPE) env.LANG = "C.UTF-8";
+  if (!process.env.LANG && !process.env.LC_ALL && !process.env.LC_CTYPE) env.LANG = "C.UTF-8";
   return env;
 }
 

--- a/lib/terminal-manager.ts
+++ b/lib/terminal-manager.ts
@@ -49,6 +49,9 @@ function shellEnvironment(): Record<string, string> {
   }
   env.TERM = "xterm-256color";
   env.COLORTERM = "truecolor";
+  // Windows shells (Git Bash / MSYS2, cmd, PowerShell) otherwise inherit the
+  // system ANSI codepage (e.g. GBK on zh-CN) and mangle non-ASCII filenames.
+  if (!env.LANG && !env.LC_ALL && !env.LC_CTYPE) env.LANG = "C.UTF-8";
   return env;
 }
 


### PR DESCRIPTION
## Problem

On Windows the spawned shell inherited the system ANSI codepage (GBK on zh-CN hosts). Non-ASCII filenames were emitted in GBK and only some bytes happened to decode as valid UTF-8, so a subset of CJK characters rendered while the rest showed as tofu or `$'\xxx'` octal escapes.

Closes #750

## Fix

Set `LANG=C.UTF-8` when the host has no explicit locale, preserving user-supplied `LANG`/`LC_ALL`/`LC_CTYPE`.

The SSE → xterm.js pipeline is already UTF-8 end to end (`TextEncoder` + `terminal.write(string)`); the only gap was the shell process locale.

## Tests

Two new cases in `lib/terminal-manager.test.mjs`:
- no host locale → `LANG=C.UTF-8` is injected
- explicit `LANG=zh_CN.UTF-8` → preserved unchanged

All 8 tests in the file pass.
