### PR TITLE
docs(cli): document SKIP_VERSION_CHECK and IDLE_TIMEOUT_MS in --help

### DIFF
--- a/bin/pi-web-options.js
+++ b/bin/pi-web-options.js
@@ -46,6 +46,8 @@ Environment:
   PI_WEB_NO_OPEN             Set to 1/true/yes/on to disable browser open
   PI_WEB_PASSWORD            Enable HTTP Basic Auth (username is always "pi")
   PI_WEB_ALLOWED_HOSTS       Extra exact proxy/custom hostnames, comma-separated
+  PI_WEB_SKIP_VERSION_CHECK  Set to 1 to disable Pi Web update checks
+  PI_WEB_IDLE_TIMEOUT_MS     Session idle timeout in ms (0 disables; default 600000)
 `;
 }
 

--- a/lib/pi-web-options.test.mjs
+++ b/lib/pi-web-options.test.mjs
@@ -24,6 +24,8 @@ test("supports --help and -h without starting the server", () => {
   assert.match(getHelpText(), /--port/);
   assert.match(getHelpText(), /--hostname/);
   assert.match(getHelpText(), /--no-open/);
+  assert.match(getHelpText(), /PI_WEB_SKIP_VERSION_CHECK/);
+  assert.match(getHelpText(), /PI_WEB_IDLE_TIMEOUT_MS/);
 });
 
 test("rejects unknown options with a help hint", () => {


### PR DESCRIPTION
README lists PI_WEB_SKIP_VERSION_CHECK and PI_WEB_IDLE_TIMEOUT_MS, but pi-web --help omitted them.
Add both to the Environment section and cover them in the help test.
