### PR TITLE
docs(i18n): use npm test in verification steps

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -157,9 +157,7 @@ Run the following commands from the repository root:
 ```bash
 node_modules/.bin/tsc --noEmit
 npm run lint
-node_modules/.bin/jiti lib/i18n/registry.test.mjs
-node_modules/.bin/jiti lib/i18n/format.test.mjs
-node --test lib/*.test.mjs
+npm test
 ```
 
 Do not run `next build` during normal development. See the repository


### PR DESCRIPTION
The i18n guide told contributors to run bare node --test lib/*.test.mjs, which misses nested tests and can fail on .ts imports.
Point verification at npm test like the rest of the repo.
