### PR TITLE
ci: pin Node.js to 22.19.0 to match engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.19.0
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.19.0
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium


### PR DESCRIPTION
CI used node-version 22, which can install an older 22.x than package.json engines (>=22.19.0).
Pin both jobs to 22.19.0.
