### PR TITLE
fix: hide leftover enabledModels warnings when other models still match

### DIFF
--- a/lib/model-scope.test.mjs
+++ b/lib/model-scope.test.mjs
@@ -108,12 +108,15 @@ test("leaves models without a pinned thinking level unpinned", async () => {
   assert.deepEqual(result.thinkingLevelPins, { "anthropic/claude-opus-5": "high" });
 });
 
-test("reports patterns that match nothing but keeps the models that matched", async () => {
-  const result = await resolveVisibleModels(runtime, ["anthropic/claude-opus-5", "ghost-gateway/*"]);
+test("keeps models that matched and stays quiet about leftover unmatched globs", async () => {
+  const result = await resolveVisibleModels(runtime, [
+    "anthropic/claude-opus-5",
+    "retired-provider/old-model-*",
+    "ghost-gateway/*",
+  ]);
 
   assert.deepEqual(refs(result), ["anthropic/claude-opus-5"]);
-  assert.equal(result.warnings.length, 1);
-  assert.match(result.warnings[0], /ghost-gateway\/\*/);
+  assert.deepEqual(result.warnings, []);
 });
 
 test("falls back to all available models when nothing matches at all", async () => {

--- a/lib/model-scope.ts
+++ b/lib/model-scope.ts
@@ -125,7 +125,13 @@ export async function resolveVisibleModels(
     getAvailable: async () => available,
   } as ModelRuntime;
   const { scopedModels, diagnostics } = await resolveModelScopeWithDiagnostics(cleaned, snapshotRuntime);
-  const warnings = diagnostics.map((diagnostic) => diagnostic.message);
+  // A leftover glob after a model was removed is not a chat-level problem when
+  // other enabledModels entries still matched. Keep no-match warnings only for
+  // a total miss, where the UI falls back to every available model and the user
+  // needs to know the scope did not apply.
+  const warnings = diagnostics
+    .filter((diagnostic) => diagnostic.code !== "no-match" || scopedModels.length === 0)
+    .map((diagnostic) => diagnostic.message);
   if (scopedModels.length === 0) {
     return {
       visible: available,


### PR DESCRIPTION
## Problem

After a configured model is removed (or a provider stops exposing it), leftover globs in `enabledModels` no longer match anything. The composer then shows this banner on **every** session — including new chats and sessions that never used that model:

> **Model scope warning**
> No models match pattern "provider/retired-model-*"

`enabledModels` is a global filter. The remaining patterns still resolve a usable model list, so the banner is leftover settings noise, not a problem with the current session.

## Solution

`resolveVisibleModels()` already falls back to every available model when **no** pattern matches. Keep `no-match` diagnostics only in that total-miss case, where the selector silently widening is surprising.

When at least one pattern still matches, drop sibling `no-match` warnings. Other diagnostics (for example an invalid thinking-level suffix) are unchanged.

## Tests

- Updated `lib/model-scope.test.mjs`: leftover globs produce no warning while another pattern still matches.
- Existing total-miss case still expects a warning and a fallback to all models.

`node --experimental-strip-types --test lib/model-scope.test.mjs` passes.

---

## 问题

配置里的模型被删除后（或供应商不再提供该模型），`enabledModels` 里残留的 glob 匹配不到任何模型。输入框会在**每一个**会话上画出这条横幅——包括新对话，以及当前根本没用这个模型的会话：

> **模型范围警告**
> No models match pattern "provider/retired-model-*"

`enabledModels` 是全局过滤器。其余 pattern 仍然能解析出可用模型列表，所以这条横幅和当前任务无关，只是删模型后留下的配置噪音。

## 解决方案

`resolveVisibleModels()` 在**所有** pattern 都匹配失败时，本来就会回退到全部可用模型。只在这种「全部未命中、选择器被悄悄放大」的情况下保留 `no-match` 诊断。

只要还有至少一条 pattern 能匹配到模型，就丢弃旁边那些残留的 `no-match` 警告。其它诊断（例如非法 thinking-level 后缀）不变。

## 测试

- 更新 `lib/model-scope.test.mjs`：残留 glob 在其它 pattern 仍能命中时不再产生警告。
- 原有的「全部未命中」用例仍然要求给出警告，并回退到全部模型。

`node --experimental-strip-types --test lib/model-scope.test.mjs` 通过。