### PR TITLE
fix: keep @ file picker within the visible area above the composer

### DIFF
--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -301,6 +301,22 @@ test("renders the shared field model selector as a disabled gray control", () =>
 test("caps an upward menu to the visible space above its anchor", () => {
   assert.equal(getUpwardMenuMaxHeight(343, 36), 299);
   assert.equal(getUpwardMenuMaxHeight(40, 36), 0);
+  // Composer sitting under a 36px top bar with only ~160px of air: a 400px
+  // file list would paint through the bar and hide the leading matches.
+  assert.equal(getUpwardMenuMaxHeight(200, 36), 156);
+  assert.ok(getUpwardMenuMaxHeight(200, 36) < 400);
+});
+
+test("file mention menu applies the measured upward height cap", () => {
+  const source = readFileSync(new URL("./ChatInput.tsx", import.meta.url), "utf8");
+  const start = source.indexOf("{atMenuOpen && atQuery !== null && (() => {");
+  assert.notEqual(start, -1);
+  const block = source.slice(start, start + 4000);
+  assert.match(block, /ref=\{atMenuRef\}/);
+  assert.match(block, /min\(48vh, 400px, \$\{atMenuMaxHeight\}px\)/);
+  assert.match(block, /flexDirection: "column"/);
+  assert.match(block, /minHeight: 0/);
+  assert.equal(block.includes("maxHeight: \"min(48vh, 400px)\""), false);
 });
 
 test("compresses large images while preserving small images and GIFs", async () => {

--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -319,6 +319,15 @@ test("file mention menu applies the measured upward height cap", () => {
   assert.equal(block.includes("maxHeight: \"min(48vh, 400px)\""), false);
 });
 
+test("file mention menu remeasures when its layout container shifts the anchor", () => {
+  const source = readFileSync(new URL("./ChatInput.tsx", import.meta.url), "utf8");
+  const start = source.indexOf("function subscribeUpwardMenuMaxHeight");
+  assert.notEqual(start, -1);
+  const block = source.slice(start, start + 1800);
+  assert.match(block, /const layoutContainer = parent\?\.parentElement;/);
+  assert.match(block, /anchorObserver\?\.observe\(layoutContainer\)/);
+});
+
 test("compresses large images while preserving small images and GIFs", async () => {
   assert.equal(shouldCompressImageFile({ size: 1024 * 1024, type: "image/png" }), false);
   assert.equal(shouldCompressImageFile({ size: 1024 * 1024 + 1, type: "image/png" }), true);

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -166,10 +166,12 @@ function subscribeUpwardMenuMaxHeight(
 
   update();
   const parent = menu.parentElement;
+  const layoutContainer = parent?.parentElement;
   const anchorObserver = typeof ResizeObserver === "undefined" || !parent
     ? null
     : new ResizeObserver(scheduleUpdate);
   if (parent) anchorObserver?.observe(parent);
+  if (layoutContainer) anchorObserver?.observe(layoutContainer);
   const viewport = window.visualViewport;
   viewport?.addEventListener("resize", scheduleUpdate);
   viewport?.addEventListener("scroll", scheduleUpdate);

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -147,6 +147,45 @@ function getVisibleTopBoundary(element: HTMLElement): number {
   return visibleTop;
 }
 
+function subscribeUpwardMenuMaxHeight(
+  menu: HTMLElement,
+  onChange: (height: number) => void,
+): () => void {
+  let frameId: number | null = null;
+  const update = () => {
+    frameId = null;
+    onChange(getUpwardMenuMaxHeight(
+      menu.getBoundingClientRect().bottom,
+      getVisibleTopBoundary(menu),
+    ));
+  };
+  const scheduleUpdate = () => {
+    if (frameId !== null) cancelAnimationFrame(frameId);
+    frameId = requestAnimationFrame(update);
+  };
+
+  update();
+  const parent = menu.parentElement;
+  const anchorObserver = typeof ResizeObserver === "undefined" || !parent
+    ? null
+    : new ResizeObserver(scheduleUpdate);
+  if (parent) anchorObserver?.observe(parent);
+  const viewport = window.visualViewport;
+  viewport?.addEventListener("resize", scheduleUpdate);
+  viewport?.addEventListener("scroll", scheduleUpdate);
+  window.addEventListener("resize", scheduleUpdate);
+  window.addEventListener("scroll", scheduleUpdate, true);
+
+  return () => {
+    anchorObserver?.disconnect();
+    viewport?.removeEventListener("resize", scheduleUpdate);
+    viewport?.removeEventListener("scroll", scheduleUpdate);
+    window.removeEventListener("resize", scheduleUpdate);
+    window.removeEventListener("scroll", scheduleUpdate, true);
+    if (frameId !== null) cancelAnimationFrame(frameId);
+  };
+}
+
 const THINKING_LEVELS = ["auto", "off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const THINKING_LEVEL_DESC_KEYS: Record<typeof THINKING_LEVELS[number], string> = {
   auto: "chat.thinkingUseDefault", off: "chat.thinkingOff", minimal: "chat.thinkingMinimal", low: "chat.thinkingLow",
@@ -527,6 +566,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const [slashMenuMaxHeight, setSlashMenuMaxHeight] = useState<number | null>(null);
   const [atQuery, setAtQuery] = useState<AtQueryMatch | null>(null);
   const [atMenuOpen, setAtMenuOpen] = useState(false);
+  const [atMenuMaxHeight, setAtMenuMaxHeight] = useState<number | null>(null);
   const [atActiveIndex, setAtActiveIndex] = useState(0);
   const [imageWarningDismissed, setImageWarningDismissed] = useState(false);
   const [historyMenuOpen, setHistoryMenuOpen] = useState(false);
@@ -553,6 +593,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const slashCommandsRequestedRef = useRef(false);
   const slashMenuRef = useRef<HTMLDivElement>(null);
   const slashItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const atMenuRef = useRef<HTMLDivElement>(null);
   const atItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const historyItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const fileIndexMetaRef = useRef<{ cwd: string; fetchedAt: number } | null>(null);
@@ -1430,44 +1471,24 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       setSlashMenuMaxHeight(null);
       return;
     }
-
     const menu = slashMenuRef.current;
     if (!menu) return;
-
-    let frameId: number | null = null;
-    const update = () => {
-      frameId = null;
-      const nextHeight = getUpwardMenuMaxHeight(
-        menu.getBoundingClientRect().bottom,
-        getVisibleTopBoundary(menu),
-      );
+    return subscribeUpwardMenuMaxHeight(menu, (nextHeight) => {
       setSlashMenuMaxHeight((current) => current === nextHeight ? current : nextHeight);
-    };
-    const scheduleUpdate = () => {
-      if (frameId !== null) cancelAnimationFrame(frameId);
-      frameId = requestAnimationFrame(update);
-    };
-
-    update();
-    const anchorObserver = typeof ResizeObserver === "undefined" || !menu.parentElement
-      ? null
-      : new ResizeObserver(scheduleUpdate);
-    if (menu.parentElement) anchorObserver?.observe(menu.parentElement);
-    const viewport = window.visualViewport;
-    viewport?.addEventListener("resize", scheduleUpdate);
-    viewport?.addEventListener("scroll", scheduleUpdate);
-    window.addEventListener("resize", scheduleUpdate);
-    window.addEventListener("scroll", scheduleUpdate, true);
-
-    return () => {
-      anchorObserver?.disconnect();
-      viewport?.removeEventListener("resize", scheduleUpdate);
-      viewport?.removeEventListener("scroll", scheduleUpdate);
-      window.removeEventListener("resize", scheduleUpdate);
-      window.removeEventListener("scroll", scheduleUpdate, true);
-      if (frameId !== null) cancelAnimationFrame(frameId);
-    };
+    });
   }, [slashMenuOpen, slashQuery]);
+
+  useLayoutEffect(() => {
+    if (!atMenuOpen || atQuery === null) {
+      setAtMenuMaxHeight(null);
+      return;
+    }
+    const menu = atMenuRef.current;
+    if (!menu) return;
+    return subscribeUpwardMenuMaxHeight(menu, (nextHeight) => {
+      setAtMenuMaxHeight((current) => current === nextHeight ? current : nextHeight);
+    });
+  }, [atMenuOpen, atQuery]);
 
   // Build model options: prefer modelList (has provider info), fallback to modelNames
   const modelOptions: ModelSelectorOption[] = (() => {
@@ -1953,6 +1974,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
               : "";
             return (
               <div
+                ref={atMenuRef}
                 style={{
                   position: "absolute",
                   left: 0,
@@ -1964,7 +1986,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                   borderRadius: 8,
                   boxShadow: "0 -6px 20px rgba(0,0,0,0.12)",
                   overflow: "hidden",
-                  maxHeight: "min(48vh, 400px)",
+                  boxSizing: "border-box",
+                  display: "flex",
+                  flexDirection: "column",
+                  maxHeight: atMenuMaxHeight === null
+                    ? "min(48vh, 400px)"
+                    : `min(48vh, 400px, ${atMenuMaxHeight}px)`,
                 }}
               >
                 <div
@@ -1977,6 +2004,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                     gap: 8,
                     fontSize: 11,
                     color: "var(--text-dim)",
+                    flexShrink: 0,
                   }}
                 >
                   <span>
@@ -1986,7 +2014,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                   </span>
                    <span style={{ fontFamily: "var(--font-mono)" }}>{t("chat.tabEnter")}</span>
                 </div>
-                <div style={{ maxHeight: "calc(min(48vh, 400px) - 34px)", overflowY: "auto", padding: 4 }}>
+                <div style={{ flex: "1 1 auto", minHeight: 0, overflowY: "auto", padding: 4 }}>
                   {!indexLoading && atMatches.length === 0 ? (
                     <div style={{ padding: "6px 8px", fontSize: 12, color: "var(--text-dim)" }}>
                        {needsServerSearch && !serverResultInUse ? t("chat.searching") : t("chat.noMatchingFiles")}


### PR DESCRIPTION
## Problem

The slash command menu already measures remaining space above the composer and caps its height so it cannot paint through the session tab bar.

The `@` file picker still used a fixed `min(48vh, 400px)` cap. On a short-composer layout (new session, few messages) a long match list opened upward past that space. The leading files were still in the DOM, but they sat under the top bar — not visible and not clickable. The menu used `overflow: hidden` with a matching inner max-height, so scrolling could not bring those rows into view.

## Solution

Reuse the same measured upward cap the slash menu already uses:

1. Observe the menu's bottom edge against the nearest clipping ancestor (the chat panel under the tab bar).
2. Set `maxHeight` to that remaining space, still bounded by `min(48vh, 400px)`.
3. Make the match list a flex child (`minHeight: 0; overflowY: auto`) so shrinking the menu scrolls instead of clipping the top.

## Tests

- `getUpwardMenuMaxHeight(200, 36)` is 156px, which is below the old 400px cap — that is the overflow case.
- Source assertion: the `@` menu applies `atMenuMaxHeight` and no longer uses a bare `min(48vh, 400px)` max-height.
- Existing slash-menu height helper is unchanged.

`node --experimental-strip-types --test components/ChatInput.test.mjs` passes.

---

## 问题

斜杠命令菜单已经会测量输入框上方的剩余空间，把高度裁在顶栏以下。

`@` 文件列表还在用固定的 `min(48vh, 400px)`。新会话或消息很少时，输入框偏上，一长串匹配会往上撑出这块空间。排在前面的文件其实还在 DOM 里，但被顶栏挡住：看不见，也点不到。外层是 `overflow: hidden`，内层高度又和这个固定上限绑在一起，所以滚轮也滚不出被挡住的那几项。

## 解决方案

复用斜杠菜单已经在用的「向上可用高度」：

1. 用菜单底边对最近的裁剪祖先（顶栏下面的聊天区）做测量。
2. 把 `maxHeight` 收成这块剩余空间，同时仍不超过 `min(48vh, 400px)`。
3. 匹配列表改成 flex 子项（`minHeight: 0; overflowY: auto`），高度变矮时在内部滚动，而不是把顶部裁掉。

## 测试

- `getUpwardMenuMaxHeight(200, 36)` 得到 156px，小于原来的 400px 上限，对应「列表顶出顶栏」的情况。
- 源码断言：`@` 菜单使用 `atMenuMaxHeight`，不再写死单独的 `min(48vh, 400px)`。
- 斜杠菜单原有高度逻辑不变。

`node --experimental-strip-types --test components/ChatInput.test.mjs` 通过。
