### PR TITLE
fix: wrap keyboard selection in the @ file picker

### DIFF
--- a/components/ChatInput.test.mjs
+++ b/components/ChatInput.test.mjs
@@ -11,7 +11,7 @@ const jiti = createJiti(import.meta.url, {
 });
 const React = await jiti.import("react");
 const { renderToStaticMarkup } = await jiti.import("react-dom/server");
-const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, compressImageFile, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand, modelSupportsImageInput, replaceLinksWithMarkdown, shouldCompressImageFile } = await jiti.import("./ChatInput.tsx");
+const { ChatInput, ModelErrorBanner, ModelScopeWarningBanner, canClearBuiltinCommandInput, canRestoreUserMessage, canRunBuiltinSlashCommandWhileStreaming, compressImageFile, cycleListIndex, filterModelOptions, getUpwardMenuMaxHeight, getUserMessageText, getUserMessageDraftImages, isExactSlashCommand, modelSupportsImageInput, replaceLinksWithMarkdown, shouldCompressImageFile } = await jiti.import("./ChatInput.tsx");
 const { ModelSelector } = await jiti.import("./ModelSelector.tsx");
 const { clearDraft, getDraft, mergeRestoredSubmissionDraft, mergeRestoredSubmissionText, rekeyDraft, setDraft } = await jiti.import("@/lib/draft-store.ts");
 const { I18nProvider } = await jiti.import("@/hooks/useI18n");
@@ -97,6 +97,66 @@ test("follow-up shortcuts preserve newline, IME, mobile and completion behavior"
     });
     assert.equal(action, expected, name);
   }
+});
+
+test("file mention arrows wrap around the match list", () => {
+  const source = ts.createSourceFile("ChatInput.tsx", readFileSync(new URL("./ChatInput.tsx", import.meta.url), "utf8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  function findHandler(node) {
+    if (ts.isVariableDeclaration(node) && node.name.getText(source) === "handleKeyDown") {
+      return node.initializer.arguments[0];
+    }
+    return ts.forEachChild(node, findHandler);
+  }
+  const script = new Script(ts.transpileModule(findHandler(source).getText(source), {
+    compilerOptions: { target: ts.ScriptTarget.ES2020 },
+  }).outputText);
+
+  function move(key, atActiveIndex, length) {
+    let next = null;
+    const handler = script.runInNewContext({
+      Date: { now: () => 1000 },
+      COMPOSITION_END_ENTER_GRACE_MS: 100,
+      isMobile: false, isStreaming: false,
+      isComposingRef: { current: false }, lastCompositionEndAtRef: { current: 0 },
+      historyMenuOpen: false, inputHistory: [], historyActiveIndex: 0,
+      slashMenuOpen: false, slashQuery: null, displayedSlashCommands: [], slashActiveIndex: 0,
+      atMenuOpen: true, atQuery: {}, atMatches: Array.from({ length }, () => ({})), atActiveIndex,
+      onSteer() {}, onFollowUp() {},
+      sendQueued() {}, handleSend() {},
+      applySlashCommand() {},
+      isExactSlashCommand() { return false; }, value: "@file",
+      setSlashMenuOpen() {}, setAtMenuOpen() {},
+      applyAtCompletion() {},
+      applyHistoryInput() {},
+      cycleListIndex,
+      setAtActiveIndex(update) {
+        next = typeof update === "function" ? update(atActiveIndex) : update;
+      },
+    });
+    handler({
+      key, shiftKey: false, altKey: false, ctrlKey: false, metaKey: false,
+      nativeEvent: { isComposing: false, keyCode: 0 },
+      preventDefault() {},
+    });
+    return next;
+  }
+
+  assert.equal(move("ArrowDown", 0, 3), 1);
+  assert.equal(move("ArrowDown", 2, 3), 0);
+  assert.equal(move("ArrowUp", 0, 3), 2);
+  assert.equal(move("ArrowUp", 1, 3), 0);
+  assert.equal(move("ArrowDown", 0, 1), 0);
+  assert.equal(move("ArrowDown", 0, 0), 0);
+});
+
+test("cycleListIndex wraps in both directions", () => {
+  assert.equal(cycleListIndex(0, 3, 1), 1);
+  assert.equal(cycleListIndex(2, 3, 1), 0);
+  assert.equal(cycleListIndex(0, 3, -1), 2);
+  assert.equal(cycleListIndex(1, 3, -1), 0);
+  assert.equal(cycleListIndex(0, 1, 1), 0);
+  assert.equal(cycleListIndex(4, 0, 1), 0);
+  assert.equal(cycleListIndex(-1, 4, 1), 0);
 });
 
 test("shows the follow-up shortcut in the button tooltip", () => {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -108,6 +108,11 @@ export function getUpwardMenuMaxHeight(menuBottom: number, visibleTop: number, g
   return Math.max(0, Math.floor(menuBottom - visibleTop - gap));
 }
 
+export function cycleListIndex(index: number, length: number, delta: number): number {
+  if (length <= 0) return 0;
+  return ((index + delta) % length + length) % length;
+}
+
 export function replaceLinksWithMarkdown(
   text: string,
   links: Iterable<{ label: string; href: string; occurrence: number }>,
@@ -1269,12 +1274,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
       if (atMenuOpen && atQuery !== null && !isComposing) {
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          setAtActiveIndex((i) => Math.min(Math.max(0, atMatches.length - 1), i + 1));
+          setAtActiveIndex((i) => cycleListIndex(i, atMatches.length, 1));
           return;
         }
         if (e.key === "ArrowUp") {
           e.preventDefault();
-          setAtActiveIndex((i) => Math.max(0, i - 1));
+          setAtActiveIndex((i) => cycleListIndex(i, atMatches.length, -1));
           return;
         }
         if (e.key === "Escape") {


### PR DESCRIPTION
## Problem

ArrowDown on the `@` file picker clamps at the last match. Once the highlight is on the bottom row, another Down does nothing, so you cannot wrap back to the first file. ArrowUp has the same clamp at the top.

The list is already scrollable and already calls `scrollIntoView` on the active row. The missing piece is cycling the index.

## Solution

Wrap the active index in both directions:

- Down on the last row → first row
- Up on the first row → last row
- Empty list stays at 0

Existing `scrollIntoView({ block: "nearest" })` then brings the opposite end into the visible list.

## Tests

- Handler-level: Down from the last of 3 matches goes to 0; Up from 0 goes to 2.
- `cycleListIndex` unit cases for both directions, a single-item list, and an empty list.

`node --experimental-strip-types --test components/ChatInput.test.mjs` passes.

---

## 问题

`@` 文件列表里按 ↓ 到最后一项会被夹住。高亮已经在最后一行时，再按 ↓ 没有反应，没法回到第一项。↑ 在第一项同样被夹住。

列表本身可以滚动，高亮行也已经会 `scrollIntoView`。缺的只是下标循环。

## 解决方案

两个方向都循环高亮下标：

- 最后一项再按 ↓ → 第一项
- 第一项再按 ↑ → 最后一项
- 空列表保持 0

现有的 `scrollIntoView({ block: "nearest" })` 会把另一端滚进可见区域。

## 测试

- 按键处理：3 条匹配时，最后一项再 ↓ 得到 0；第 0 项再 ↑ 得到 2。
- `cycleListIndex` 覆盖双向循环、只有一项、空列表。

`node --experimental-strip-types --test components/ChatInput.test.mjs` 通过。
