### PR TITLE
Make the session list and file explorer split resizable

### DIFF
--- a/components/SessionSidebar.explorer-split.test.mjs
+++ b/components/SessionSidebar.explorer-split.test.mjs
@@ -8,6 +8,10 @@ const hook = await readFile(new URL("../hooks/useResizablePanel.ts", import.meta
 test("the explorer split reuses the shared panel resizer", () => {
   assert.match(source, /useResizablePanel\(\{[\s\S]*?cssVariable: "--explorer-height"[\s\S]*?growthDirection: "up"[\s\S]*?storageKey: "pi-explorer-height"/);
   assert.match(source, /\{\.\.\.explorerResizer\.separatorProps\}/);
+  // The ceiling is the space the list and explorer share, not the whole sidebar:
+  // the header above the list is fixed, so counting it would let the explorer overflow.
+  assert.match(source, /const listHeight = listScrollRef\.current\?\.getBoundingClientRect\(\)\.height \?\? 0;/);
+  assert.match(source, /Math\.floor\(listHeight \+ explorerHeight\) - SESSION_LIST_MIN_HEIGHT/);
   // The list yields the remaining space, so both panels keep a usable minimum.
   assert.match(source, /height: explorerOpen \? "var\(--explorer-height\)" : undefined/);
   assert.match(source, /flex: "1 1 0", overflowY: "auto", padding: "0", minHeight: SESSION_LIST_MIN_HEIGHT/);

--- a/components/SessionSidebar.explorer-split.test.mjs
+++ b/components/SessionSidebar.explorer-split.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./SessionSidebar.tsx", import.meta.url), "utf8");
+const hook = await readFile(new URL("../hooks/useResizablePanel.ts", import.meta.url), "utf8");
+
+test("the explorer split reuses the shared panel resizer", () => {
+  assert.match(source, /useResizablePanel\(\{[\s\S]*?cssVariable: "--explorer-height"[\s\S]*?growthDirection: "up"[\s\S]*?storageKey: "pi-explorer-height"/);
+  assert.match(source, /\{\.\.\.explorerResizer\.separatorProps\}/);
+  // The list yields the remaining space, so both panels keep a usable minimum.
+  assert.match(source, /height: explorerOpen \? "var\(--explorer-height\)" : undefined/);
+  assert.match(source, /flex: "1 1 0", overflowY: "auto", padding: "0", minHeight: SESSION_LIST_MIN_HEIGHT/);
+});
+
+test("the resizer drives either axis from one implementation", () => {
+  assert.match(hook, /const vertical = growthDirection === "up" \|\| growthDirection === "down"/);
+  assert.match(hook, /startPosition: vertical \? event\.clientY : event\.clientX/);
+  assert.match(hook, /document\.body\.style\.cursor = vertical \? "row-resize" : "col-resize"/);
+  assert.match(hook, /"aria-orientation": vertical \? \("horizontal" as const\) : \("vertical" as const\)/);
+  // Horizontal callers keep their original keys and direction.
+  assert.match(hook, /growthDirection === "right" \|\| growthDirection === "down" \? 1 : -1/);
+  assert.match(hook, /growthDirection === "right" \? "ArrowRight"/);
+});

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, type CSSProperties, type MutableRefObject, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, type CSSProperties, type ReactNode } from "react";
 import type { SessionInfo } from "@/lib/types";
 import { listSessionFamilies } from "@/lib/session-family";
 import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
@@ -407,7 +407,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const wtNewInputRef = useRef<HTMLInputElement>(null);
   const [explorerOpen, setExplorerOpen] = useState(true);
   const explorerHeightRef = useRef(EXPLORER_DEFAULT_HEIGHT);
-  const sidebarBodyRef = useRef<HTMLDivElement>(null);
+  const explorerPanelRef = useRef<HTMLDivElement>(null);
   const [explorerKey, setExplorerKey] = useState(0);
   const [explorerUploadBusy, setExplorerUploadBusy] = useState(false);
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
@@ -513,13 +513,13 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     setExplorerOpen(loadExplorerOpen());
   }, []);
 
-  const getExplorerMaxHeight = useCallback(
-    () => Math.max(
-      EXPLORER_MIN_HEIGHT,
-      (sidebarBodyRef.current?.getBoundingClientRect().height ?? 0) - SESSION_LIST_MIN_HEIGHT,
-    ),
-    [],
-  );
+  // Only the list and the explorer share the resizable space; the header above
+  // the list keeps its height, so measure those two rather than the sidebar.
+  const getExplorerMaxHeight = useCallback(() => {
+    const listHeight = listScrollRef.current?.getBoundingClientRect().height ?? 0;
+    const explorerHeight = explorerPanelRef.current?.getBoundingClientRect().height ?? explorerHeightRef.current;
+    return Math.max(EXPLORER_MIN_HEIGHT, Math.floor(listHeight + explorerHeight) - SESSION_LIST_MIN_HEIGHT);
+  }, []);
   const explorerResizer = useResizablePanel({
     ariaLabel: t("layout.resizeExplorer"),
     cssVariable: "--explorer-height",
@@ -1043,10 +1043,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
     <div
       // The explorer panel only exists once a project is open, so the resized
       // height lives on the sidebar itself and is inherited by the panel.
-      ref={(node) => {
-        sidebarBodyRef.current = node;
-        (explorerResizer.panelRef as MutableRefObject<HTMLDivElement | null>).current = node;
-      }}
+      ref={explorerResizer.panelRef}
       style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}
     >
       {customPathOpen && (
@@ -1773,6 +1770,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       {/* File Explorer section */}
       {(selectedCwdProp || selectedCwd) && (
         <div
+          ref={explorerPanelRef}
           style={{
             borderTop: "1px solid var(--border)",
             display: "flex",

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef, type CSSProperties, type MutableRefObject, type ReactNode } from "react";
 import type { SessionInfo } from "@/lib/types";
 import { listSessionFamilies } from "@/lib/session-family";
 import { loadExplorerOpen, saveExplorerOpen } from "@/lib/file-explorer-state";
@@ -10,6 +10,7 @@ import { getProjectActivity, getRecentProjects, sessionsForProject } from "@/lib
 import { workspaceKeyOf } from "@/lib/workspace-memory";
 import { formatRelativeTime } from "@/lib/i18n/format";
 import { useI18n } from "@/hooks/useI18n";
+import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { DirectoryPicker } from "./DirectoryPicker";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
 import { SessionSearch } from "./SessionSearch";
@@ -17,6 +18,11 @@ import { SessionSearch } from "./SessionSearch";
 // Fixed row height for the session list. SessionItem renders at exactly this
 // height, so the list can be windowed (only the visible slice is mounted).
 const SESSION_LIST_ITEM_HEIGHT = 54;
+// The split keeps a few session rows and a usable file tree visible at any sidebar height.
+const SESSION_LIST_MIN_HEIGHT = 80;
+const EXPLORER_MIN_HEIGHT = 120;
+const EXPLORER_MAX_HEIGHT = 2000;
+const EXPLORER_DEFAULT_HEIGHT = 260;
 
 export function getSessionListIndices(count: number, scrollTop: number, viewportHeight: number, focusedIndex = -1): number[] {
   const overscan = 8;
@@ -400,6 +406,8 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const wtDropdownRef = useRef<HTMLDivElement>(null);
   const wtNewInputRef = useRef<HTMLInputElement>(null);
   const [explorerOpen, setExplorerOpen] = useState(true);
+  const explorerHeightRef = useRef(EXPLORER_DEFAULT_HEIGHT);
+  const sidebarBodyRef = useRef<HTMLDivElement>(null);
   const [explorerKey, setExplorerKey] = useState(0);
   const [explorerUploadBusy, setExplorerUploadBusy] = useState(false);
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
@@ -504,6 +512,25 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   useEffect(() => {
     setExplorerOpen(loadExplorerOpen());
   }, []);
+
+  const getExplorerMaxHeight = useCallback(
+    () => Math.max(
+      EXPLORER_MIN_HEIGHT,
+      (sidebarBodyRef.current?.getBoundingClientRect().height ?? 0) - SESSION_LIST_MIN_HEIGHT,
+    ),
+    [],
+  );
+  const explorerResizer = useResizablePanel({
+    ariaLabel: t("layout.resizeExplorer"),
+    cssVariable: "--explorer-height",
+    defaultWidth: EXPLORER_DEFAULT_HEIGHT,
+    getMaxWidth: getExplorerMaxHeight,
+    growthDirection: "up",
+    maxWidth: EXPLORER_MAX_HEIGHT,
+    minWidth: EXPLORER_MIN_HEIGHT,
+    storageKey: "pi-explorer-height",
+    widthRef: explorerHeightRef,
+  });
 
   // Persist unread markers so they survive a browser refresh before the user
   // has actually opened the completed session.
@@ -1013,7 +1040,15 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   );
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+    <div
+      // The explorer panel only exists once a project is open, so the resized
+      // height lives on the sidebar itself and is inherited by the panel.
+      ref={(node) => {
+        sidebarBodyRef.current = node;
+        (explorerResizer.panelRef as MutableRefObject<HTMLDivElement | null>).current = node;
+      }}
+      style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}
+    >
       {customPathOpen && (
         <DirectoryPicker
           initialPath={customPathValue}
@@ -1672,12 +1707,12 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         )}
       </div>
 
-      {/* Session list */}
+      {/* Session list; the explorer keeps its own height and this takes the rest. */}
       <SessionSearch open={sessionSearchOpen} query={sessionSearchQuery} refreshKey={sessionListVersion} selectedSessionId={selectedSessionId} onSelectSession={handleSelectSessionFromList}>
       <div
         ref={listScrollRef}
         onScroll={handleListScroll}
-        style={{ flex: explorerOpen && (selectedCwdProp || selectedCwd) ? "1 1 0" : "1 1 auto", overflowY: "auto", padding: "0", minHeight: 80 }}
+        style={{ flex: "1 1 0", overflowY: "auto", padding: "0", minHeight: SESSION_LIST_MIN_HEIGHT }}
       >
         {loading && (
           <div style={{ padding: "16px 14px", color: "var(--text-muted)", fontSize: 12 }}>
@@ -1742,11 +1777,24 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
             borderTop: "1px solid var(--border)",
             display: "flex",
             flexDirection: "column",
-            flex: explorerOpen ? "1 1 0" : "0 0 auto",
+            flex: "0 0 auto",
+            height: explorerOpen ? "var(--explorer-height)" : undefined,
             minHeight: 0,
             overflow: "hidden",
           }}
         >
+          {explorerOpen && (
+            <div
+              {...explorerResizer.separatorProps}
+              title={`${t("layout.resizeExplorer")}: ${t("layout.resizeHint")}`}
+              style={{
+                height: 7, flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center",
+                cursor: "row-resize", touchAction: "none", outline: "none",
+              }}
+            >
+              <span style={{ width: 28, height: 2, borderRadius: 2, background: explorerResizer.isResizing ? "var(--text-muted)" : "var(--border)" }} />
+            </div>
+          )}
           <div style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
             <button
               onClick={() => setExplorerOpen((open) => {

--- a/hooks/useResizablePanel.ts
+++ b/hooks/useResizablePanel.ts
@@ -13,20 +13,21 @@ import { clampPanelWidth } from "@/lib/panel-layout";
 
 interface DragState {
   pointerId: number;
-  startX: number;
+  startPosition: number;
   startWidth: number;
   target: HTMLDivElement;
   previousCursor: string;
   previousUserSelect: string;
 }
 
+/** "width" below means the resized extent: horizontal for left/right, vertical for up/down. */
 interface UseResizablePanelOptions {
   ariaLabel: string;
   cssVariable: `--${string}`;
   defaultWidth: number;
   getDefaultWidth?: () => number;
   getMaxWidth: () => number;
-  growthDirection: "left" | "right";
+  growthDirection: "left" | "right" | "up" | "down";
   maxWidth: number;
   minWidth: number;
   storageKey: string;
@@ -70,6 +71,7 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
     storageKey,
     widthRef,
   } = options;
+  const vertical = growthDirection === "up" || growthDirection === "down";
   const panelRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<DragState | null>(null);
   const restoredRef = useRef(false);
@@ -138,16 +140,16 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
     target.setPointerCapture(event.pointerId);
     dragRef.current = {
       pointerId: event.pointerId,
-      startX: event.clientX,
+      startPosition: vertical ? event.clientY : event.clientX,
       startWidth: widthRef.current,
       target,
       previousCursor: document.body.style.cursor,
       previousUserSelect: document.body.style.userSelect,
     };
-    document.body.style.cursor = "col-resize";
+    document.body.style.cursor = vertical ? "row-resize" : "col-resize";
     document.body.style.userSelect = "none";
     setIsResizing(true);
-  }, [finishResize, widthRef]);
+  }, [finishResize, vertical, widthRef]);
 
   const onPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
@@ -158,12 +160,13 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
     }
     event.preventDefault();
 
-    const direction = growthDirection === "right" ? 1 : -1;
-    const nextWidth = clampWidth(drag.startWidth + ((event.clientX - drag.startX) * direction));
+    const direction = growthDirection === "right" || growthDirection === "down" ? 1 : -1;
+    const position = vertical ? event.clientY : event.clientX;
+    const nextWidth = clampWidth(drag.startWidth + ((position - drag.startPosition) * direction));
     applyLiveWidth(nextWidth);
     event.currentTarget.setAttribute("aria-valuenow", String(nextWidth));
     event.currentTarget.setAttribute("aria-valuetext", `${nextWidth} px`);
-  }, [applyLiveWidth, clampWidth, finishResize, growthDirection]);
+  }, [applyLiveWidth, clampWidth, finishResize, growthDirection, vertical]);
 
   const onPointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
     finishResize(event.pointerId);
@@ -188,8 +191,12 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 32 : 12;
-    const growKey = growthDirection === "right" ? "ArrowRight" : "ArrowLeft";
-    const shrinkKey = growthDirection === "right" ? "ArrowLeft" : "ArrowRight";
+    const growKey = growthDirection === "right" ? "ArrowRight"
+      : growthDirection === "left" ? "ArrowLeft"
+      : growthDirection === "down" ? "ArrowDown" : "ArrowUp";
+    const shrinkKey = growthDirection === "right" ? "ArrowLeft"
+      : growthDirection === "left" ? "ArrowRight"
+      : growthDirection === "down" ? "ArrowUp" : "ArrowDown";
 
     if (event.key === growKey) {
       event.preventDefault();
@@ -265,7 +272,8 @@ export function useResizablePanel(options: UseResizablePanelOptions) {
     resetWidth,
     separatorProps: {
       "aria-label": ariaLabel,
-      "aria-orientation": "vertical" as const,
+      // The separator's own orientation is perpendicular to the axis it resizes.
+      "aria-orientation": vertical ? ("horizontal" as const) : ("vertical" as const),
       "aria-valuemax": mounted ? effectiveMaxWidth() : maxWidth,
       "aria-valuemin": minWidth,
       "aria-valuenow": width,

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -176,6 +176,7 @@ export const enLocale: LocalePlugin = {
     "files.noneOpen": "No file open",
     "layout.resizeSidebar": "Resize sidebar",
     "layout.resizeFilePanel": "Resize file panel",
+    "layout.resizeExplorer": "Resize file explorer",
     "layout.resizeHint": "Drag to resize. Double-click or press Enter to reset.",
     "sidebar.new": "New",
     "sidebar.newSessionTitle": "New session in {path}",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -175,6 +175,7 @@ export const zhCNLocale: LocalePlugin = {
     "files.showPanel": "显示文件面板",
     "files.noneOpen": "没有打开的文件",
     "layout.resizeSidebar": "调整侧边栏宽度",
+    "layout.resizeExplorer": "调整文件浏览器高度",
     "layout.resizeFilePanel": "调整文件面板宽度",
     "layout.resizeHint": "拖动调整宽度。双击或按 Enter 恢复默认值。",
     "sidebar.new": "新建",

--- a/lib/i18n/messages/zh-TW.ts
+++ b/lib/i18n/messages/zh-TW.ts
@@ -175,6 +175,7 @@ export const zhTWLocale: LocalePlugin = {
     "files.showPanel": "顯示檔案面板",
     "files.noneOpen": "沒有開啟的檔案",
     "layout.resizeSidebar": "調整側邊欄寬度",
+    "layout.resizeExplorer": "調整檔案瀏覽器高度",
     "layout.resizeFilePanel": "調整檔案面板寬度",
     "layout.resizeHint": "拖曳以調整寬度。按兩下或按 Enter 鍵即可重設。",
     "sidebar.new": "新增",


### PR DESCRIPTION
## Problem

The sidebar splits its height evenly between the session list and the file explorer whenever the explorer is open. The split cannot be changed, so the balance is wrong for most of the work in the sidebar: browsing a deep file tree leaves half the sidebar showing sessions, and scanning a long session list leaves half of it showing a handful of files.

The sidebar width and the file panel width are both resizable, so this is the one panel boundary that cannot be adjusted.

## Change

The boundary between the session list and the explorer becomes a draggable separator, using the same `useResizablePanel` hook that already drives the sidebar and file panel. That means the same drag, `Home`/`End`, `Enter` to reset, shift-step, pointer capture, blur cancellation, and width reclamping on window resize, plus persistence under `pi-explorer-height`.

To reuse the hook, `growthDirection` accepts `up` and `down` in addition to `left` and `right`. The vertical axis reads `clientY`, uses `row-resize`, reports `aria-orientation="horizontal"` for the separator, and drives the arrow keys of that axis. Horizontal callers are unchanged.

The explorer keeps its own height and the session list takes the remaining space, with both sides floored so neither collapses. The height is applied through a CSS variable on the sidebar rather than the explorer element, because the explorer only mounts once a project is open.

## Tests

- `components/SessionSidebar.explorer-split.test.mjs` — the sidebar drives the shared resizer, and the hook handles both axes without changing horizontal behaviour.
- Full `npm test` (952), `tsc --noEmit`, `eslint`, and `next build` pass.
- Verified in a production build with a real browser: dragging the separator moves the boundary (explorer 260 → 340, list 590 → 510), the value persists and is restored when the project is reopened, `Enter` resets to the default, arrow keys step it, and the existing sidebar width resizer still works (260 → 330).
