### PR TITLE
Show the session message count in the header

### DIFF
--- a/components/AppShell.session-stats.test.mjs
+++ b/components/AppShell.session-stats.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./AppShell.tsx", import.meta.url), "utf8");
+const stats = source.slice(source.indexOf("const renderSessionStatsButton"));
+
+test("reports the session message count alongside tokens and context", () => {
+  assert.match(stats, /const totalMessages = sessionStats\?\.totalMessages \?\? 0;/);
+  // Hidden for an empty session, so a new chat keeps the same header as before.
+  assert.match(stats, /\{totalMessages > 0 && \(\s*<span/);
+  assert.match(stats, /\{formatCompact\(totalMessages\)\}/);
+  assert.match(stats, /if \(totalMessages > 0\) tooltipParts\.push\(`messages: \$\{totalMessages\.toLocaleString\(locale\)\}`\)/);
+});
+
+test("warns before a session grows large enough to slow switching", () => {
+  assert.match(stats, /totalMessages > 5000\s*\?\s*"#ef4444"/);
+  assert.match(stats, /totalMessages > 2000\s*\?\s*"rgba\(234,179,8,0\.95\)"/);
+  // Same thresholds and colours the context gauge already uses.
+  assert.match(stats, /percent > 90\) contextColor = "#ef4444"/);
+  assert.match(stats, /percent > 70\) contextColor = "rgba\(234,179,8,0\.95\)"/);
+});

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1649,6 +1649,15 @@ export function AppShell() {
         : String(value);
     const costText = cost > 0 ? (cost >= 0.01 ? `$${cost.toFixed(2)}` : `<$0.01`) : null;
 
+    // Session files grow with the message count, and past a few thousand messages
+    // opening or switching to the session is visibly slower.
+    const totalMessages = sessionStats?.totalMessages ?? 0;
+    const messageCountColor = totalMessages > 5000
+      ? "#ef4444"
+      : totalMessages > 2000
+        ? "rgba(234,179,8,0.95)"
+        : "var(--text-muted)";
+
     let contextColor = "var(--text-muted)";
     let desktopContextText: string | null = null;
     let mobileContextText: string | null = null;
@@ -1663,6 +1672,7 @@ export function AppShell() {
     }
 
     const tooltipParts: string[] = [];
+    if (totalMessages > 0) tooltipParts.push(`messages: ${totalMessages.toLocaleString(locale)}`);
     if (tokens) {
       tooltipParts.push(`in: ${tokens.input.toLocaleString(locale)}`);
       tooltipParts.push(`out: ${tokens.output.toLocaleString(locale)}`);
@@ -1757,6 +1767,14 @@ export function AppShell() {
           </>
         ) : (
           <>
+            {totalMessages > 0 && (
+              <span style={{ display: "flex", alignItems: "center", gap: 4, color: messageCountColor }}>
+                <svg width="12" height="12" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M1 2.5 Q1 1 2.5 1 L7.5 1 Q9 1 9 2.5 L9 5 Q9 6.5 7.5 6.5 L4 6.5 L2 8.5 L2 6.5 Q1 6.5 1 5 Z" />
+                </svg>
+                {formatCompact(totalMessages)}
+              </span>
+            )}
             {tokens && tokens.input > 0 && (
               <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
                 <svg width="12" height="12" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Problem

The header reports tokens, cost, and context usage, but not how many messages the session holds. That number is the one that predicts a specific problem: the session file grows with it, and past a few thousand messages opening or switching to that session is visibly slower. Today the only way to see it is the sidebar row, which is not visible while reading the conversation.

## Change

`renderSessionStatsButton` gains a message count next to the existing token and context readouts, using the same compact formatting (`1.2k`, `3.4M`) and the tooltip already assembled there.

It reuses the thresholds and colours of the context gauge: muted by default, amber past 2,000 messages, red past 5,000. Nothing is shown for an empty session, so a new chat keeps exactly the header it has today. The mobile toolbar is unchanged.

## Tests

- `components/AppShell.session-stats.test.mjs` — the count renders only for a non-empty session, joins the tooltip, and shares the warning thresholds with the context gauge.
- Full `npm test` (952), `tsc --noEmit`, `eslint`, and `next build` pass.
- Verified in a production build with a real browser: after one exchange the header shows the count beside the token and context readouts, and the tooltip reads `messages: 2  |  in: 7,511  |  ...`.
