### PR TITLE
Generate session titles from a lightweight text transcript

### DIFF
--- a/lib/session-title.test.mjs
+++ b/lib/session-title.test.mjs
@@ -6,11 +6,10 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
 const {
-  appendTitleRequestToTrailingUser,
   buildSessionTitleAgentOptions,
+  buildTitleTranscript,
   generateSessionTitle,
   parseGeneratedSessionTitle,
-  sanitizeTitleMessages,
 } = await jiti.import("./session-title.ts");
 
 function assistantMessage(text) {
@@ -21,17 +20,48 @@ function assistantMessage(text) {
     provider: "test",
     model: "test-model",
     usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
+      input: 12, output: 4, cacheRead: 0, cacheWrite: 0, totalTokens: 16,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     stopReason: "stop",
     timestamp: Date.now(),
   };
 }
+
+function replyWith(message, observe = () => {}) {
+  return (_model, context) => {
+    observe(context);
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => {
+      stream.push(message.stopReason === "error"
+        ? { type: "error", reason: "error", error: message }
+        : { type: "done", reason: "stop", message });
+    });
+    return stream;
+  };
+}
+
+function sourceAgent(messages) {
+  return {
+    state: {
+      systemPrompt: "SOURCE_SYSTEM_SENTINEL",
+      model: { provider: "test", id: "test-model" },
+      thinkingLevel: "high",
+      tools: [{
+        name: "read", label: "read", description: "TOOL_SCHEMA_SENTINEL",
+        parameters: { type: "object", properties: {} },
+        execute: async () => { throw new Error("Source tools must not run"); },
+      }],
+      messages,
+    },
+    waitForIdle: async () => {},
+    convertToLlm,
+    streamFunction: replyWith(assistantMessage("Fix session titles")),
+    sessionId: "source-session-id",
+  };
+}
+
+const user = (content) => ({ role: "user", content, timestamp: 1 });
 
 test("cleans common session title response wrappers", () => {
   assert.equal(parseGeneratedSessionTitle("标题：修复 SSE 重连。"), "修复 SSE 重连");
@@ -43,242 +73,109 @@ test("rejects responses without a usable title", () => {
   assert.throws(() => parseGeneratedSessionTitle("```\n---\n```"), /usable session title/);
 });
 
-test("folds the title request into a trailing user message without mutating the source", () => {
-  const source = [
-    { role: "assistant", content: [], timestamp: 1 },
-    { role: "user", content: [{ type: "text", text: "Fix the running-session race" }], timestamp: 2 },
-  ];
-
-  const prepared = appendTitleRequestToTrailingUser(source);
-
-  assert.deepEqual(prepared.map((message) => message.role), ["assistant", "user"]);
-  assert.match(prepared[1].content.at(-1).text, /Create a concise title/);
-  assert.equal(source[1].content.length, 1);
-  assert.notEqual(prepared[1], source[1]);
-});
-
-test("leaves a completed conversation unchanged before adding the title turn", () => {
-  const source = [
-    { role: "user", content: "Fix it", timestamp: 1 },
-    { role: "assistant", content: [], timestamp: 2 },
-  ];
-
-  assert.equal(appendTitleRequestToTrailingUser(source), source);
+test("sends one text-only title request without source context or source mutation", async () => {
+  const source = sourceAgent([
+    user([{ type: "text", text: "Fix session titles" }, { type: "image", data: "IMAGE_SENTINEL", mimeType: "image/png" }]),
+    { ...assistantMessage("Investigating"), content: [
+      { type: "text", text: "Investigating" },
+      { type: "thinking", thinking: "THINKING_SENTINEL" },
+      { type: "toolCall", id: "call-1", name: "read", arguments: { path: "TOOL_ARGUMENT_SENTINEL" } },
+      { type: "toolCall", id: "incomplete", name: "read", arguments: {} },
+    ] },
+    { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [{ type: "text", text: "TOOL_RESULT_SENTINEL".repeat(10000) }], isError: false, timestamp: 2 },
+    user("Keep the new goal in the title"),
+  ]);
+  const before = structuredClone(source.state.messages);
+  let seen;
+  source.streamFunction = replyWith(assistantMessage("Fix session titles"), (context) => { seen = context; });
+  const result = await generateSessionTitle({ agent: source });
+  assert.equal(result.title, "Fix session titles");
+  assert.deepEqual(result.usage, { input: 12, output: 4, cacheRead: 0, cacheWrite: 0, total: 16 });
+  assert.deepEqual(seen.messages.map((message) => message.role), ["user"]);
+  assert.equal(seen.tools?.length ?? 0, 0);
+  const payload = JSON.stringify(seen);
+  assert.match(payload, /User: Fix session titles/);
+  assert.match(payload, /Assistant: Investigating/);
+  assert.match(payload, /Keep the new goal in the title/);
+  assert.match(payload, /Create a concise title/);
+  assert.doesNotMatch(payload, /SENTINEL/);
+  assert.deepEqual(source.state.messages, before);
 });
 
 test("waits for the source reply before sending the title prompt", async () => {
-  let sourceReplyFinished = false;
-  let providerRoles;
-  const sourceAgent = {
-    state: {
-      systemPrompt: "system",
-      model: { provider: "test", id: "test-model" },
-      thinkingLevel: "off",
-      tools: [],
-      messages: [{ role: "user", content: "Implement auto name", timestamp: 1 }],
-    },
-    waitForIdle: async () => {
-      sourceAgent.state.messages.push(assistantMessage("The implementation is complete"));
-      sourceReplyFinished = true;
-    },
-    convertToLlm: (messages) => messages,
-    streamFunction: (_model, context) => {
-      assert.equal(sourceReplyFinished, true);
-      providerRoles = context.messages.map((message) => message.role);
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        stream.push({
-          type: "done",
-          reason: "stop",
-          message: assistantMessage("Wait for Complete Agent Reply"),
-        });
-      });
-      return stream;
-    },
-    sessionId: "source-session-id",
+  const source = sourceAgent([user("Implement auto name")]);
+  let finished = false;
+  source.waitForIdle = async () => {
+    source.state.messages.push(assistantMessage("The implementation is complete"));
+    finished = true;
   };
-
-  const result = await generateSessionTitle({ agent: sourceAgent });
-
-  assert.equal(result.title, "Wait for Complete Agent Reply");
-  assert.deepEqual(providerRoles, ["user", "assistant", "user"]);
+  source.streamFunction = replyWith(assistantMessage("Wait for Complete Agent Reply"), (context) => {
+    assert.equal(finished, true);
+    assert.deepEqual(context.messages.map((message) => message.role), ["user"]);
+    assert.match(JSON.stringify(context.messages), /The implementation is complete/);
+  });
+  assert.equal((await generateSessionTitle({ agent: source })).title, "Wait for Complete Agent Reply");
 });
 
 test("generates a title when compaction removed all literal user messages", async () => {
-  let providerMessages;
-  const sourceAgent = {
-    state: {
-      systemPrompt: "system",
-      model: { provider: "test", id: "test-model" },
-      thinkingLevel: "off",
-      tools: [],
-      messages: [
-        {
-          role: "compactionSummary",
-          summary: "The user asked to fix title generation after compaction.",
-          tokensBefore: 100_000,
-          timestamp: 1,
-        },
-        assistantMessage("The implementation is complete"),
-      ],
-    },
-    waitForIdle: async () => {},
-    convertToLlm,
-    streamFunction: (_model, context) => {
-      providerMessages = context.messages;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        stream.push({
-          type: "done",
-          reason: "stop",
-          message: assistantMessage("Title Generation After Compaction"),
-        });
-      });
-      return stream;
-    },
-    sessionId: "source-session-id",
-  };
-
-  const result = await generateSessionTitle({ agent: sourceAgent });
-
-  assert.equal(result.title, "Title Generation After Compaction");
-  assert.deepEqual(providerMessages.map((message) => message.role), ["user", "assistant", "user"]);
-  assert.match(providerMessages[0].content[0].text, /fix title generation after compaction/);
+  const source = sourceAgent([{
+    role: "compactionSummary", summary: "Fix title generation after compaction.", tokensBefore: 100000, timestamp: 1,
+  }, assistantMessage("The implementation is complete")]);
+  source.streamFunction = replyWith(assistantMessage("Title Generation After Compaction"), (context) => {
+    assert.deepEqual(context.messages.map((message) => message.role), ["user"]);
+    assert.match(JSON.stringify(context.messages), /Earlier summary.*Fix title generation after compaction/);
+  });
+  assert.equal((await generateSessionTitle({ agent: source })).title, "Title Generation After Compaction");
 });
 
-test("temporary title agent preserves the provider-facing prefix", async () => {
-  const model = { provider: "test", id: "cached-model" };
-  const messages = [{ role: "user", content: [{ type: "text", text: "Fix it" }] }];
-  const originalExecute = async () => ({ content: [], details: {} });
-  const tools = [{
-    name: "read",
-    label: "read",
-    description: "Read a file",
-    parameters: { type: "object", properties: {} },
-    execute: originalExecute,
-  }];
-  const convertToLlm = (value) => value;
-  const transformContext = async (value) => value;
-  const streamFunction = () => { throw new Error("not called"); };
-  const source = {
-    state: {
-      systemPrompt: "cached system prompt",
-      model,
-      thinkingLevel: "high",
-      tools,
-      messages,
-    },
-    convertToLlm,
-    transformContext,
-    streamFunction,
-    steeringMode: "one-at-a-time",
-    followUpMode: "one-at-a-time",
-    sessionId: "source-session-id",
-    transport: "sse",
-    toolExecution: "parallel",
-  };
-
+test("temporary title agent changes context, not model or transport settings", () => {
+  const source = sourceAgent([user("Fix it")]);
+  source.getApiKey = async () => "test-key";
+  source.transformContext = async (messages) => messages;
+  source.transport = "sse";
   const options = buildSessionTitleAgentOptions(source);
-
-  assert.equal(options.initialState.systemPrompt, source.state.systemPrompt);
-  assert.equal(options.initialState.model, model);
+  assert.notEqual(options.initialState.systemPrompt, source.state.systemPrompt);
+  assert.equal(options.initialState.model, source.state.model);
   assert.equal(options.initialState.thinkingLevel, "high");
-  assert.equal(options.initialState.messages, messages);
+  assert.deepEqual(options.initialState.tools, []);
+  assert.deepEqual(options.initialState.messages, []);
   assert.equal(options.convertToLlm, convertToLlm);
-  assert.equal(options.transformContext, transformContext);
-  assert.equal(options.streamFn, streamFunction);
-  assert.equal(options.sessionId, "source-session-id");
-  const withoutExecute = (tool) => Object.fromEntries(
-    Object.entries(tool).filter(([key]) => key !== "execute"),
-  );
-  assert.deepEqual(
-    options.initialState.tools.map(withoutExecute),
-    tools.map(withoutExecute),
-  );
-  assert.notEqual(options.initialState.tools[0].execute, originalExecute);
-  await assert.rejects(
-    options.initialState.tools[0].execute("call", {}, undefined, undefined),
-    /cannot be executed/,
-  );
+  assert.equal(options.transformContext, source.transformContext);
+  assert.equal(options.streamFn, source.streamFunction);
+  assert.equal(options.getApiKey, source.getApiKey);
+  assert.equal(options.transport, "sse");
+  assert.equal(options.sessionId, source.sessionId);
 });
 
-test("keeps only tool calls with adjacent matching results", () => {
+test("caps text by Unicode code points while retaining user turns and the last nonempty reply", () => {
   const messages = [
-    { role: "user", content: "inspect both files", timestamp: 1 },
-    {
-      ...assistantMessage("Inspecting files"),
-      content: [
-        { type: "text", text: "Inspecting files" },
-        { type: "toolCall", id: "call-complete", name: "read", arguments: { path: "a.txt" } },
-        { type: "toolCall", id: "call-incomplete", name: "read", arguments: { path: "b.txt" } },
-      ],
-      stopReason: "toolUse",
-    },
-    {
-      role: "toolResult",
-      toolCallId: "call-complete",
-      toolName: "read",
-      content: [{ type: "text", text: "file contents" }],
-      isError: false,
-      timestamp: 2,
-    },
+    user("😀".repeat(801)),
+    assistantMessage("a".repeat(301)),
+    user("A mid-session change of goal"),
+    { role: "compactionSummary", summary: "s".repeat(601), tokensBefore: 1000, timestamp: 1 },
+    assistantMessage("z".repeat(601)),
+    assistantMessage("  "),
+    { role: "toolResult", content: [{ type: "text", text: "ignored" }] },
+    user("The final user request"),
   ];
-
-  const sanitized = sanitizeTitleMessages(messages);
-
-  assert.deepEqual(
-    sanitized[1].content.filter((block) => block.type === "toolCall").map((block) => block.id),
-    ["call-complete"],
-  );
-  assert.equal(sanitized[2], messages[2]);
-  assert.equal(messages[1].content.length, 3);
+  assert.equal(buildTitleTranscript(messages), [
+    `User: ${"😀".repeat(800)}…`,
+    `Assistant: ${"a".repeat(300)}…`,
+    "User: A mid-session change of goal",
+    `[Earlier summary] ${"s".repeat(600)}…`,
+    `Assistant: ${"z".repeat(600)}…`,
+    "User: The final user request",
+  ].join("\n\n"));
+  assert.equal(buildTitleTranscript([user("x".repeat(800))]), `User: ${"x".repeat(800)}`);
+  assert.equal(buildTitleTranscript([user([]), assistantMessage("")]), "");
 });
 
-test("removes incomplete tool calls before invoking the title provider", async () => {
-  let providerMessages;
-  const sourceAgent = {
-    state: {
-      systemPrompt: "system",
-      model: { provider: "test", id: "test-model" },
-      thinkingLevel: "off",
-      tools: [],
-      messages: [
-        { role: "user", content: "run a command", timestamp: 1 },
-        {
-          ...assistantMessage(""),
-          content: [{
-            type: "toolCall",
-            id: "call-incomplete",
-            name: "bash",
-            arguments: { command: "sleep 10" },
-          }],
-          stopReason: "toolUse",
-        },
-      ],
-    },
-    waitForIdle: async () => {},
-    convertToLlm: (messages) => messages,
-    streamFunction: (_model, context) => {
-      providerMessages = context.messages.map((message) => ({
-        role: message.role,
-        content: message.content,
-      }));
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        stream.push({
-          type: "done",
-          reason: "stop",
-          message: assistantMessage("Sanitized Tool Call History"),
-        });
-      });
-      return stream;
-    },
-    sessionId: "source-session-id",
-  };
+test("rejects a session without a user message or summary", async () => {
+  await assert.rejects(generateSessionTitle({ agent: sourceAgent([]) }), /no user messages/);
+});
 
-  const result = await generateSessionTitle({ agent: sourceAgent });
-
-  assert.equal(result.title, "Sanitized Tool Call History");
-  assert.deepEqual(providerMessages.map((message) => message.role), ["user"]);
-  assert.match(providerMessages[0].content, /Create a concise title/);
+test("propagates title provider errors", async () => {
+  const source = sourceAgent([user("Fix it")]);
+  source.streamFunction = replyWith({ ...assistantMessage(""), stopReason: "error", errorMessage: "Provider unavailable" });
+  await assert.rejects(generateSessionTitle({ agent: source }), /Provider unavailable/);
 });

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -2,12 +2,20 @@ import {
   Agent,
   type AgentMessage,
   type AgentOptions,
-  type AgentTool,
 } from "@earendil-works/pi-agent-core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 
 const TITLE_TIMEOUT_MS = 90_000;
 const MAX_TITLE_LENGTH = 80;
+
+// These are per-message code-point caps, not a total transcript budget.
+// Retain every user turn so middle-of-session changes of goal remain visible.
+const USER_CHARS = 800;
+const ASSISTANT_CHARS = 300;
+const LAST_ASSISTANT_CHARS = 600;
+const SUMMARY_CHARS = 600;
+const TITLE_SYSTEM_PROMPT =
+  "You name chat sessions from a transcript. Reply with the title only.";
 
 const TITLE_PROMPT = `Create a concise title for this session based on the conversation above.
 
@@ -29,29 +37,16 @@ export interface GeneratedSessionTitle {
   };
 }
 
-function createShadowTools(tools: AgentTool[]): AgentTool[] {
-  return tools.map((tool) => ({
-    ...tool,
-    execute: async () => {
-      throw new Error("Tools cannot be executed while generating a session title");
-    },
-  }));
-}
-
-/**
- * Build a temporary Agent configuration whose provider-facing prefix matches
- * the source Agent. Tool implementations are replaced without changing their
- * names, descriptions, or schemas, so a naming run cannot mutate the project.
- */
+/** Build a temporary Agent with a separate title prompt and no tools or history. */
 export function buildSessionTitleAgentOptions(source: Agent): AgentOptions {
   const state = source.state;
   return {
     initialState: {
-      systemPrompt: state.systemPrompt,
+      systemPrompt: TITLE_SYSTEM_PROMPT,
       model: state.model,
       thinkingLevel: state.thinkingLevel,
-      tools: createShadowTools(state.tools),
-      messages: state.messages,
+      tools: [],
+      messages: [],
     },
     convertToLlm: source.convertToLlm,
     transformContext: source.transformContext,
@@ -69,23 +64,44 @@ export function buildSessionTitleAgentOptions(source: Agent): AgentOptions {
   };
 }
 
-/**
- * A running source session usually ends in the user message currently being
- * answered. Fold the title request into a copy of that message so the title
- * request does not send two consecutive user messages to the provider.
- */
-export function appendTitleRequestToTrailingUser(messages: AgentMessage[]): AgentMessage[] {
-  const lastMessage = messages.at(-1);
-  if (!lastMessage || lastMessage.role !== "user") return messages;
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is { type: "text"; text: string } =>
+      typeof block === "object" && block !== null && block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("\n");
+}
 
-  const content = typeof lastMessage.content === "string"
-    ? `${lastMessage.content}\n\n${TITLE_PROMPT}`
-    : [...lastMessage.content, { type: "text" as const, text: TITLE_PROMPT }];
+function clip(text: string, max: number): string {
+  const characters = Array.from(text);
+  return characters.length <= max ? text : `${characters.slice(0, max).join("")}…`;
+}
 
-  return [
-    ...messages.slice(0, -1),
-    { ...lastMessage, content },
-  ];
+/** Flatten user/assistant text and compaction summaries without tool traffic. */
+export function buildTitleTranscript(messages: AgentMessage[]): string {
+  let lastAssistant: AgentMessage | undefined;
+  for (const message of messages) {
+    if (message.role === "assistant" && textOf(message.content).trim()) lastAssistant = message;
+  }
+
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.role === "compactionSummary") {
+      lines.push(`[Earlier summary] ${clip(message.summary.trim(), SUMMARY_CHARS)}`);
+      continue;
+    }
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    const text = textOf(message.content).trim();
+    if (!text) continue;
+    if (message.role === "user") {
+      lines.push(`User: ${clip(text, USER_CHARS)}`);
+    } else {
+      lines.push(`Assistant: ${clip(text, message === lastAssistant ? LAST_ASSISTANT_CHARS : ASSISTANT_CHARS)}`);
+    }
+  }
+  return lines.join("\n\n");
 }
 
 function stripWrappingQuotes(value: string): string {
@@ -135,8 +151,8 @@ export function parseGeneratedSessionTitle(raw: string): string {
   return value;
 }
 
-function getAssistantResult(agent: Agent, historyLength: number): GeneratedSessionTitle {
-  const generatedMessages = agent.state.messages.slice(historyLength);
+function getAssistantResult(agent: Agent): GeneratedSessionTitle {
+  const generatedMessages = agent.state.messages;
   for (let i = generatedMessages.length - 1; i >= 0; i--) {
     const message = generatedMessages[i];
     if (message.role !== "assistant") continue;
@@ -165,72 +181,19 @@ function getAssistantResult(agent: Agent, historyLength: number): GeneratedSessi
   throw new Error("The model did not return a session title");
 }
 
-export function sanitizeTitleMessages(messages: AgentMessage[]): AgentMessage[] {
-  const sanitized: AgentMessage[] = [];
-  let expectedToolResultIds: Set<string> | undefined;
-
-  for (let index = 0; index < messages.length; index++) {
-    const message = messages[index];
-
-    if (message.role === "assistant") {
-      const followingToolResultIds = new Set<string>();
-      for (let resultIndex = index + 1; resultIndex < messages.length; resultIndex++) {
-        const resultMessage = messages[resultIndex];
-        if (resultMessage.role !== "toolResult") break;
-        followingToolResultIds.add(resultMessage.toolCallId);
-      }
-
-      expectedToolResultIds = new Set<string>();
-      const content = message.content.filter((block) => {
-        if (block.type !== "toolCall") return true;
-        if (!followingToolResultIds.has(block.id)) return false;
-        expectedToolResultIds!.add(block.id);
-        return true;
-      });
-
-      if (content.length > 0) {
-        sanitized.push({ ...message, content });
-      }
-      continue;
-    }
-
-    if (message.role === "toolResult") {
-      if (expectedToolResultIds?.delete(message.toolCallId)) {
-        sanitized.push(message);
-      }
-      continue;
-    }
-
-    expectedToolResultIds = undefined;
-    sanitized.push(message);
-  }
-
-  return sanitized;
-}
-
 export async function generateSessionTitle(source: AgentSession): Promise<GeneratedSessionTitle> {
   const sourceAgent = source.agent;
   await sourceAgent.waitForIdle();
 
-  const sanitizedMessages = sanitizeTitleMessages(sourceAgent.state.messages);
-  const historyLength = sanitizedMessages.length;
-  if (!sanitizedMessages.some(
+  const messages = sourceAgent.state.messages;
+  if (!messages.some(
     (message) => message.role === "user" || message.role === "compactionSummary",
   )) {
     throw new Error("The session has no user messages to name");
   }
 
-  const options = buildSessionTitleAgentOptions(sourceAgent);
-  options.initialState!.messages = sanitizedMessages;
-  const continuesFromTrailingUser = sanitizedMessages.at(-1)?.role === "user";
-  if (continuesFromTrailingUser) {
-    options.initialState!.messages = appendTitleRequestToTrailingUser(sanitizedMessages);
-  }
-
-  const temporaryAgent = new Agent(options);
-  const runPromise = continuesFromTrailingUser
-    ? temporaryAgent.continue()
-    : temporaryAgent.prompt(TITLE_PROMPT);
+  const temporaryAgent = new Agent(buildSessionTitleAgentOptions(sourceAgent));
+  const runPromise = temporaryAgent.prompt(`${buildTitleTranscript(messages)}\n\n${TITLE_PROMPT}`);
   let timeout: ReturnType<typeof setTimeout> | undefined;
 
   try {
@@ -251,5 +214,5 @@ export async function generateSessionTitle(source: AgentSession): Promise<Genera
     if (timeout) clearTimeout(timeout);
   }
 
-  return getAssistantResult(temporaryAgent, historyLength);
+  return getAssistantResult(temporaryAgent);
 }


### PR DESCRIPTION
## Problem

Generating a short session title currently replays the source system prompt, tool schemas, and conversation history, including tool results and reasoning. Tool-heavy sessions can therefore send substantially more context than is useful for naming.

## Change

The temporary title agent receives a short naming system prompt, no tools, and one user message containing a plain-text transcript followed by the existing title instructions. This transcript is extracted locally; there is no extra summarization-model call.

The transcript keeps messages in order and includes:

- Up to 800 Unicode code points from each nonempty user message.
- Up to 300 code points from each nonempty assistant text message, or 600 for the last nonempty assistant text message.
- Up to 600 code points from each compaction summary.

Tool calls, tool results, thinking blocks, images, and other message roles are omitted. All user turns with text remain represented, including changes of goal in the middle of a session. The obsolete shadow-tool, tool-pair sanitization, and trailing-user folding helpers are removed.

## Scope and relationship to #776

Related to #671. This PR is based directly on `main` and does not depend on #776 (dedicated title model selection). It changes the input, not the choice of model or thinking level. Both changes are complementary, but they touch the same implementation file and may need reconciliation when one lands.

The manual trigger, `waitForIdle()`, inherited model and thinking level, transport/credential hooks, 90-second generation timeout, title cleanup, usage reporting, and persistence route are unchanged. This PR does not add first-message automatic naming or any settings/UI changes.

## Trade-offs

The caps are heuristics, not a fixed total context or token budget: input still grows with the number of messages. Truncation can cut mid-sentence, and information present only in omitted tool/image content or after a cap is unavailable to the title model. The shorter prompt also stops deliberately matching the source conversation's cache prefix; this is not a claim of lower billed cost or latency for every provider/cache state. Custom conversion/context/payload hooks remain inherited as before.

## Validation

- The focused tests failed against the original implementation and now pass (9 tests).
- Provider-boundary tests use the real temporary Agent and SDK conversion with a synthetic streaming provider. They verify a single user request, absence of source-system/tool/image/thinking sentinels, source-message immutability, preserved model/transport choices, compaction-only history, unchanged idle waiting, Unicode caps and mid-session goals, usage reporting, and provider errors.
- Full `npm test`: 973 passed.
- TypeScript, ESLint, `git diff --check`, and production build passed.
- No live-provider quality/latency benchmark or browser end-to-end test was run for this isolated PR branch. No production session or settings were modified.
