### PR TITLE
fix: preserve the streaming partial when switching back to a running session

### DIFF
--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -533,3 +533,16 @@ test("keeps a detached viewport in place when streaming completes", () => {
   assert.doesNotMatch(scrollEffectSource, /\|\|/);
   assert.match(source, /addEventListener\("scroll", handleScrollPositionChange/);
 });
+
+test("mount restore resumes the stream instead of resetting a restored snapshot", () => {
+  const mountRestoreSource = source.slice(
+    source.indexOf("if (agentState.state?.isStreaming || agentState.state?.isPromptRunning) {"),
+    source.indexOf("if (agentState.state?.isBashRunning) {"),
+  );
+
+  // The mount restore runs after the event stream may already have restored
+  // the in-flight partial via its snapshot; a plain "start" would blank it.
+  assert.match(mountRestoreSource, /dispatch\(\{ type: "resume" \}\)/);
+  assert.doesNotMatch(mountRestoreSource, /dispatch\(\{ type: "start" \}\)/);
+  assert.match(mountRestoreSource, /void maintainEventsConnected\(session\.id\)/);
+});

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1923,7 +1923,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             agentRunningRef.current = true;
             setAgentRunning(true);
             setAgentPhase(agentState.state.isStreaming ? { kind: "waiting_model" } : { kind: "running_command" });
-            dispatch({ type: "start" });
+            // The event stream may have connected while this state fetch was in
+            // flight and already restored the in-flight partial via its
+            // snapshot; resuming keeps it instead of restarting from scratch.
+            dispatch({ type: "resume" });
             void maintainEventsConnected(session.id);
             if (!agentState.state.isStreaming && agentState.state.isPromptRunning) {
               void waitForPromptSettlement(session.id);

--- a/lib/streaming-message.test.mjs
+++ b/lib/streaming-message.test.mjs
@@ -177,3 +177,30 @@ test("normalizes tool calls in snapshots and clears on end", () => {
   }]);
   assert.strictEqual(streamReducer(state, { type: "end" }), INITIAL_STREAMING_STATE);
 });
+
+test("resume keeps a partial already restored by a reconnect snapshot", () => {
+  const restored = snapshot(INITIAL_STREAMING_STATE, assistant([
+    { type: "thinking", thinking: "Plan" },
+  ]));
+  const resumed = streamReducer(restored, { type: "resume" });
+
+  // Identity is preserved: the mount-restore path must not blank the chat.
+  assert.strictEqual(resumed, restored);
+  assert.equal(resumed.isStreaming, true);
+  assert.deepEqual(resumed.streamingMessage.content, [
+    { type: "thinking", thinking: "Plan" },
+  ]);
+
+  // Deltas keep accumulating onto the restored partial.
+  const continued = delta(resumed, { type: "thinking_delta", contentIndex: 0, delta: "ning" });
+  assert.deepEqual(continued.streamingMessage.content, [
+    { type: "thinking", thinking: "Planning" },
+  ]);
+});
+
+test("resume enters streaming state when nothing was restored yet", () => {
+  const resumed = streamReducer(INITIAL_STREAMING_STATE, { type: "resume" });
+
+  assert.equal(resumed.isStreaming, true);
+  assert.equal(resumed.streamingMessage, null);
+});

--- a/lib/streaming-message.ts
+++ b/lib/streaming-message.ts
@@ -15,6 +15,9 @@ export interface StreamingState {
 
 export type StreamAction =
   | { type: "start" }
+  // Server reports a live run (e.g. session mount): enter streaming state
+  // unless the event stream already restored a partial, which must survive.
+  | { type: "resume" }
   | { type: "snapshot"; message: AgentMessage }
   | { type: "delta"; event: ClientAssistantMessageEvent }
   | { type: "end" };
@@ -128,6 +131,12 @@ export function streamReducer(
   switch (action.type) {
     case "start":
       return { isStreaming: true, streamingMessage: null };
+    case "resume":
+      // The mount-restore path runs after the event stream may already have
+      // delivered a reconnect snapshot. Resetting here would blank the chat
+      // for the rest of the current message: later deltas no-op onto a null
+      // message while each one also clears the phase label.
+      return state.isStreaming ? state : { isStreaming: true, streamingMessage: null };
     case "snapshot": {
       const message = normalizeStreamingToolCalls(action.message);
       return message.role === "assistant"


### PR DESCRIPTION
## Problem

Switching away from a session whose model is still streaming and then switching back left the chat completely blank - no thinking text, no tool progress, and not even the phase label - until the current message finished.

## Root cause

Remounting ChatWindow for a still-running session raced two restore paths:

1. The SSE event stream reconnects and restores the in-flight partial from its snapshot (connected -> message_start). This is fast because the session is already alive server-side.
2. The mount effect's loadSession() resolves later (two sequential HTTP round trips: session file, then agent state) and unconditionally dispatched { type: "start" }, which resets streamingMessage to null and wipes the just-restored snapshot.

Every subsequent delta then no-oped in updateContentBlock (no baseline message) while each one also cleared the agent phase, so the UI showed nothing at all until the next message boundary.

## Fix

The mount restore now dispatches a reducer-owned "resume" action that enters streaming state without discarding a partial the event stream already restored. "start" keeps its reset semantics for genuinely new runs (send, agent_start). The partial is still owned by the single streamReducer - no state-mirroring refs.

## Tests

- lib/streaming-message.test.mjs: resume keeps a partial restored by a reconnect snapshot (identity preserved, deltas keep accumulating); resume enters streaming state when nothing was restored yet.
- hooks/useAgentSession.test.mjs: the mount restore dispatches resume, never start.

npm test (976 passing), npm run lint, and npx tsc --noEmit are green.

## Reproduction

1. Send a prompt that makes the model think/stream for a while.
2. Switch to another session, then switch back.
3. Before: blank until the next message boundary. After: the streaming bubble is restored immediately and keeps growing.