### PR TITLE
feat(pwa): serve the cached app shell when the network is unreachable

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,8 @@
 const CACHE_PREFIX = "pi-web";
 const CACHE_VERSION = new URL(self.location.href).searchParams.get("v") || "dev";
 const STATIC_CACHE = `${CACHE_PREFIX}-static-${CACHE_VERSION}`;
+const SHELL_CACHE = `${CACHE_PREFIX}-shell-${CACHE_VERSION}`;
+const CURRENT_CACHES = new Set([STATIC_CACHE, SHELL_CACHE]);
 const OFFLINE_URL = "/offline.html";
 const PRECACHE_URLS = [
   OFFLINE_URL,
@@ -9,15 +11,40 @@ const PRECACHE_URLS = [
   "/icons/icon-512.png",
   "/icons/apple-touch-icon.png",
 ];
+// A stalled network (reachable port, dead upstream) never rejects, so a plain
+// fetch().catch() would hang the navigation forever. Bound every network wait.
+const NAVIGATION_TIMEOUT_MS = 8000;
+const ASSET_TIMEOUT_MS = 8000;
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches
-      .open(STATIC_CACHE)
-      .then((cache) => cache.addAll(PRECACHE_URLS))
-      .then(() => self.skipWaiting()),
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      await cache.addAll(PRECACHE_URLS);
+      await primeShellCache();
+      await self.skipWaiting();
+    })(),
   );
 });
+
+/**
+ * Cache the app shell during install.
+ *
+ * The navigation that triggers the very first visit cannot be captured: the
+ * worker is not controlling the page yet, so the fetch handler never sees that
+ * response. Without priming the shell here, a user who installs the app and
+ * then goes offline would still fall back to offline.html on the next launch.
+ * A failed fetch (offline install) or a redirect to the login page simply
+ * leaves the shell cache empty instead of failing the install.
+ */
+async function primeShellCache() {
+  const request = new Request(new URL("/", self.location.origin));
+  const response = await fetchWithTimeout(request, NAVIGATION_TIMEOUT_MS).catch(() => null);
+  if (!response) return;
+  if (!isCacheableResponse(request, response) || !isHtml(response)) return;
+  const cache = await caches.open(SHELL_CACHE);
+  await cache.put(request, response);
+}
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
@@ -26,7 +53,7 @@ self.addEventListener("activate", (event) => {
       .then((keys) =>
         Promise.all(
           keys
-            .filter((key) => key.startsWith(`${CACHE_PREFIX}-`) && key !== STATIC_CACHE)
+            .filter((key) => key.startsWith(`${CACHE_PREFIX}-`) && !CURRENT_CACHES.has(key))
             .map((key) => caches.delete(key)),
         ),
       )
@@ -45,12 +72,7 @@ self.addEventListener("fetch", (event) => {
   if (url.pathname.startsWith("/api/") || url.pathname === "/sw.js") return;
 
   if (request.mode === "navigate") {
-    event.respondWith(
-      fetch(request).catch(async () => {
-        const fallback = await caches.match(OFFLINE_URL);
-        return fallback ?? Response.error();
-      }),
-    );
+    event.respondWith(handleNavigation(request));
     return;
   }
 
@@ -59,9 +81,121 @@ self.addEventListener("fetch", (event) => {
     PRECACHE_URLS.includes(url.pathname);
 
   if (isStaticAsset) {
-    event.respondWith(cacheFirst(request));
+    event.respondWith(networkFirst(request, STATIC_CACHE, ASSET_TIMEOUT_MS));
   }
 });
+
+/**
+ * Navigation keeps working offline by replaying the last shell document for
+ * this app. The client router reads the address bar itself, so serving the
+ * cached shell for any in-app URL still resolves the right session once the
+ * session list loads.
+ */
+async function handleNavigation(request) {
+  try {
+    const response = await fetchWithTimeout(request, NAVIGATION_TIMEOUT_MS);
+    if (isCacheableResponse(request, response) && isHtml(response)) {
+      const copy = response.clone();
+      void putAndTrim(SHELL_CACHE, request, copy);
+    }
+    return response;
+  } catch {
+    // Exact URL first, then any cached shell document, then offline.html, and
+    // finally a self-contained page so a blank screen is never the outcome.
+    const exact = await openAndMatch(SHELL_CACHE, request, { ignoreSearch: true });
+    if (exact) return exact;
+
+    const fallback = await cachedShellDocument();
+    if (fallback) return fallback;
+
+    const offline = await caches.match(OFFLINE_URL);
+    return offline ?? offlineFallbackResponse();
+  }
+}
+
+/** Guarantees readable output when neither a shell nor offline.html is cached. */
+function offlineFallbackResponse() {
+  return new Response(
+    "<!doctype html><meta charset=\"utf-8\">"
+    + "<meta name=viewport content=\"width=device-width,initial-scale=1\">"
+    + "<title>Pi Web is offline</title>"
+    + "<body style=\"margin:0;min-height:100dvh;display:grid;place-items:center;"
+    + "background:#1a1a1a;color:#e8e8e8;font-family:system-ui,sans-serif;text-align:center\">"
+    + "<div><h1 style=\"font-size:20px\">Pi Web is offline</h1>"
+    + "<p style=\"color:#9ca3af;font-size:14px\">Reconnect to the Pi Web server, then try again.</p>"
+    + "<button onclick=\"location.reload()\" style=\"margin-top:16px;padding:10px 18px;"
+    + "background:#242424;color:#e8e8e8;border:1px solid #3a3a3a;border-radius:6px;font:inherit;"
+    + "cursor:pointer\">Try again</button></div>",
+    { status: 503, headers: { "Content-Type": "text/html; charset=utf-8" } },
+  );
+}
+
+async function openAndMatch(cacheName, request, options) {
+  const cache = await caches.open(cacheName);
+  return cache.match(request, options);
+}
+
+async function cachedShellDocument() {
+  const cache = await caches.open(SHELL_CACHE);
+  const keys = await cache.keys();
+  // Prefer the root document; otherwise any cached HTML navigation.
+  const ordered = [
+    ...keys.filter((key) => new URL(key.url).pathname === "/"),
+    ...keys.filter((key) => new URL(key.url).pathname !== "/"),
+  ];
+  for (const key of ordered) {
+    const response = await cache.match(key);
+    if (response && isHtml(response)) return response;
+  }
+  return undefined;
+}
+
+function isHtml(response) {
+  return (response.headers.get("Content-Type") ?? "").toLowerCase().includes("text/html");
+}
+
+/**
+ * A redirect (e.g. the web-auth login page) must never be stored under the
+ * original URL: fetch follows redirects transparently, so the final body would
+ * be cached against a key the app later expects to hold its own document.
+ */
+function isCacheableResponse(request, response) {
+  return response.ok && response.type === "basic" && response.url === request.url;
+}
+
+async function networkFirst(request, cacheName, timeoutMs) {
+  try {
+    const response = await fetchWithTimeout(request, timeoutMs);
+    if (isCacheableResponse(request, response)) {
+      const copy = response.clone();
+      void putAndTrim(cacheName, request, copy);
+    }
+    return response;
+  } catch {
+    const cached = await openAndMatch(cacheName, request);
+    return cached ?? Response.error();
+  }
+}
+
+async function putAndTrim(cacheName, request, response) {
+  try {
+    const cache = await caches.open(cacheName);
+    await cache.put(request, response);
+  } catch {
+    // Storage pressure or a non-cacheable response must not break the fetch.
+  }
+}
+
+async function fetchWithTimeout(request, timeoutMs) {
+  if (!timeoutMs || !Number.isFinite(timeoutMs)) return fetch(request);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(request, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 self.addEventListener("push", (event) => {
   let payload = {};
@@ -128,16 +262,4 @@ async function focusOrOpenWindow(targetUrl) {
   }
 
   await self.clients.openWindow(targetUrl);
-}
-
-async function cacheFirst(request) {
-  const cached = await caches.match(request);
-  if (cached) return cached;
-
-  const response = await fetch(request);
-  if (response.ok && response.type === "basic") {
-    const cache = await caches.open(STATIC_CACHE);
-    await cache.put(request, response.clone());
-  }
-  return response;
 }

--- a/public/sw.test.mjs
+++ b/public/sw.test.mjs
@@ -9,6 +9,8 @@ globalThis.self = {
   },
   addEventListener: (type, listener) => listeners.set(type, listener),
   clients: null,
+  // Present on ServiceWorkerGlobalScope; called by install/activate.
+  skipWaiting: async () => {},
 };
 
 await import("./sw.js");
@@ -138,4 +140,167 @@ test("notification click opens a window and rejects cross-origin targets", async
   await event.pending;
 
   assert.deepEqual(opened, ["https://pi.test/"]);
+});
+
+// ---------------------------------------------------------------------------
+// Offline app shell
+// ---------------------------------------------------------------------------
+
+// Minimal Cache API stub: enough to exercise the navigation strategies.
+function installCacheStub() {
+  const stores = new Map();
+
+  const openStore = (name) => {
+    if (!stores.has(name)) {
+      const entries = new Map();
+      stores.set(name, {
+        entries,
+        put: async (request, response) => { entries.set(request.url, response); },
+        addAll: async (requests) => {
+          for (const request of requests) {
+            const url = typeof request === "string" ? request : request.url;
+            entries.set(url, new Response("", { status: 200 }));
+          }
+        },
+        match: async (request, options) => {
+          const key = typeof request === "string" ? request : request.url;
+          if (options?.ignoreSearch) {
+            const bare = key.split("?")[0];
+            for (const [url, response] of entries) {
+              if (url.split("?")[0] === bare) return response;
+            }
+            return undefined;
+          }
+          return entries.get(key);
+        },
+        keys: async () => [...entries.keys()].map((url) => ({ url })),
+        delete: async (key) => entries.delete(typeof key === "string" ? key : key.url),
+      });
+    }
+    return stores.get(name);
+  };
+
+  globalThis.caches = {
+    open: async (name) => openStore(name),
+    match: async (request) => {
+      for (const store of stores.values()) {
+        const found = await store.match(request);
+        if (found) return found;
+      }
+      return undefined;
+    },
+    keys: async () => [...stores.keys()],
+    delete: async (name) => stores.delete(name),
+    _stores: stores,
+  };
+
+  globalThis.fetch = async () => { throw new TypeError("no network in this test"); };
+
+  return { stores, openStore };
+}
+
+/** Build a same-origin response the way a real fetch would. */
+function basicResponse(body, url, headers = { "Content-Type": "text/html" }) {
+  const response = new Response(body, { status: 200, headers });
+  Object.defineProperty(response, "url", { value: url });
+  Object.defineProperty(response, "type", { value: "basic" });
+  return response;
+}
+
+function dispatchFetch(url, { mode = "cors" } = {}) {
+  let pending;
+  const request = new Request(url);
+  Object.defineProperty(request, "mode", { value: mode });
+  listeners.get("fetch")({
+    request,
+    respondWith: (promise) => { pending = promise; },
+  });
+  return pending;
+}
+
+function dispatchInstall() {
+  let pending;
+  listeners.get("install")({ waitUntil: (promise) => { pending = promise; } });
+  return pending;
+}
+
+test("navigation serves the cached shell when the network is unreachable", async () => {
+  installCacheStub();
+
+  globalThis.fetch = async (request) => basicResponse(
+    "<!doctype html><title>Pi Web</title>",
+    typeof request === "string" ? request : request.url,
+  );
+  const online = await dispatchFetch("https://pi.test/", { mode: "navigate" });
+  assert.match(await online.text(), /<title>Pi Web<\/title>/);
+  // Let the fire-and-forget cache write land.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  globalThis.fetch = async () => { throw new TypeError("offline"); };
+  const offline = await dispatchFetch("https://pi.test/", { mode: "navigate" });
+  const body = await offline.text();
+  assert.match(body, /<title>Pi Web<\/title>/, "the cached shell must be replayed");
+  assert.doesNotMatch(body, /is offline/, "the offline placeholder must not be used");
+});
+
+test("a navigation with a query string reuses the cached shell", async () => {
+  installCacheStub();
+
+  globalThis.fetch = async (request) => basicResponse(
+    "<!doctype html><title>Pi Web</title>",
+    typeof request === "string" ? request : request.url,
+  );
+  await dispatchFetch("https://pi.test/", { mode: "navigate" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  globalThis.fetch = async () => { throw new TypeError("offline"); };
+  const offline = await dispatchFetch("https://pi.test/?session=abc", { mode: "navigate" });
+  assert.match(await offline.text(), /<title>Pi Web<\/title>/);
+});
+
+test("install primes the shell cache so the first visit is already offline-capable", async () => {
+  const { openStore } = installCacheStub();
+  globalThis.fetch = async (request) => basicResponse(
+    "<!doctype html><title>Pi Web</title>",
+    typeof request === "string" ? request : request.url,
+  );
+  void openStore;
+
+  await dispatchInstall();
+
+  const shell = await caches.open("pi-web-shell-test").then((cache) => cache.keys());
+  assert.equal(shell.length, 1, "install must prime the shell cache");
+  assert.equal(shell[0].url, "https://pi.test/");
+});
+
+test("install survives an unreachable server", async () => {
+  installCacheStub();
+  globalThis.fetch = async () => { throw new TypeError("offline"); };
+
+  // Must not reject: an offline install still has to activate.
+  await dispatchInstall();
+
+  const shell = await caches.open("pi-web-shell-test").then((cache) => cache.keys());
+  assert.equal(shell.length, 0);
+});
+
+test("a redirected navigation is not stored as the app shell", async () => {
+  const { openStore } = installCacheStub();
+  // fetch follows redirects, so the login page arrives with a different URL.
+  globalThis.fetch = async () => basicResponse(
+    "<html>login</html>",
+    "https://pi.test/login",
+  );
+
+  await dispatchFetch("https://pi.test/", { mode: "navigate" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const shell = await openStore("pi-web-shell-test");
+  assert.equal(shell.entries.size, 0, "login HTML must not be cached as the shell");
+});
+
+test("api traffic is never intercepted", async () => {
+  installCacheStub();
+  const pending = dispatchFetch("https://pi.test/api/sessions");
+  assert.equal(pending, undefined, "the worker must leave /api/ untouched");
 });


### PR DESCRIPTION
## Summary

Reopening the app without a connection currently shows the `offline.html` placeholder, even though the service worker has already cached every static asset. Navigations are pure network-first with a single fallback to that placeholder, and the app shell document itself is never stored.

This caches the shell document and replays it offline, so the app boots from cache.

- cache the app shell document per navigation, then serve it when the network fails
- prime the shell cache during `install`
- bound navigation/asset fetches with an 8s timeout
- never store a redirect body under the requested URL
- `/api/` handling and the push handlers are untouched

## Why prime the shell cache in `install`

The navigation that registers the worker cannot be captured — the worker is not controlling the page yet, so its `fetch` handler never sees that response. Without priming, a user who opens the app once and then goes offline still lands on `offline.html` on the next launch. This is easy to miss when testing by loading the page twice.

Priming is best-effort: an unreachable server, a redirect to the login page, or a non-HTML response leaves the shell cache empty rather than failing the install.

## Why the timeout

A reachable port with a dead upstream (a stopped dev server behind a proxy, a tunnel that is up while the remote is down) never rejects. `fetch().catch()` therefore never runs, the navigation hangs, and the user gets a blank page instead of the offline fallback.

## Behavior

| URL | Online | Offline |
|---|---|---|
| `/` | network (cached as shell) | cached shell |
| `/?session=x` | network | cached shell |
| `/_next/static/*` | network, falls back to cache | cache |
| `/api/*` | network (unchanged) | network error (unchanged) |

Offline, the router reads the address bar itself, so serving the cached shell for any in-app URL still resolves the right session once data is available.

## Testing

```
node --experimental-strip-types --test public/sw.test.mjs   # 11 passed
env PI_CODING_AGENT_DIR=/tmp/pi-web-test-agent npm test     # 1026 passed
node_modules/.bin/tsc --noEmit
npm run lint
```

Six new tests cover offline shell replay, shell reuse across query strings, install priming, install against an unreachable server, redirect safety, and that `/api/` traffic stays untouched. The existing push and notification-click tests are unchanged.

## Scope

Deliberately limited to the shell. Caching session JSON for offline history is a larger behavioral change (it alters what `/api/` may serve from cache) and I would rather raise it separately if this direction looks right.

Related: #803 (conditional requests for `/api/sessions`) is independent — this PR is about working offline at all, that one is about not re-transferring unchanged data while online.
