### PR TITLE
Remember the selected thinking level for new sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ The last preset explicitly selected by the user is stored in browser `localStora
 ### Model defaults for new sessions
 `GET /api/models` returns `defaultModel` read from `~/.pi/agent/settings.json`. `ChatWindow` pre-selects this on mount for new sessions. Explicit browser model/thinking selections are applied atomically during AgentSession construction, then `lib/startup-preferences.ts` persists their effective values without replaying `set_model`/`set_thinking_level`; implicit `enabledModels` fallbacks and thinking pins are not persisted.
 
+The last explicit thinking selection (including `auto`) is stored in browser `localStorage` immediately. Fresh composers resolve a current explicit choice, a model-scope pin, then a compatible remembered choice. Unsupported remembered levels fall back without overwriting the preference; session creation asks Pi to clamp a quick send when the model list is still loading. Existing sessions restore their own thinking state.
+
 ### `enabledModels` scoping
 The `enabledModels` setting uses pi's `--models` syntax: minimatch globs against `provider/modelId` or a bare `modelId`, fuzzy matching for non-glob patterns, and an optional `:thinkingLevel` suffix. Never compare those patterns as literal strings — `lib/model-scope.ts` delegates to the SDK's `resolveModelScopeWithDiagnostics()` so pi-web and the TUI agree on the visible model list, and falls back to all available models when patterns resolve to nothing. `startRpcSession()` resolves that scope before creating an AgentSession and passes the selected initial model, thinking pin, and SDK-native `scopedModels` atomically; `GET /api/models` reuses the helper only for selector data, `thinkingLevelPins`, and `modelScopeWarnings` display.
 

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -2437,7 +2437,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                       return (
                         <button
                           key={lvl}
-                          onClick={() => { setThinkingDropdownOpen(false); if (!isActive) onThinkingLevelChange(lvl); }}
+                          onClick={() => { setThinkingDropdownOpen(false); onThinkingLevelChange(lvl); }}
                           style={{
                             display: "flex", alignItems: "center", gap: 8,
                             width: "100%", padding: "7px 12px",

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { checkExtensionDialogs, extensionSource } from "./extension-dialog.mjs";
 import { checkChatAppearance } from "./chat-appearance.mjs";
+import { seedThinkingPreference, checkThinkingPreference } from "./thinking-preference.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const mode = process.env.E2E_SERVER_MODE || "dev";
@@ -57,6 +58,7 @@ process.once("SIGINT", interrupt);
 process.once("SIGTERM", interrupt);
 
 try {
+  const featureSessionIds = seedThinkingPreference(writeSession, timestamp);
   // Seed before startup so the first catalogue scan sees every fixture.
   mkdirSync(join(agentDir, "extensions"));
   writeFileSync(join(agentDir, "extensions", "e2e-dialog.js"), extensionSource);
@@ -144,7 +146,7 @@ try {
     const response = await fetch(`${base}/api/sessions`, { signal: AbortSignal.timeout(5000) }).catch(() => null);
     if (response?.ok) {
       const { sessions } = await response.json();
-      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED].sort());
+      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED, ...featureSessionIds].sort());
       break;
     }
     assert.ok(Date.now() < deadline, "Server readiness timed out; see server.log");
@@ -358,6 +360,7 @@ try {
       await page.locator(".markdown-code-block pre").waitFor();
       await checkChatAppearance(page);
     }
+    await checkThinkingPreference({ page, base, project, artifacts, width: viewport.width });
     assert.deepEqual(errors, [], `Browser errors at width ${viewport.width}`);
     console.log(`PASS: ${viewport.width}px browser pagination, branch, markdown, code, tool call, and compaction navigation`);
     await context.tracing.stop();

--- a/e2e/thinking-preference.mjs
+++ b/e2e/thinking-preference.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+const OLD = "e2e-thinking-preference";
+export function seedThinkingPreference(writeSession, timestamp) {
+  writeSession(OLD, [
+    { type: "thinking_level_change", id: "setting", parentId: null, timestamp, thinkingLevel: "low" },
+    { type: "message", id: "user", parentId: "setting", timestamp, message: { role: "user", content: "Old session keeps its own thinking" } },
+    { type: "message", id: "answer", parentId: "user", timestamp, message: { role: "assistant", provider: "test", model: "reasoner", content: [{ type: "text", text: "Preference history fixture" }] } },
+  ]);
+  return [OLD];
+}
+
+export async function checkThinkingPreference({ page, base, project, artifacts, width }) {
+  await page.setViewportSize({ width, height: width > 600 ? 800 : 844 });
+  const data = {
+    models: { "test:reasoner": "Test Reasoner", "test:plain": "Test Plain" },
+    modelList: [{ provider: "test", id: "reasoner", name: "Test Reasoner" }, { provider: "test", id: "plain", name: "Test Plain" }],
+    defaultModel: { provider: "test", modelId: "reasoner" },
+    thinkingLevels: { "test:reasoner": ["off", "low", "high"], "test:plain": ["off"] },
+    thinkingLevelPins: {},
+  };
+  let created = 0;
+  await page.route(/\/api\/models(?:\?.*)?$/, (route) => route.fulfill({ json: data }));
+  page.on("request", (request) => { if (new URL(request.url()).pathname === "/api/agent/new") created++; });
+  const control = () => page.getByRole("button", { name: "Change reasoning level", exact: true });
+  const revealMobileControls = async () => {
+    if (width <= 600 && !(await control().isVisible())) {
+      await page.locator('button[aria-label="More controls"]:not([data-mobile-toolbar-more])').click();
+    }
+  };
+  const fresh = async (level) => {
+    await page.goto(`${base}/?cwd=${encodeURIComponent(project)}&sidebar=collapsed`);
+    await page.waitForFunction((expected) => document.querySelector('[aria-label="Change reasoning level"]')?.getAttribute("title") === `Change reasoning level: ${expected}`, level);
+  };
+  const choose = async (level) => {
+    await revealMobileControls();
+    await control().click();
+    await page.getByRole("button", { name: new RegExp(`^${level}\\s`) }).click();
+    await page.waitForFunction((expected) => localStorage.getItem("pi-thinking-level") === expected, level);
+  };
+  await fresh("auto");
+  await choose("high");
+  await fresh("high");
+  await page.reload();
+  await page.waitForFunction(() => document.querySelector('[aria-label="Change reasoning level"]')?.getAttribute("title") === "Change reasoning level: high");
+  await revealMobileControls();
+  await page.screenshot({ path: join(artifacts, `thinking-preference-${width}.png`) });
+
+  data.defaultModel = { provider: "test", modelId: "plain" };
+  await fresh("auto");
+  assert.equal(await page.evaluate(() => localStorage.getItem("pi-thinking-level")), "high");
+  data.defaultModel = { provider: "test", modelId: "reasoner" };
+  await fresh("high");
+  await page.goto(`${base}/?session=${OLD}&sidebar=collapsed`);
+  await page.getByText("Preference history fixture", { exact: true }).waitFor();
+  await page.waitForFunction(() => document.querySelector('[aria-label="Change reasoning level"]')?.getAttribute("title") === "Change reasoning level: low");
+  assert.equal(await page.evaluate(() => localStorage.getItem("pi-thinking-level")), "high");
+  await fresh("high");
+  await choose("auto");
+  await fresh("auto");
+  await choose("off");
+  await fresh("off");
+  assert.equal(created, 0, "Changing a preference must not create an agent session");
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  console.log(`PASS: ${width}px explicit thinking memory, refresh, old session, unsupported model, auto and off`);
+}

--- a/hooks/model-loading.test.mjs
+++ b/hooks/model-loading.test.mjs
@@ -3,6 +3,9 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { Script } from "node:vm";
 import ts from "typescript";
+import { createJiti } from "jiti";
+
+const { resolveThinkingPreference } = await createJiti(import.meta.url).import("../lib/thinking-level-preference.ts");
 
 const source = ts.createSourceFile(
   "useAgentSession.ts",
@@ -25,6 +28,10 @@ const retry = effect.arguments[0].body.statements.find(ts.isExpressionStatement)
 function script(text) {
   return new Script(ts.transpileModule(text, { compilerOptions: { target: ts.ScriptTarget.ESNext } }).outputText);
 }
+const applyThinking = nodes.find((node) => ts.isVariableDeclaration(node) && node.name.getText(source) === "applyNewSessionThinking");
+const applyScript = script(`(${applyThinking.initializer.arguments[0].getText(source)})`);
+const changeThinking = nodes.find((node) => ts.isVariableDeclaration(node) && node.name.getText(source) === "handleThinkingLevelChange");
+const changeScript = script(`(${changeThinking.initializer.arguments[0].getText(source)})`);
 const loadScript = script(`(${loader.initializer.arguments[0].getText(source)})`);
 const retryScript = script(retry.getText(source));
 
@@ -36,6 +43,10 @@ function setup(fetchImpl) {
     controller: new AbortController(),
     newSessionCwd: "/project", session: null, isNew: true,
     sessionIdRef: { current: null }, thinkingLevelOverrideRef: { current: null },
+    modelsRequestIdRef: { current: 0 },
+    modelsResponseRef: { current: null }, newSessionModelOverrideRef: { current: null },
+    explicitThinkingSelectionRef: { current: null }, ensuringNewSessionRef: { current: null },
+    preferred: null, resolveThinkingPreference,
     fetch: fetchImpl,
     MODELS_RETRY_DELAYS_MS: script(schedule.initializer.getText(source)).runInNewContext(),
     delay: async (ms) => { delays.push(ms); },
@@ -43,6 +54,10 @@ function setup(fetchImpl) {
   for (const name of ["ModelError", "ModelNames", "ModelScopeWarnings", "ModelThinkingLevels", "ModelThinkingLevelMaps", "ModelList", "NewSessionDefaultModel", "ThinkingLevel"]) {
     context[`set${name}`] = (value) => writes.push([name, value]);
   }
+  context.getPreferredThinkingLevel = () => context.preferred;
+  context.setPreferredThinkingLevel = (value) => { context.preferred = value; };
+  context.applyNewSessionThinking = applyScript.runInNewContext(context);
+  context.changeThinking = changeScript.runInNewContext(context);
   context.loadModels = loadScript.runInNewContext(context);
   return { context, writes, delays, run: () => retryScript.runInNewContext(context) };
 }
@@ -113,4 +128,125 @@ test("cancelling model loads prevents state writes and further retries", async (
   waiting.context.delay = async () => waiting.context.controller.abort();
   await waiting.run();
   assert.equal(attempts, 1);
+});
+
+test("a late model response cannot overwrite a newer model list", async () => {
+  const first = Promise.withResolvers();
+  let calls = 0;
+  const state = setup(async () => ++calls === 1 ? first.promise : Response.json({
+    models: {}, modelList: [{ provider: "test", id: "new" }], defaultModel: { provider: "test", modelId: "new" },
+  }));
+  const oldLoad = state.context.loadModels();
+  await state.context.loadModels();
+  first.resolve(Response.json({ models: {}, modelList: [{ provider: "test", id: "old" }], defaultModel: { provider: "test", modelId: "old" } }));
+  await oldLoad;
+  assert.equal(state.context.modelsResponseRef.current.defaultModel.modelId, "new");
+  assert.equal(state.writes.some(([name, value]) => name === "NewSessionDefaultModel" && value?.modelId === "old"), false);
+});
+
+const modelData = {
+  models: { "openai-codex:gpt-6-astra": "Astra" },
+  modelList: [{ provider: "openai-codex", id: "gpt-6-astra" }],
+  defaultModel: { provider: "openai-codex", modelId: "gpt-6-astra" },
+  thinkingLevels: { "openai-codex:gpt-6-astra": ["low", "high", "max"] },
+};
+
+test("a remembered selection survives a new composer before sending", async () => {
+  const first = setup(async () => Response.json(modelData));
+  first.context.preferred = "high";
+  await first.run();
+  assert.ok(first.writes.some(([key, value]) => key === "ThinkingLevel" && value === "high"));
+  assert.equal(first.context.thinkingLevelOverrideRef.current, "high");
+
+  await first.context.changeThinking("high");
+  const next = setup(async () => Response.json(modelData));
+  next.context.preferred = first.context.preferred;
+  await next.run();
+  assert.equal(next.context.thinkingLevelOverrideRef.current, "high");
+
+  await next.context.changeThinking("auto");
+  await next.run();
+  assert.equal(next.writes.filter(([key]) => key === "ThinkingLevel").at(-1)[1], "auto");
+  assert.equal(next.context.thinkingLevelOverrideRef.current, null);
+});
+
+test("late model data respects a new explicit selection and existing session state", async () => {
+  const pending = Promise.withResolvers();
+  const current = setup(async () => {
+    await pending.promise;
+    return Response.json(modelData);
+  });
+  const loading = current.run();
+  await current.context.changeThinking("max");
+  pending.resolve();
+  await loading;
+  assert.equal(current.context.thinkingLevelOverrideRef.current, "max");
+
+  for (const oldLevel of ["low", "off"]) {
+    const existing = setup(async () => Response.json(modelData));
+    existing.context.isNew = false;
+    existing.context.sessionIdRef.current = "existing";
+    existing.context.preferred = "high";
+    existing.context.setThinkingLevel(oldLevel);
+    await existing.run();
+    assert.deepEqual(existing.writes.filter(([key]) => key === "ThinkingLevel"), [["ThinkingLevel", oldLevel]]);
+  }
+});
+
+test("a selected new-session model controls compatibility when model loading finishes late", async () => {
+  const state = setup(async () => Response.json({
+    ...modelData,
+    thinkingLevels: { ...modelData.thinkingLevels, "other:small": ["off"] },
+  }));
+  state.context.preferred = "high";
+  state.context.newSessionModelOverrideRef.current = { provider: "other", modelId: "small" };
+  await state.run();
+  assert.equal(state.writes.filter(([key]) => key === "ThinkingLevel").at(-1)[1], "auto");
+  assert.equal(state.context.thinkingLevelOverrideRef.current, null);
+  assert.equal(state.context.preferred, "high");
+});
+
+test("quick session creation sends remembered thinking before model capabilities finish loading", async () => {
+  const pending = Promise.withResolvers();
+  const posted = [];
+  const state = setup(async (url, options) => {
+    if (url === "/api/agent/new") {
+      posted.push(JSON.parse(options.body));
+      return Response.json({ sessionId: "new-session", thinkingLevel: "low" });
+    }
+    await pending.promise;
+    return Response.json(modelData);
+  });
+  state.context.preferred = "low";
+  state.context.thinkingLevelOverrideRef.current = "low";
+  state.context.toolPreset = "default";
+  state.context.getToolNamesForPreset = () => [];
+  state.context.setPendingModel = () => {};
+  const ensure = nodes.find((node) => ts.isVariableDeclaration(node)
+    && node.name.getText(source) === "ensureNewSession");
+  const create = script(`(${ensure.initializer.arguments[0].getText(source)})`).runInNewContext(state.context);
+
+  const loading = state.run();
+  const creating = create();
+  await Promise.resolve();
+  assert.equal(await creating, "new-session");
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].thinkingLevel, "low");
+  pending.resolve();
+  await loading;
+});
+
+test("a safe model-catalog failure does not erase a remembered selection", async () => {
+  const state = setup(async () => Response.json({
+    models: {},
+    modelList: [],
+    defaultModel: null,
+    modelError: "Unavailable",
+  }));
+  state.context.preferred = "high";
+  state.context.thinkingLevelOverrideRef.current = "high";
+  await state.run();
+  assert.equal(state.context.modelsResponseRef.current, null);
+  assert.equal(state.context.thinkingLevelOverrideRef.current, "high");
+  assert.equal(state.writes.some(([key]) => key === "ThinkingLevel"), false);
 });

--- a/hooks/model-scope-startup.test.mjs
+++ b/hooks/model-scope-startup.test.mjs
@@ -41,10 +41,18 @@ test("model-list refresh does not overwrite a live session or explicit thinking 
     source.indexOf("const handleBuiltinSlashCommand"),
   );
 
-  assert.match(loadModelsSource, /if \(isNew && !sessionIdRef\.current\)/);
-  assert.match(
-    loadModelsSource,
-    /thinkingLevelOverrideRef\.current === null/,
+  assert.match(loadModelsSource, /if \(isNew && !sessionIdRef\.current && !d\.modelError && thinkingModel\)/);
+  assert.match(loadModelsSource, /applyNewSessionThinking\(thinkingModel, d\)/);
+  assert.match(loadModelsSource, /displayDefaultModel \? \{ provider: displayDefaultModel.provider, modelId: displayDefaultModel.id \} : null/);
+});
+
+test("a lazily-created composer reapplies remembered thinking after a model switch", () => {
+  const modelChangeSource = source.slice(
+    source.indexOf("const handleModelChange"),
+    source.indexOf("const handleCompact"),
   );
-  assert.match(loadModelsSource, /setThinkingLevel\(\(pinned[\s\S]*\?\? "auto"\)/);
+  assert.match(modelChangeSource, /applyNewSessionThinking\(selectedModel, modelsResponseRef\.current\)/);
+  assert.match(modelChangeSource, /type: "set_model"/);
+  assert.match(modelChangeSource, /type: "set_thinking_level", level: selectedThinkingLevel/);
+  assert.match(modelChangeSource, /type: "get_state"/);
 });

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -17,6 +17,7 @@ import { normalizeToolCalls } from "@/lib/normalize";
 import { isPromptRejectedError, sendAgentCommand } from "@/lib/agent-client";
 import { clearDraft, rekeyDraft, restoreDraftSubmission } from "@/lib/draft-store";
 import { getPreferredToolPreset, setPreferredToolPreset } from "@/lib/tool-preset-preference";
+import { getPreferredThinkingLevel, setPreferredThinkingLevel, resolveThinkingPreference, type ThinkingLevelOption } from "@/lib/thinking-level-preference";
 import { getPresetFromToolNames, getToolNamesForPreset, type ToolEntry, type ToolPreset } from "@/lib/tool-presets";
 import type { SessionStatsInfo } from "@/lib/pi-types";
 import { mergeSessionStats, type SessionFileStats } from "@/lib/session-stats";
@@ -161,7 +162,7 @@ export interface UseAgentSessionOptions {
   deferInitialScroll?: boolean;
 }
 
-export type ThinkingLevelOption = "auto" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+export type { ThinkingLevelOption } from "@/lib/thinking-level-preference";
 
 const PROMPT_SETTLE_INITIAL_DELAY_MS = 800;
 const PROMPT_SETTLE_POLL_MS = 600;
@@ -353,6 +354,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const newSessionPromotedRef = useRef(false);
   const newSessionModelOverrideRef = useRef<SelectedModel | null>(null);
   const thinkingLevelOverrideRef = useRef<Exclude<ThinkingLevelOption, "auto"> | null>(null);
+  const explicitThinkingSelectionRef = useRef<ThinkingLevelOption | null>(null);
+  const modelsResponseRef = useRef<ModelsResponse | null>(null);
+  const modelsRequestIdRef = useRef(0);
   const promptRunIdRef = useRef(0);
   const optimisticUserMessageKeyRef = useRef<string | null>(null);
   const modelSwitchPendingRef = useRef(false);
@@ -389,6 +393,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     if (!existingSessionId && (!isNew || sessionIdRef.current)) return;
     setToolPresetState(getPreferredToolPreset());
   }, [existingSessionId, isNew, setToolPresetState]);
+
+  useLayoutEffect(() => {
+    if (!isNew || sessionIdRef.current) return;
+    const preferred = getPreferredThinkingLevel();
+    thinkingLevelOverrideRef.current = preferred && preferred !== "auto" ? preferred : null;
+    setThinkingLevel(preferred ?? "auto");
+  }, [isNew]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     const container = scrollContainerRef.current;
@@ -498,7 +509,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setToolPresetState(d.toolNames !== undefined ? getPresetFromToolNames(d.toolNames) : "default");
       setCurrentModelOverride((current) => modelSwitchPendingRef.current ? current : null);
       setError(null);
-      if (d.context.thinkingLevel && d.context.thinkingLevel !== "off") {
+      if (d.context.thinkingLevel) {
         setThinkingLevel(d.context.thinkingLevel as ThinkingLevelOption);
       }
 
@@ -1581,16 +1592,41 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [loadContext]);
 
+  const applyNewSessionThinking = useCallback((model: SelectedModel | null, models: ModelsResponse) => {
+    const key = model ? `${model.provider}:${model.modelId}` : "";
+    const resolved = resolveThinkingPreference({
+      explicit: explicitThinkingSelectionRef.current,
+      preferred: getPreferredThinkingLevel(),
+      supported: models.thinkingLevels?.[key],
+      pinned: model ? models.thinkingLevelPins?.[`${model.provider}/${model.modelId}`] : undefined,
+    });
+    thinkingLevelOverrideRef.current = resolved.override;
+    setThinkingLevel(resolved.level);
+  }, []);
+
   const handleModelChange = useCallback(async (provider: string, modelId: string) => {
     if (isNew) {
       const selectedModel = { provider, modelId };
       newSessionModelOverrideRef.current = selectedModel;
       setNewSessionModel(selectedModel);
       setPendingModel(selectedModel);
+      if (modelsResponseRef.current) {
+        applyNewSessionThinking(selectedModel, modelsResponseRef.current);
+      }
       const sid = sessionIdRef.current ?? await ensuringNewSessionRef.current;
       if (!sid) return;
       try {
         await sendAgentCommand(sid, { type: "set_model", provider, modelId });
+        const selectedThinkingLevel = thinkingLevelOverrideRef.current;
+        if (selectedThinkingLevel) {
+          await sendAgentCommand(sid, { type: "set_thinking_level", level: selectedThinkingLevel });
+          setThinkingLevel(selectedThinkingLevel);
+        } else {
+          const state = await sendAgentCommand<AgentStateResponse>(sid, { type: "get_state" });
+          if (sessionIdRef.current === sid && state.thinkingLevel) {
+            setThinkingLevel(state.thinkingLevel as ThinkingLevelOption);
+          }
+        }
       } catch (e) {
         console.error("Failed to set model:", e);
       }
@@ -1625,7 +1661,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       modelSwitchPendingRef.current = false;
       setModelSwitching(false);
     }
-  }, [addNotice, currentModelOverride, isNew, loadSession, setNewSessionModel]);
+  }, [addNotice, applyNewSessionThinking, currentModelOverride, isNew, loadSession, setNewSessionModel]);
 
   const handleCompact = useCallback(async () => {
     const sid = sessionIdRef.current;
@@ -1646,6 +1682,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [isCompacting, loadSession]);
 
   const loadModels = useCallback(async (signal?: AbortSignal) => {
+    const requestId = ++modelsRequestIdRef.current;
     const modelCwd = newSessionCwd ?? session?.cwd ?? "";
     const modelsUrl = modelCwd ? `/api/models?cwd=${encodeURIComponent(modelCwd)}` : "/api/models";
     let d: ModelsResponse;
@@ -1667,11 +1704,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       d = await res.json() as ModelsResponse;
       signal?.throwIfAborted();
     } catch (e) {
+      if (requestId !== modelsRequestIdRef.current) return;
       if (!signal?.aborted && !(e instanceof DOMException && e.name === "AbortError")) {
         setModelError(e instanceof Error ? e.message : String(e));
       }
       throw e;
     }
+    if (requestId !== modelsRequestIdRef.current) return;
+    modelsResponseRef.current = d.modelError ? null : d;
     setModelNames(d.models);
     setModelError(d.modelError ?? null);
     setModelScopeWarnings(d.modelScopeWarnings ?? []);
@@ -1685,16 +1725,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     setNewSessionDefaultModel(displayDefaultModel
       ? { provider: displayDefaultModel.provider, modelId: displayDefaultModel.id }
       : null);
-    if (isNew && !sessionIdRef.current) {
+    const thinkingModel = newSessionModelOverrideRef.current ?? (
+      displayDefaultModel ? { provider: displayDefaultModel.provider, modelId: displayDefaultModel.id } : null
+    );
+    if (isNew && !sessionIdRef.current && !d.modelError && thinkingModel) {
       // The first listed model is not necessarily the runtime's automatic choice.
-      // An `enabledModels` pattern may pin a thinking level (`anthropic/*:high`).
-      // Like pi, apply it to the model a new session starts with.
-      const pinned = displayDefaultModel && d.thinkingLevelPins?.[`${displayDefaultModel.provider}/${displayDefaultModel.id}`];
-      if (thinkingLevelOverrideRef.current === null) {
-        setThinkingLevel((pinned as ThinkingLevelOption | undefined) ?? "auto");
-      }
+      applyNewSessionThinking(thinkingModel, d);
     }
-  }, [isNew, newSessionCwd, session?.cwd]);
+  }, [applyNewSessionThinking, isNew, newSessionCwd, session?.cwd]);
 
   const handleBuiltinSlashCommand = useCallback(async (text: string): Promise<BuiltinSlashCommandResult> => {
     if (!text.startsWith("/")) return { handled: false };
@@ -1877,8 +1915,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [opts.chatInputRef, addNotice]);
 
   const handleThinkingLevelChange = useCallback(async (level: ThinkingLevelOption) => {
+    setPreferredThinkingLevel(level);
+    explicitThinkingSelectionRef.current = level;
     setThinkingLevel(level);
-    if (isNew && !sessionIdRef.current) {
+    if (isNew) {
       thinkingLevelOverrideRef.current = level === "auto" ? null : level;
     }
     if (level === "auto") return; // "auto" leaves pi's current setting untouched

--- a/lib/thinking-level-preference.test.mjs
+++ b/lib/thinking-level-preference.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const {
+  getPreferredThinkingLevel,
+  setPreferredThinkingLevel,
+  resolveThinkingPreference,
+} = await createJiti(import.meta.url).import("./thinking-level-preference.ts");
+
+test("explicit high and auto persist immediately without creating a session", () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+
+  assert.equal(getPreferredThinkingLevel(storage), null);
+  for (const level of ["high", "auto", "off", "max"]) {
+    setPreferredThinkingLevel(level, storage);
+    assert.equal(getPreferredThinkingLevel(storage), level);
+  }
+  values.set("pi-thinking-level", "invalid");
+  assert.equal(getPreferredThinkingLevel(storage), null);
+});
+
+test("unavailable storage remains safe", () => {
+  const blocked = {
+    getItem() { throw new Error("blocked"); },
+    setItem() { throw new Error("blocked"); },
+  };
+
+  assert.equal(getPreferredThinkingLevel(blocked), null);
+  assert.equal(getPreferredThinkingLevel(null), null);
+  assert.doesNotThrow(() => setPreferredThinkingLevel("high", blocked));
+  assert.doesNotThrow(() => setPreferredThinkingLevel("high", null));
+});
+
+test("new sessions respect explicit choices, scope pins and remembered levels", () => {
+  const base = { explicit: null, preferred: "high", supported: ["off", "low", "medium", "high"] };
+  assert.deepEqual(resolveThinkingPreference(base), { level: "high", override: "high" });
+  assert.deepEqual(resolveThinkingPreference({ ...base, pinned: "low" }), { level: "low", override: null });
+  assert.deepEqual(resolveThinkingPreference({ ...base, pinned: "low", explicit: "high" }), { level: "high", override: "high" });
+  assert.deepEqual(resolveThinkingPreference({ ...base, pinned: "low", explicit: "auto" }), { level: "auto", override: null });
+  assert.deepEqual(resolveThinkingPreference({ ...base, preferred: "auto", pinned: "low" }), { level: "low", override: null });
+});
+
+test("unsupported memory falls back without destroying the original preference", () => {
+  const base = { explicit: null, preferred: "high" };
+  assert.deepEqual(resolveThinkingPreference({ ...base, supported: ["off"] }), { level: "auto", override: null });
+  assert.deepEqual(resolveThinkingPreference({ ...base, supported: ["low"] }), { level: "auto", override: null });
+  assert.deepEqual(resolveThinkingPreference({ ...base, supported: ["high"] }), { level: "high", override: "high" });
+});

--- a/lib/thinking-level-preference.ts
+++ b/lib/thinking-level-preference.ts
@@ -1,0 +1,51 @@
+const STORAGE_KEY = "pi-thinking-level";
+export type ThinkingLevelOption = "auto" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+const LEVELS = new Set<string>(["auto", "off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function browserStorage(): StorageLike | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getPreferredThinkingLevel(storage: StorageLike | null = browserStorage()): ThinkingLevelOption | null {
+  try {
+    const value = storage?.getItem(STORAGE_KEY);
+    return value && LEVELS.has(value) ? value as ThinkingLevelOption : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setPreferredThinkingLevel(level: ThinkingLevelOption, storage: StorageLike | null = browserStorage()): void {
+  try {
+    storage?.setItem(STORAGE_KEY, level);
+  } catch {
+    // Browser storage is best-effort.
+  }
+}
+
+/** Current selections beat scope pins; inherited preferences do not. */
+export function resolveThinkingPreference(options: {
+  explicit: ThinkingLevelOption | null;
+  preferred: ThinkingLevelOption | null;
+  supported?: string[];
+  pinned?: string;
+}): { level: ThinkingLevelOption; override: Exclude<ThinkingLevelOption, "auto"> | null } {
+  const { explicit, preferred, supported, pinned } = options;
+  const compatible = (value: string | null | undefined): value is Exclude<ThinkingLevelOption, "auto"> =>
+    Boolean(value && value !== "auto" && LEVELS.has(value) && supported?.includes(value));
+  if (explicit === "auto") return { level: "auto", override: null };
+  if (compatible(explicit)) return { level: explicit, override: explicit };
+  if (pinned && LEVELS.has(pinned)) return { level: pinned as ThinkingLevelOption, override: null };
+  if (preferred === "auto") return { level: "auto", override: null };
+  if (compatible(preferred)) return { level: preferred, override: preferred };
+  return { level: "auto", override: null };
+}


### PR DESCRIPTION
Fresh composers currently reset the reasoning selector even after the user explicitly chose a level in the previous session. This stores the last explicit choice (including `auto`) in browser storage, reapplies it only to fresh sessions after model-scope compatibility checks, and keeps existing sessions bound to their own persisted state.

Validation:

- `npm test` (1031 passed)
- `npm run lint`
- `node_modules/.bin/tsc --noEmit --incremental false`
- Playwright at 1280px and 390px: refresh, old-session isolation, incompatible-model fallback, and `auto`/`off`
