### PR TITLE
Show the selected thinking level beside assistant model names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ The last preset explicitly selected by the user is stored in browser `localStora
 ### Model defaults for new sessions
 `GET /api/models` returns `defaultModel` read from `~/.pi/agent/settings.json`. `ChatWindow` pre-selects this on mount for new sessions. Explicit browser model/thinking selections are applied atomically during AgentSession construction, then `lib/startup-preferences.ts` persists their effective values without replaying `set_model`/`set_thinking_level`; implicit `enabledModels` fallbacks and thinking pins are not persisted.
 
+Assistant model labels echo the composer’s thinking label when Send is pressed. The client sends that bounded display label alongside the prompt; the server records it as a versioned `pi-web:message-thinking` custom entry after preflight accepts the prompt. This keeps `auto` and provider-mapped labels stable without changing SDK messages. Older replies fall back to their branch setting history.
+
 ### `enabledModels` scoping
 The `enabledModels` setting uses pi's `--models` syntax: minimatch globs against `provider/modelId` or a bare `modelId`, fuzzy matching for non-glob patterns, and an optional `:thinkingLevel` suffix. Never compare those patterns as literal strings — `lib/model-scope.ts` delegates to the SDK's `resolveModelScopeWithDiagnostics()` so pi-web and the TUI agree on the visible model list, and falls back to all available models when patterns resolve to nothing. `startRpcSession()` resolves that scope before creating an AgentSession and passes the selected initial model, thinking pin, and SDK-native `scopedModels` atomically; `GET /api/models` reuses the helper only for selector data, `thinkingLevelPins`, and `modelScopeWarnings` display.
 

--- a/components/MessageView.test.mjs
+++ b/components/MessageView.test.mjs
@@ -29,6 +29,29 @@ function renderMessage(message, props = {}) {
   );
 }
 
+test("model labels show the answer's recorded thinking level during and after streaming", () => {
+  for (const isStreaming of [false, true]) {
+    for (const thinkingLevel of ["high", "off", "xhigh", "auto"]) {
+      const html = renderMessage({
+        role: "assistant", provider: "test", model: "astra", thinkingLevel,
+        content: [{ type: "text", text: "Answer" }],
+      }, { isStreaming, modelNames: { "test:astra": "GPT-6 Astra" } });
+      assert.ok(html.includes(`<span>GPT-6 Astra · ${thinkingLevel}</span>`));
+    }
+  }
+});
+
+test("model labels omit the separator for unknown or blank thinking levels", () => {
+  for (const thinkingLevel of [undefined, null, 3, "", " "]) {
+    const html = renderMessage({
+      role: "assistant", provider: "test", model: "astra", thinkingLevel,
+      content: [{ type: "text", text: "Answer" }],
+    }, { modelNames: { "test:astra": "GPT-6 Astra" } });
+    assert.match(html, /<span>GPT-6 Astra<\/span>/);
+    assert.doesNotMatch(html, /GPT-6 Astra ·/);
+  }
+});
+
 test("updates a reused message when its written files change", () => {
   const props = { message: { role: "assistant", content: [] } };
   assert.equal(MessageView.compare(props, props), true);

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -629,6 +629,7 @@ function AssistantMessageView({
     .filter(({ block }) => !isEmptyThinkingBlock(block, { isStreaming })), [message.content, isStreaming]);
   const blocks = useMemo(() => blockItems.map(({ block }) => block), [blockItems]);
   const providerError = getAssistantErrorMessage(message, { isStreaming });
+  const thinkingLevel = typeof message.thinkingLevel === "string" ? message.thinkingLevel.trim() : undefined;
   const [hovered, setHovered] = useState(false);
   const [copied, setCopied] = useState(false);
   const streamStartRef = useRef<number | null>(null);
@@ -768,7 +769,7 @@ function AssistantMessageView({
         }}
       >
         {message.provider && (
-          <span>{getModelDisplayName(message.provider, message.model, modelNames)}</span>
+          <span>{getModelDisplayName(message.provider, message.model, modelNames)}{thinkingLevel ? ` · ${thinkingLevel}` : ""}</span>
         )}
         {isStreaming && (() => {
           const est = Math.round(estimatedTokens);

--- a/e2e/reply-thinking.mjs
+++ b/e2e/reply-thinking.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+const ID = "e2e-reply-thinking";
+export function seedReplyThinking(writeSession, timestamp) {
+  const entries = [];
+  const append = (type, fields) => {
+    const entry = { type, id: `r${entries.length}`, parentId: entries.at(-1)?.id ?? null, timestamp, ...fields };
+    entries.push(entry);
+    return entry;
+  };
+  for (const [level, label, text] of [
+    ["high", "xhigh", "Mapped high answer"],
+    ["high", "auto", "Automatic answer"],
+    ["off", null, "Legacy disabled answer"],
+  ]) {
+    append("thinking_level_change", { thinkingLevel: level });
+    append("message", { message: { role: "user", content: `Use ${level}` } });
+    if (label) append("custom", { customType: "pi-web:message-thinking", data: { version: 1, label } });
+    append("message", { message: { role: "assistant", provider: "test", model: "reasoner", content: [{ type: "text", text }] } });
+  }
+  writeSession(ID, entries);
+  return [ID];
+}
+
+export async function checkReplyThinking({ page, base, artifacts, width }) {
+  await page.setViewportSize({ width, height: width > 600 ? 800 : 844 });
+  const check = async () => {
+    for (const [level, text] of [["xhigh", "Mapped high answer"], ["auto", "Automatic answer"], ["off", "Legacy disabled answer"]]) {
+      const message = page.locator('[data-message-role="assistant"]').filter({ hasText: text });
+      await message.getByText(`test/reasoner · ${level}`, { exact: true }).waitFor();
+    }
+  };
+  await page.goto(`${base}/?session=${ID}&sidebar=collapsed`);
+  await check();
+  await page.reload();
+  await check();
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  await page.screenshot({ path: join(artifacts, `reply-thinking-${width}.png`) });
+  console.log(`PASS: ${width}px per-reply thinking labels remain distinct after reload`);
+}

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { checkExtensionDialogs, extensionSource } from "./extension-dialog.mjs";
 import { checkChatAppearance } from "./chat-appearance.mjs";
+import { seedReplyThinking, checkReplyThinking } from "./reply-thinking.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const mode = process.env.E2E_SERVER_MODE || "dev";
@@ -57,6 +58,7 @@ process.once("SIGINT", interrupt);
 process.once("SIGTERM", interrupt);
 
 try {
+  const featureSessionIds = seedReplyThinking(writeSession, timestamp);
   // Seed before startup so the first catalogue scan sees every fixture.
   mkdirSync(join(agentDir, "extensions"));
   writeFileSync(join(agentDir, "extensions", "e2e-dialog.js"), extensionSource);
@@ -144,7 +146,7 @@ try {
     const response = await fetch(`${base}/api/sessions`, { signal: AbortSignal.timeout(5000) }).catch(() => null);
     if (response?.ok) {
       const { sessions } = await response.json();
-      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED].sort());
+      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED, ...featureSessionIds].sort());
       break;
     }
     assert.ok(Date.now() < deadline, "Server readiness timed out; see server.log");
@@ -358,6 +360,7 @@ try {
       await page.locator(".markdown-code-block pre").waitFor();
       await checkChatAppearance(page);
     }
+    await checkReplyThinking({ page, base, artifacts, width: viewport.width });
     assert.deepEqual(errors, [], `Browser errors at width ${viewport.width}`);
     console.log(`PASS: ${viewport.width}px browser pagination, branch, markdown, code, tool call, and compaction navigation`);
     await context.tracing.stop();

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -256,7 +256,7 @@ test("streaming submissions cannot be stranded in an idle direct queue", () => {
 
   assert.match(queueSource, /type: "prompt"/);
   assert.match(queueSource, /streamingBehavior: behavior/);
-  assert.match(queueSource, /if \(isPromptRejectedError\(e\)\) restore\(\)/);
+  assert.match(queueSource, /if \(isPromptRejectedError\(e\)\) \{[\s\S]*?restore\(\);[\s\S]*?\}/);
   assert.doesNotMatch(queueSource, /type: "steer"/);
   assert.doesNotMatch(queueSource, /type: "follow_up"/);
 });
@@ -359,7 +359,7 @@ test("keeps one reducer-owned assistant partial and consumes Pi JSON deltas", ()
   assert.match(connectedSource, /dispatch\(\{ type: "end" \}\)/);
   assert.match(connectedSource, /event\.isStreaming === true/);
   assert.match(connectedSource, /agentRunningRef\.current = true/);
-  assert.match(streamSource, /msg\?\.role === "assistant"[\s\S]*dispatch\(\{ type: "snapshot", message: msg \}\)/);
+  assert.match(streamSource, /msg\?\.role === "assistant"[\s\S]*dispatch\(\{ type: "snapshot", message: withMessageThinking\(msg, sentThinkingLevelRef\.current\) \}\)/);
   assert.match(streamSource, /event\.assistantMessageEvent as ClientAssistantMessageEvent/);
   assert.match(streamSource, /dispatch\(\{ type: "delta", event: delta \}\)/);
   assert.match(streamSource, /delta\.type !== "toolcall_start" && delta\.type !== "toolcall_delta"/);
@@ -368,6 +368,19 @@ test("keeps one reducer-owned assistant partial and consumes Pi JSON deltas", ()
   assert.match(messageEndSource, /normalizeToolCalls\(completed\)/);
   assert.match(messageEndSource, /dispatch\(\{ type: "end" \}\)/);
   assert.doesNotMatch(messageEndSource, /streamState\.streamingMessage/);
+});
+
+test("a reconnect cannot replace the thinking label of a pending prompt", () => {
+  const connectedSource = source.slice(
+    source.indexOf('case "connected"'),
+    source.indexOf('case "agent_start"'),
+  );
+  assert.match(
+    connectedSource,
+    /!rpcPromptPendingRef\.current && typeof event\.messageThinkingLevel === "string"/,
+  );
+  assert.match(source, /!rpcPromptPendingRef\.current && liveState\?\.messageThinkingLevel/);
+  assert.match(source, /const previousThinkingLabel = sentThinkingLevelRef\.current;[\s\S]*?sentThinkingLevelRef\.current = previousThinkingLabel;[\s\S]*?rpcPromptPendingRef\.current = false/);
 });
 
 test("restoring a running session does not clear an SSE snapshot", () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/lib/types";
 import { isBlockingExtensionUiRequest } from "@/lib/browser-notifications";
 import { normalizeToolCalls } from "@/lib/normalize";
+import { withMessageThinking } from "@/lib/message-thinking";
 import { isPromptRejectedError, sendAgentCommand } from "@/lib/agent-client";
 import { clearDraft, rekeyDraft, restoreDraftSubmission } from "@/lib/draft-store";
 import { getPreferredToolPreset, setPreferredToolPreset } from "@/lib/tool-preset-preference";
@@ -72,6 +73,7 @@ type AgentStateResponse = {
   contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null;
   systemPrompt?: string;
   thinkingLevel?: string;
+  messageThinkingLevel?: string;
   isStreaming?: boolean;
   isPromptRunning?: boolean;
   isBashRunning?: boolean;
@@ -354,6 +356,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const newSessionModelOverrideRef = useRef<SelectedModel | null>(null);
   const thinkingLevelOverrideRef = useRef<Exclude<ThinkingLevelOption, "auto"> | null>(null);
   const promptRunIdRef = useRef(0);
+  const sentThinkingLevelRef = useRef<string | undefined>(undefined);
   const optimisticUserMessageKeyRef = useRef<string | null>(null);
   const modelSwitchPendingRef = useRef(false);
   const draftKeyAliasesRef = useRef(new Map<string, string>());
@@ -489,6 +492,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const d = await res.json() as SessionData;
       if (sessionIdRef.current !== sid) return null;
       const persistedMessages = d.context.messages;
+      sentThinkingLevelRef.current ??= d.context.thinkingLevel;
       setData(d);
       setActiveLeafId(d.leafId);
       setMessages(persistedMessages);
@@ -513,6 +517,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         if (sessionIdRef.current !== sid) return null;
 
         const liveState = agentState.state;
+        if (!rpcPromptPendingRef.current && liveState?.messageThinkingLevel) {
+          sentThinkingLevelRef.current = liveState.messageThinkingLevel;
+        }
         syncLiveModel(liveState);
         if (liveState) {
           if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
@@ -1112,6 +1119,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const handleAgentEvent = useCallback((event: AgentEvent) => {
     switch (event.type) {
       case "connected": {
+        if (!rpcPromptPendingRef.current && typeof event.messageThinkingLevel === "string") {
+          sentThinkingLevelRef.current = event.messageThinkingLevel;
+        }
         dispatch({ type: "end" });
         if (event.isStreaming === true) {
           cancelEventStreamGrace();
@@ -1209,7 +1219,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           const msg = event.message as AgentMessage | undefined;
           if (msg?.role === "user") break;
           if (msg?.role === "assistant") {
-            dispatch({ type: "snapshot", message: msg });
+            dispatch({ type: "snapshot", message: withMessageThinking(msg, sentThinkingLevelRef.current) });
             if (msg.content.length > 0) setAgentPhase(null);
           } else if (msg) {
             setAgentPhase(null);
@@ -1260,7 +1270,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
             return [...prev, delivered];
           });
         } else if (completed) {
-          setMessages((prev) => [...prev, normalizeToolCalls(completed)]);
+          setMessages((prev) => [...prev, withMessageThinking(normalizeToolCalls(completed), sentThinkingLevelRef.current)]);
         }
         dispatch({ type: "end" });
         setAgentPhase({ kind: "waiting_model" });
@@ -1388,6 +1398,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
 
     const promptRunId = promptRunIdRef.current + 1;
+    const previousThinkingLabel = sentThinkingLevelRef.current;
+    const levelMap = displayModel ? modelThinkingLevelMaps[`${displayModel.provider}:${displayModel.modelId}`] : undefined;
+    sentThinkingLevelRef.current = thinkingLevel === "auto" ? "auto" : (levelMap?.[thinkingLevel] ?? thinkingLevel);
     cancelEventStreamGrace();
     rpcPromptPendingRef.current = true;
 
@@ -1432,6 +1445,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         await sendAgentCommand(sid, {
           type: "prompt",
           message,
+          displayThinkingLevel: sentThinkingLevelRef.current,
           ...(piImages?.length ? { images: piImages } : {}),
         });
         promoteNewSession(1, message);
@@ -1442,6 +1456,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         await sendAgentCommand(session.id, {
           type: "prompt",
           message,
+          displayThinkingLevel: sentThinkingLevelRef.current,
           ...(piImages?.length ? { images: piImages } : {}),
         });
       } else {
@@ -1460,6 +1475,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         void waitForPromptSettlement(sentSessionId, promptRunId);
         return;
       }
+      sentThinkingLevelRef.current = previousThinkingLabel;
       rpcPromptPendingRef.current = false;
       setMessages((prev) => {
         const optimisticIndex = prev.lastIndexOf(userMsg);
@@ -1483,7 +1499,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       setAgentPhase(null);
       dispatch({ type: "end" });
     }
-  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, composerDraftKey, reconcileAgentState, restoreSubmission]);
+  }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, composerDraftKey, reconcileAgentState, restoreSubmission, thinkingLevel, displayModel, modelThinkingLevelMaps]);
 
   const executeBash = useCallback(async (command: string, excludeFromContext: boolean) => {
     if (agentRunningRef.current || bashRunningRef.current) return;
@@ -1812,11 +1828,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       return;
     }
     const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
+    const previousThinkingLabel = sentThinkingLevelRef.current;
+    const levelMap = displayModel ? modelThinkingLevelMaps[`${displayModel.provider}:${displayModel.modelId}`] : undefined;
+    const displayThinkingLevel = thinkingLevel === "auto" ? "auto" : (levelMap?.[thinkingLevel] ?? thinkingLevel);
+    sentThinkingLevelRef.current = displayThinkingLevel;
     try {
       await sendAgentCommand(sid, {
         type: "prompt",
         message,
         streamingBehavior: behavior,
+        displayThinkingLevel,
         ...(piImages?.length ? { images: piImages } : {}),
       });
     } catch (e) {
@@ -1824,13 +1845,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // A transport failure after dispatch is ambiguous: the server may have
       // accepted the queued prompt before the response was lost. Restoring in
       // that case would invite a duplicate turn.
-      if (isPromptRejectedError(e)) restore();
+      if (isPromptRejectedError(e)) {
+        sentThinkingLevelRef.current = previousThinkingLabel;
+        restore();
+      }
       addNotice({
         type: "error",
         message: e instanceof Error ? e.message : String(e),
       });
     }
-  }, [addNotice, composerDraftKey, restoreSubmission]);
+  }, [addNotice, composerDraftKey, displayModel, modelThinkingLevelMaps, restoreSubmission, thinkingLevel]);
 
   const handleSteer = useCallback(async (message: string, images?: AttachedImage[]) => {
     await sendStreamingPrompt(message, "steer", images);

--- a/lib/agent-event-stream.test.mjs
+++ b/lib/agent-event-stream.test.mjs
@@ -57,6 +57,7 @@ test("opens the transport before a slow session is ready and snapshots after sub
   startup.resolve({
     isStreaming: true,
     streamingMessage: snapshot,
+    messageThinkingLevel: "auto",
     onEvent(nextListener) {
       subscribeCount += 1;
       listener = nextListener;
@@ -78,6 +79,7 @@ test("opens the transport before a slow session is ready and snapshots after sub
     type: "connected",
     sessionId: "session-id",
     isStreaming: true,
+    messageThinkingLevel: "auto",
   });
   assert.deepEqual(messageStart, { type: "agent_start" });
   assert.deepEqual(replayedEvent, { type: "message_start", message: snapshot });

--- a/lib/agent-event-stream.ts
+++ b/lib/agent-event-stream.ts
@@ -8,6 +8,7 @@ import { acquireSessionLivenessLease } from "./session-liveness";
 export interface AgentEventStreamSession {
   readonly isStreaming: boolean;
   readonly streamingMessage: unknown;
+  readonly messageThinkingLevel?: string;
   onEvent(listener: (event: AgentEventLike) => void): () => void;
 }
 
@@ -97,6 +98,9 @@ export function createAgentEventStream(
             type: "connected",
             sessionId,
             isStreaming: session.isStreaming,
+            ...(session.messageThinkingLevel
+              ? { messageThinkingLevel: session.messageThinkingLevel }
+              : {}),
           });
           for (const event of bufferedEvents) forwardEvent(event, snapshot);
           if (snapshot !== undefined && snapshot !== null) {

--- a/lib/message-thinking.test.mjs
+++ b/lib/message-thinking.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { buildSessionContext } = await jiti.import("./session-reader.ts");
+const {
+  MESSAGE_THINKING_CUSTOM_TYPE,
+  normalizeMessageThinkingLabel,
+  readCurrentMessageThinkingLabel,
+  readMessageThinkingLevels,
+  messageThinkingLevel,
+  withMessageThinking,
+} = await jiti.import("./message-thinking.ts");
+const { streamReducer, INITIAL_STREAMING_STATE } = await jiti.import("./streaming-message.ts");
+
+const at = (time) => new Date(time).toISOString();
+const change = (id, parentId, thinkingLevel, time = 0) => ({
+  id, parentId, type: "thinking_level_change", thinkingLevel, timestamp: at(time),
+});
+const answer = (id, parentId, time = 100, extra = {}) => ({
+  id, parentId, type: "message", timestamp: at(time + 10),
+  message: { role: "assistant", provider: "test", model: "gpt-6-astra", timestamp: time, content: [{ type: "text", text: id }], ...extra },
+});
+const display = (id, parentId, label, time = 0) => ({
+  id, parentId, type: "custom", customType: MESSAGE_THINKING_CUSTOM_TYPE,
+  timestamp: at(time), data: { version: 1, label },
+});
+
+test("each historical answer keeps the level on its own branch after later changes", () => {
+  const entries = [
+    change("high", null, "high"), answer("a1", "high"),
+    change("medium", "a1", "medium", 200), answer("a2", "medium", 300),
+    change("low", "a1", "low", 400), answer("other", "low", 500),
+    change("xhigh", "a2", "xhigh", 600),
+  ];
+  const context = buildSessionContext(entries, "xhigh");
+  assert.equal(context.thinkingLevel, "xhigh");
+  assert.deepEqual(context.entryIds, ["a1", "a2"]);
+  assert.deepEqual(context.messages.map((message) => message.thinkingLevel), ["high", "medium"]);
+  assert.deepEqual(buildSessionContext(entries, "other").messages.map((message) => message.thinkingLevel), ["high", "low"]);
+  assert.equal(entries[1].message.thinkingLevel, undefined, "reading does not mutate stored legacy messages");
+});
+
+test("paged and compacted history recovers settings from before the requested page", () => {
+  const entries = [change("setting", null, "high"), answer("a1", "setting")];
+  entries.push({ type: "compaction", id: "compact", parentId: "a1", timestamp: at(200), summary: "kept", tokensBefore: 500, firstKeptEntryId: "a1" });
+  entries.push(answer("a2", "compact", 300), change("off", "a2", "off", 400), answer("a3", "off", 500));
+  const latest = buildSessionContext(entries, "a3", { tail: 1 });
+  assert.equal(latest.messages[0].thinkingLevel, "off");
+  const older = buildSessionContext(entries, latest.oldestEntryId, { tail: 3, excludeLeaf: true, deferThinking: true });
+  assert.deepEqual(older.entryIds, ["compact", "a2"]);
+  assert.equal(older.messages[1].thinkingLevel, "high");
+  assert.deepEqual(buildSessionContext(entries, null).messages, []);
+});
+
+test("labels use the selected setting rather than provider-native effort names", () => {
+  const entries = [
+    change("setting", null, "medium"),
+    answer("captured", "setting", 100, { thinkingLevel: "high" }),
+    answer("native", "captured", 200, { thinkingLevel: "xhigh", providerThinkingLevel: "ultra" }),
+  ];
+  assert.deepEqual(buildSessionContext(entries).messages.map((message) => message.thinkingLevel), ["high", "xhigh"]);
+  assert.equal(messageThinkingLevel({ thinkingLevel: "auto" }, "high"), "auto");
+});
+
+test("accepted prompt metadata preserves auto and provider-mapped labels", () => {
+  const entries = [
+    change("high", null, "high"),
+    display("mapped", "high", "xhigh", 50),
+    answer("mapped-answer", "mapped", 100),
+    change("still-high", "mapped-answer", "high", 200),
+    display("automatic", "still-high", "auto", 250),
+    answer("auto-answer", "automatic", 300),
+  ];
+  assert.deepEqual(
+    buildSessionContext(entries).messages.map((message) => message.thinkingLevel),
+    ["xhigh", "auto"],
+  );
+  assert.equal(readCurrentMessageThinkingLabel(entries), "auto");
+  assert.equal(normalizeMessageThinkingLabel(" xhigh "), "xhigh");
+  assert.throws(() => normalizeMessageThinkingLabel("bad\nlabel"), /Invalid message thinking label/);
+});
+
+test("malformed custom labels are ignored and later setting changes clear stale labels", () => {
+  const entries = [
+    display("bad", null, " ", 10),
+    change("high", "bad", "high", 20),
+    display("valid", "high", "mapped-high", 30),
+    answer("mapped", "valid", 40),
+    change("low", "mapped", "low", 50),
+    answer("fallback", "low", 60),
+  ];
+  assert.deepEqual(
+    buildSessionContext(entries).messages.map((message) => message.thinkingLevel),
+    ["mapped-high", "low"],
+  );
+  assert.equal(readCurrentMessageThinkingLabel(entries), undefined);
+});
+
+test("unknown older settings stay absent and a selected auto label stays auto", () => {
+  const entries = [answer("old", null), change("auto", "old", "auto", 200), answer("automatic", "auto", 300)];
+  const context = buildSessionContext(entries);
+  assert.deepEqual(context.messages.map((message) => message.thinkingLevel), [undefined, "auto"]);
+  assert.equal(messageThinkingLevel({ thinkingLevel: " " }), undefined);
+});
+
+test("legacy responses use their start time when the user changed effort during generation", () => {
+  const entries = [
+    change("high", null, "high", 100), change("medium", "high", "medium", 300),
+    answer("long", "medium", 200), answer("next", "long", 400),
+  ];
+  assert.deepEqual(buildSessionContext(entries).messages.map((message) => message.thinkingLevel), ["high", "medium"]);
+});
+
+test("deep histories resolve iteratively and broken ancestry remains unknown", () => {
+  const entries = [change("start", null, "high")];
+  for (let i = 0; i < 5000; i += 1) entries.push(answer(`a${i}`, entries.at(-1).id, i + 100));
+  assert.equal(readMessageThinkingLevels(entries, ["a4999"]).get("a4999"), "high");
+  const detached = answer("detached", "missing");
+  assert.equal(readMessageThinkingLevels([...entries, detached], ["detached"]).get("detached"), undefined);
+});
+
+test("stream deltas and refreshed snapshots retain the per-message effort", () => {
+  const received = answer("live", null, 100).message;
+  const message = withMessageThinking(received, "high");
+  assert.equal(received.thinkingLevel, undefined, "display annotation does not change the received message");
+  let state = streamReducer(INITIAL_STREAMING_STATE, { type: "snapshot", message });
+  state = streamReducer(state, { type: "delta", event: { type: "text_delta", contentIndex: 0, delta: " text" } });
+  assert.equal(state.streamingMessage.thinkingLevel, "high");
+  state = streamReducer(state, { type: "snapshot", message: { ...message, content: [{ type: "text", text: "refreshed" }] } });
+  assert.equal(state.streamingMessage.thinkingLevel, "high");
+});

--- a/lib/message-thinking.ts
+++ b/lib/message-thinking.ts
@@ -1,0 +1,97 @@
+import type { AgentMessage, AssistantMessage, SessionEntry } from "./types";
+
+export const MESSAGE_THINKING_CUSTOM_TYPE = "pi-web:message-thinking";
+const MAX_MESSAGE_THINKING_LABEL_LENGTH = 64;
+
+export function normalizeMessageThinkingLabel(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error("Invalid message thinking label");
+  const label = value.trim();
+  if (!label || label.length > MAX_MESSAGE_THINKING_LABEL_LENGTH || /[\u0000-\u001f\u007f]/.test(label)) {
+    throw new Error("Invalid message thinking label");
+  }
+  return label;
+}
+
+function customMessageThinkingLabel(entry: SessionEntry): string | undefined {
+  if (entry.type !== "custom" || entry.customType !== MESSAGE_THINKING_CUSTOM_TYPE) return undefined;
+  const data = entry.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
+  const fields = data as Record<string, unknown>;
+  if (fields.version !== 1) return undefined;
+  try {
+    return normalizeMessageThinkingLabel(fields.label);
+  } catch {
+    return undefined;
+  }
+}
+
+export function knownThinkingLevel(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const level = value.trim();
+  return level || undefined;
+}
+
+export function messageThinkingLevel(
+  message: Pick<AssistantMessage, "thinkingLevel">,
+  fallback?: unknown,
+): string | undefined {
+  return knownThinkingLevel(message.thinkingLevel)
+    ?? knownThinkingLevel(fallback);
+}
+
+/** Browser display only: copy the label selected when Send was pressed. */
+export function withMessageThinking(message: AgentMessage, label?: string): AgentMessage {
+  return message.role === "assistant" && label
+    ? { ...message, thinkingLevel: label }
+    : message;
+}
+
+/** Resolve only the displayed branch, including settings before a history page. */
+export function readMessageThinkingLevels(
+  entries: SessionEntry[],
+  entryIds: string[],
+): Map<string, string> {
+  const levels = new Map<string, string>();
+  if (!entryIds.length) return levels;
+  const wanted = new Set(entryIds);
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  const branch: SessionEntry[] = [];
+  const visited = new Set<string>();
+  let current = byId.get(entryIds[entryIds.length - 1]);
+  while (current && !visited.has(current.id)) {
+    visited.add(current.id);
+    branch.push(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+
+  const changes: Array<{ level: string | undefined; timestamp: number }> = [];
+  let displayLabel: string | undefined;
+  for (const entry of branch.reverse()) {
+    if (entry.type === "thinking_level_change") {
+      changes.push({ level: knownThinkingLevel(entry.thinkingLevel), timestamp: Date.parse(entry.timestamp) });
+      displayLabel = undefined;
+    }
+    displayLabel = customMessageThinkingLabel(entry) ?? displayLabel;
+    if (!wanted.has(entry.id) || entry.type !== "message" || entry.message.role !== "assistant") continue;
+    const message = entry.message;
+    let index = changes.length - 1;
+    // Old records were appended at completion. A setting changed mid-response
+    // must not relabel a response whose start timestamp precedes that change.
+    if (typeof message.timestamp === "number" && Number.isFinite(message.timestamp)) {
+      while (index >= 0 && changes[index].timestamp > message.timestamp) index -= 1;
+    }
+    const level = messageThinkingLevel(message, displayLabel ?? changes[index]?.level);
+    if (level !== undefined) levels.set(entry.id, level);
+  }
+  return levels;
+}
+
+export function readCurrentMessageThinkingLabel(entries: SessionEntry[]): string | undefined {
+  let label: string | undefined;
+  for (const entry of entries) {
+    if (entry.type === "thinking_level_change") label = undefined;
+    label = customMessageThinkingLabel(entry) ?? label;
+  }
+  return label;
+}

--- a/lib/rpc-manager-shutdown.test.mjs
+++ b/lib/rpc-manager-shutdown.test.mjs
@@ -12,12 +12,19 @@ const { registerSessionLivenessProvider } = await jiti.import("./session-livenes
 const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
 
 function makePromptInner(prompt) {
+  const entries = [];
   return {
     sessionId: "session-1",
     isBashRunning: false,
     isStreaming: false,
     extensionRunner: {},
-    sessionManager: { getCwd: () => "/tmp" },
+    sessionManager: {
+      getCwd: () => "/tmp",
+      getBranch: () => entries,
+      appendCustomEntry(customType, data) {
+        entries.push({ type: "custom", id: `custom-${entries.length}`, parentId: null, timestamp: new Date().toISOString(), customType, data });
+      },
+    },
     agent: { state: {} },
     getContextUsage: () => null,
     getSteeringMessages: () => [],
@@ -89,6 +96,41 @@ test("prompt commands wait for SDK preflight acceptance before acknowledging", a
 
   assert.equal(wrapper.isRunning(), false);
   assert.equal(events.filter((event) => event.type === "prompt_done").length, 1);
+});
+
+test("accepted prompts persist their bounded display thinking label", async (t) => {
+  const inner = makePromptInner((_message, options) => {
+    options.preflightResult(true);
+    return Promise.resolve();
+  });
+  const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
+
+  await wrapper.send({ type: "prompt", message: "hello", displayThinkingLevel: " auto " });
+  await nextTurn();
+
+  assert.deepEqual(inner.sessionManager.getBranch().map(({ customType, data }) => ({ customType, data })), [{
+    customType: "pi-web:message-thinking",
+    data: { version: 1, label: "auto" },
+  }]);
+  assert.equal((await wrapper.send({ type: "get_state" })).messageThinkingLevel, "auto");
+});
+
+test("invalid display thinking labels reject before starting a prompt", async (t) => {
+  let promptCalls = 0;
+  const inner = makePromptInner(() => {
+    promptCalls += 1;
+    return Promise.resolve();
+  });
+  const wrapper = new AgentSessionWrapper(inner);
+  t.after(() => wrapper.destroy());
+
+  await assert.rejects(
+    wrapper.send({ type: "prompt", message: "hello", displayThinkingLevel: "bad\nlabel" }),
+    /Invalid message thinking label/,
+  );
+  assert.equal(promptCalls, 0);
+  assert.deepEqual(inner.sessionManager.getBranch(), []);
 });
 
 test("completion notification waits for an accepted agent run to become idle", async (t) => {
@@ -217,12 +259,13 @@ test("prompt commands reject when SDK preflight fails", async (t) => {
   wrapper.onEvent((event) => events.push(event));
 
   await assert.rejects(
-    wrapper.send({ type: "prompt", message: "hello" }),
+    wrapper.send({ type: "prompt", message: "hello", displayThinkingLevel: "high" }),
     /Authentication failed/,
   );
 
   assert.equal(wrapper.isRunning(), false);
   assert.deepEqual(events, []);
+  assert.deepEqual(inner.sessionManager.getBranch(), []);
 });
 
 test("accepted prompt failures still finish through the event stream", async (t) => {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -43,6 +43,11 @@ import { isBuiltInSubagentsEnabled } from "./subagent-settings";
 import { resolveShellTools } from "./powershell-settings";
 import { CHAT_ONLY_RESOURCE_LOADER_OPTIONS, contextFilesSystemPrompt } from "./chat-only";
 import {
+  MESSAGE_THINKING_CUSTOM_TYPE,
+  normalizeMessageThinkingLabel,
+  readCurrentMessageThinkingLabel,
+} from "./message-thinking";
+import {
   appendSessionToolSelection,
   readSessionToolSelection,
   validateSessionToolSelection,
@@ -276,6 +281,15 @@ export class AgentSessionWrapper {
 
   get isStreaming(): boolean {
     return this.inner.isStreaming;
+  }
+
+  get messageThinkingLevel(): string | undefined {
+    const manager = this.inner.sessionManager as unknown as { getBranch?: () => unknown };
+    if (typeof manager.getBranch !== "function") return undefined;
+    const entries = manager.getBranch();
+    return readCurrentMessageThinkingLabel(
+      Array.isArray(entries) ? entries as SessionEntry[] : [],
+    );
   }
 
   isAlive(): boolean {
@@ -590,15 +604,31 @@ export class AgentSessionWrapper {
           }
           const promptImages = command.images as Array<{ type: "image"; data: string; mimeType: string }> | undefined;
           const streamingBehavior = command.streamingBehavior as "steer" | "followUp" | undefined;
+          const messageThinkingLevel = normalizeMessageThinkingLabel(command.displayThinkingLevel);
           let preflightAccepted = false;
           let preflightSettled = false;
           let promptSettled = false;
+          let thinkingLabelPersisted = false;
           let acceptPreflight!: () => void;
           let rejectPreflight!: (error: unknown) => void;
           const preflight = new Promise<void>((resolve, reject) => {
             acceptPreflight = () => {
               preflightAccepted = true;
               this.agentRunNeedsCompletion = true;
+              if (messageThinkingLevel && !thinkingLabelPersisted) {
+                thinkingLabelPersisted = true;
+                try {
+                  this.inner.sessionManager.appendCustomEntry(
+                    MESSAGE_THINKING_CUSTOM_TYPE,
+                    { version: 1, label: messageThinkingLevel },
+                  );
+                } catch (error) {
+                  console.error(
+                    "[pi-web] failed to persist message thinking label:",
+                    error instanceof Error ? error.message : error,
+                  );
+                }
+              }
               if (preflightSettled) return;
               preflightSettled = true;
               resolve();
@@ -706,6 +736,7 @@ export class AgentSessionWrapper {
             : null,
           systemPrompt: this.inner.agent.state?.systemPrompt ?? "",
           thinkingLevel: this.inner.agent.state?.thinkingLevel ?? "off",
+          messageThinkingLevel: this.messageThinkingLevel,
           extensionStatuses: this.getExtensionStatuses(),
           extensionWidgets: this.getExtensionWidgets(),
         };

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -14,6 +14,7 @@ import { MAX_TOOL_RESULT_IMAGE_BYTES, TOOL_RESULT_IMAGE_MIMES } from "./tool-res
 import { resolveProject, type ProjectInfo } from "./worktree";
 import { readSubagentRun, SUBAGENT_META_TYPE } from "./subagents";
 import { listSessionsIncremental } from "./session-list-scanner";
+import { readMessageThinkingLevels } from "./message-thinking";
 
 export { getAgentDir };
 
@@ -470,10 +471,12 @@ export function buildSessionContext(
   // Convert messages and their IDs together to keep fork/navigation targets aligned.
   const messages: AgentMessage[] = [];
   const entryIds: string[] = [];
+  const messageThinkingLevels = readMessageThinkingLevels(entries, sliced.map((entry) => entry.id));
   for (const entry of sliced) {
     const m = entryToUiMessage(entry, options);
     if (m) {
-      messages.push(m);
+      const level = messageThinkingLevels.get(entry.id);
+      messages.push(m.role === "assistant" && level !== undefined ? { ...m, thinkingLevel: level } : m);
       entryIds.push(entry.id);
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,6 +74,8 @@ export interface AssistantMessage {
   content: AssistantContentBlock[];
   model: string;
   provider: string;
+  /** Display label copied from the composer or read from session settings. */
+  thinkingLevel?: string;
   stopReason?: string;
   errorMessage?: string;
   timestamp?: number;


### PR DESCRIPTION
Assistant replies currently show only the model, so historical turns lose the reasoning level selected when Send was pressed. This adds the display label beside the model, records a bounded versioned custom entry after prompt preflight accepts, and restores exact `auto` and provider-mapped labels across streaming reconnects and history reloads while legacy replies use branch setting history.

Validation:

- `npm test` (1034 passed)
- `npm run lint`
- `node_modules/.bin/tsc --noEmit --incremental false`
- Full Playwright E2E at 1280px and 390px
