### PR TITLE
Show total turn duration in existing chat metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,10 @@ Newer pi emits `compaction_start` / `compaction_end`; older versions emitted `au
 - While a run is active, `useAgentSession` periodically calls `GET /api/agent/[id]` and also reconciles on `visibilitychange`/`online`. This fixes missed terminal events from background tabs or half-open connections.
 - Prompt runs use a monotonic run id; late SSE or slow reconciliation responses from an old run must be ignored so they cannot resurrect stale streaming bubbles.
 
+### Turn duration
+
+Whole-run duration uses the server run lifecycle, including retries, queued follow-ups, tools and automatic compaction. SSE and state snapshots carry `turnTiming`; completed records use the versioned `pi-web:turn-timing` custom entry anchored to a visible entry. Old sessions without this record show no duration. Keep the timer in existing process, phase or message metadata rows so history pagination is still based on the existing rendered rows.
+
 ### Worktrees and project grouping
 - `lib/worktree.ts` resolves linked worktree top-levels back to the main repo `projectRoot`; `listAllSessions()` attaches that to each `SessionInfo` so all worktrees for one repo are grouped together in the sidebar.
 - Worktree operations are served by `/api/worktrees` and guarded by the same allowed-root rules as `/api/files`.

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -10,6 +10,8 @@ import { extractTurnWrittenFiles, type WrittenFile } from "@/lib/turn-written-fi
 import { buildQuotedSelection } from "@/lib/quoted-selection";
 import { MessageView } from "./MessageView";
 import { MarkdownBody } from "./MarkdownBody";
+import { TurnDuration } from "./TurnDuration";
+import type { TurnTiming } from "@/lib/turn-timing";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
 import { ChatMinimap, useMessageRefs } from "./ChatMinimap";
 import { ExtensionStatusBar } from "./ExtensionStatusBar";
@@ -193,12 +195,12 @@ function withAssistantBlocks(
   return next;
 }
 
-function ProcessDetailsGroup({ messageCount, toolCallCount, defaultExpanded = false, reveal = false, children, t }: { messageCount: number; toolCallCount: number; defaultExpanded?: boolean; reveal?: boolean; children: ReactNode; t: (key: string, params?: Record<string, string | number>) => string }) {
+function ProcessDetailsGroup({ messageCount, toolCallCount, timing, defaultExpanded = false, reveal = false, children, t }: { messageCount: number; toolCallCount: number; timing?: TurnTiming; defaultExpanded?: boolean; reveal?: boolean; children: ReactNode; t: (key: string, params?: Record<string, string | number>) => string }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   useLayoutEffect(() => {
     if (reveal) setExpanded(true);
   }, [reveal]);
-  const parts = [t("chat.processDetails"), `${messageCount} ${t(messageCount === 1 ? "chat.message" : "chat.messages")}`];
+  const parts = [`${messageCount} ${t(messageCount === 1 ? "chat.message" : "chat.messages")}`];
   if (toolCallCount > 0) parts.push(`${toolCallCount} ${t(toolCallCount === 1 ? "chat.toolCall" : "chat.toolCalls")}`);
 
   return (
@@ -212,6 +214,7 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, defaultExpanded = fa
           alignItems: "center",
           gap: 8,
           width: "auto",
+          maxWidth: "100%",
           minHeight: 24,
           padding: "2px 0",
           border: "none",
@@ -226,8 +229,10 @@ function ProcessDetailsGroup({ messageCount, toolCallCount, defaultExpanded = fa
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, transform: expanded ? "rotate(90deg)" : "none", transition: "transform 0.15s" }}>
           <polyline points="4 2.5 7.5 6 4 9.5" />
         </svg>
-        <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          {parts.join(" · ")}
+        <span style={{ minWidth: 0, display: "flex", alignItems: "baseline", flexWrap: "wrap", columnGap: 4 }}>
+          <span>{t("chat.processDetails")}</span>
+          {timing && <> · <TurnDuration timing={timing} /></>}
+          {` · ${parts.join(" · ")}`}
         </span>
       </button>
       {(expanded || reveal) && (
@@ -273,7 +278,7 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
   const [restoreAnchorReady, setRestoreAnchorReady] = useState(false);
 
   const {
-    loading, error, messages, activeToolResults, entryIds, historyCursor, hasEarlierMessages, streamState,
+    loading, error, messages, activeToolResults, entryIds, historyCursor, hasEarlierMessages, streamState, turnTiming, turnTimings,
     agentRunning, bashRunning, pendingBash, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, toolPreset, thinkingLevel,
     retryInfo, contextUsage, forkingEntryId,
     isCompacting, compactError, compactResult, displayModel: displayModelValue, modelSwitching, sessionStats,
@@ -296,6 +301,13 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
     deferInitialScroll: Boolean(pendingScrollRestore),
   });
   const sessionBusy = agentRunning || bashRunning;
+  const timingsByEntry = useMemo(() => {
+    const timings = new Map<string, TurnTiming>();
+    for (const timing of [...turnTimings, ...(turnTiming?.endedAt !== undefined ? [turnTiming] : [])]) {
+      if (timing.anchorEntryId && timing.endedAt !== undefined) timings.set(timing.anchorEntryId, timing);
+    }
+    return timings;
+  }, [turnTimings, turnTiming]);
   const [quotedSelection, setQuotedSelection] = useState<{
     text: string;
     top: number;
@@ -1017,7 +1029,7 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                 if (idx === lastUserIdx) { (lastUserMsgRef as { current: HTMLDivElement | null }).current = el; }
               };
 
-              const renderMessage = (idx: number, options: { attachRef?: boolean; keyPrefix?: string; messageOverride?: AgentMessage; showTimestamp?: boolean; writtenFiles?: WrittenFile[] } = {}): ReactNode => {
+              const renderMessage = (idx: number, options: { attachRef?: boolean; keyPrefix?: string; messageOverride?: AgentMessage; showTimestamp?: boolean; writtenFiles?: WrittenFile[]; turnTiming?: TurnTiming } = {}): ReactNode => {
                 const msg = options.messageOverride ?? messages[idx];
                 const isVisible = isMessageGroupAnchor(msg) || msg.role === "assistant";
                 const currentRefIdx = visibleRefIndexByMessage.get(idx);
@@ -1056,6 +1068,7 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                     prevTimestamp={idx > 0 ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp : undefined}
                     sessionId={session?.id ?? sessionIdRef.current ?? undefined}
                     writtenFiles={options.writtenFiles}
+                    turnTiming={options.turnTiming}
                   />
                 );
                 if (!isVisible || currentRefIdx === undefined) return view;
@@ -1070,7 +1083,9 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
               for (let idx = 0; idx < messages.length;) {
                 const msg = messages[idx];
                 if (!isMessageGroupAnchor(msg)) {
-                  rendered.push(renderMessage(idx));
+                  rendered.push(renderMessage(idx, {
+                    turnTiming: timingsByEntry.get(entryIds[idx]),
+                  }));
                   idx += 1;
                   continue;
                 }
@@ -1080,16 +1095,23 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                 while (endIdx < messages.length && !isMessageGroupAnchor(messages[endIdx])) endIdx += 1;
 
                 const finalAssistantIdx = findFinalAssistantIndex(messages, userIdx, endIdx);
+                const isLiveTail = (sessionBusy || streamState.isStreaming) && endIdx === messages.length && userIdx === lastAnchorIdx;
+                let timing: TurnTiming | undefined;
+                for (let timingIdx = endIdx - 1; timingIdx >= userIdx; timingIdx--) {
+                  timing = timingsByEntry.get(entryIds[timingIdx]);
+                  if (timing) break;
+                }
+                if (isLiveTail && turnTiming?.endedAt === undefined) timing = turnTiming ?? undefined;
+
 
                 if (finalAssistantIdx === -1) {
                   for (let renderIdx = userIdx; renderIdx < endIdx; renderIdx++) {
-                    rendered.push(renderMessage(renderIdx));
+                    rendered.push(renderMessage(renderIdx, { turnTiming: !isLiveTail && renderIdx === userIdx ? timing : undefined }));
                   }
                   idx = endIdx;
                   continue;
                 }
 
-                const isLiveTail = (sessionBusy || streamState.isStreaming) && endIdx === messages.length && userIdx === lastAnchorIdx;
                 if (isLiveTail) {
                   for (let renderIdx = userIdx; renderIdx < endIdx; renderIdx++) {
                     rendered.push(renderMessage(renderIdx));
@@ -1098,11 +1120,11 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                   continue;
                 }
 
-                rendered.push(renderMessage(userIdx));
-
                 const finalAssistant = messages[finalAssistantIdx] as AssistantMessage;
                 const finalSplit = splitFinalAssistantBlocks(finalAssistant);
-                const finalAnswerMessage = finalSplit.answerBlocks.length > 0 || getAssistantErrorMessage(finalAssistant)
+                const providerError = getAssistantErrorMessage(finalAssistant);
+                const providerErrorOnly = finalSplit.answerBlocks.length === 0 && Boolean(providerError);
+                const finalAnswerMessage = finalSplit.answerBlocks.length > 0 || providerError
                   ? withAssistantBlocks(finalAssistant, finalSplit.answerBlocks)
                   : null;
 
@@ -1139,13 +1161,18 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                   }));
                 }
 
+                const timingOnUser = processViews.length === 0 && (providerErrorOnly || !finalAnswerMessage)
+                  ? timing
+                  : undefined;
+                rendered.push(renderMessage(userIdx, { turnTiming: timingOnUser }));
+
                 if (processViews.length > 0) {
                   rendered.push(
                     <div
                       key={`process-group-${entryIds[userIdx] ?? userIdx}`}
                       ref={processRefIdx === undefined ? undefined : (el) => { messageRefs.current[processRefIdx] = el; }}
                     >
-                      <ProcessDetailsGroup messageCount={processViews.length} toolCallCount={processToolCount} defaultExpanded={!finalAnswerMessage} reveal={revealProcess} t={t}>
+                      <ProcessDetailsGroup messageCount={processViews.length} toolCallCount={processToolCount} timing={timing} defaultExpanded={!finalAnswerMessage} reveal={revealProcess} t={t}>
                         {processViews}
                       </ProcessDetailsGroup>
                     </div>,
@@ -1167,6 +1194,7 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
                   const writtenFiles = extractTurnWrittenFiles(turnContent, toolResultsMap, messageCwd);
                   rendered.push(renderMessage(finalAssistantIdx, {
                     messageOverride: finalAnswerMessage,
+                    turnTiming: processViews.length === 0 && !timingOnUser ? timing : undefined,
                     writtenFiles,
                   }));
                 }
@@ -1189,12 +1217,13 @@ export function ChatWindow({ session, searchTarget, onSearchTargetHandled, initi
               );
             })()}
             {streamState.isStreaming && hasStreamingContent && streamState.streamingMessage && (
-              <MessageView message={streamState.streamingMessage as AgentMessage} toolResults={toolResultsMap} isStreaming modelNames={modelNames} cwd={messageCwd} onOpenFile={onOpenFile} onOpenSession={onOpenSession} />
+              <MessageView turnTiming={turnTiming ?? undefined} message={streamState.streamingMessage as AgentMessage} toolResults={toolResultsMap} isStreaming modelNames={modelNames} cwd={messageCwd} onOpenFile={onOpenFile} onOpenSession={onOpenSession} />
             )}
 
-            {agentRunning && !hasStreamingContent && agentPhase && (
+            {agentRunning && !hasStreamingContent && (agentPhase || turnTiming) && (
               <div className="break-words py-2 text-[13px] text-text-muted">
-                <span className="animate-[pulse_1.5s_infinite]">{phaseLabel(agentPhase, t)}</span>
+                <span className="animate-[pulse_1.5s_infinite]">{phaseLabel(agentPhase, t) ?? t("chat.processDetails")}</span>
+                {turnTiming && <> · <TurnDuration timing={turnTiming} live elapsedOnly /></>}
               </div>
             )}
 

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { TurnDuration } from "./TurnDuration";
+import type { TurnTiming } from "@/lib/turn-timing";
 
 import { memo, useState, useRef, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
@@ -180,6 +182,7 @@ function loadThinkingContent(sessionId: string, entryId: string, blockIndex: num
 }
 
 interface Props {
+  turnTiming?: TurnTiming;
   message: AgentMessage;
   isStreaming?: boolean;
   toolResults?: Map<string, ToolResultMessage>;
@@ -270,12 +273,12 @@ function haveSameRelevantToolResults(
   return true;
 }
 
-export const MessageView = memo(function MessageView({ message, isStreaming, toolResults, modelNames, cwd, onOpenFile, onOpenSession, entryId, searchBlock, onFork, forking, onNavigate, onEditContent, showTimestamp, prevTimestamp, sessionId, writtenFiles }: Props) {
+export const MessageView = memo(function MessageView({ turnTiming, message, isStreaming, toolResults, modelNames, cwd, onOpenFile, onOpenSession, entryId, searchBlock, onFork, forking, onNavigate, onEditContent, showTimestamp, prevTimestamp, sessionId, writtenFiles }: Props) {
   if (message.role === "user") {
-    return <UserMessageView message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} onEditContent={onEditContent} />;
+    return <UserMessageView turnTiming={turnTiming} message={message as UserMessage} cwd={cwd} onOpenFile={onOpenFile} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} onEditContent={onEditContent} />;
   }
   if (message.role === "assistant") {
-    return <AssistantMessageView message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} onOpenSession={onOpenSession} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} searchBlock={searchBlock} writtenFiles={writtenFiles} />;
+    return <AssistantMessageView turnTiming={turnTiming} message={message as AssistantMessage} isStreaming={isStreaming} toolResults={toolResults} modelNames={modelNames} cwd={cwd} onOpenFile={onOpenFile} onOpenSession={onOpenSession} showTimestamp={showTimestamp} prevTimestamp={prevTimestamp} sessionId={sessionId} entryId={entryId} searchBlock={searchBlock} writtenFiles={writtenFiles} />;
   }
   if (message.role === "toolResult") {
     // Rendered inline under its toolCall — skip standalone rendering if paired
@@ -283,9 +286,9 @@ export const MessageView = memo(function MessageView({ message, isStreaming, too
   }
   if (message.role === "custom") {
     if ((message as CustomMessage).customType === "compaction") {
-      return <CompactionMessageView message={message as CustomMessage} />;
+      return <CompactionMessageView turnTiming={turnTiming} message={message as CustomMessage} />;
     }
-    return <CustomMessageView message={message as CustomMessage} cwd={cwd} onOpenFile={onOpenFile} />;
+    return <CustomMessageView turnTiming={turnTiming} message={message as CustomMessage} cwd={cwd} onOpenFile={onOpenFile} />;
   }
   if (message.role === "bashExecution") {
     return <BashExecutionView message={message as BashExecutionMessage} sessionId={sessionId} />;
@@ -308,11 +311,13 @@ export const MessageView = memo(function MessageView({ message, isStreaming, too
     && prev.showTimestamp === next.showTimestamp
     && prev.prevTimestamp === next.prevTimestamp
     && prev.writtenFiles === next.writtenFiles
+    && prev.turnTiming === next.turnTiming
     && prev.sessionId === next.sessionId;
 });
 
-function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, onEditContent }: {
+function UserMessageView({ turnTiming, message, cwd, onOpenFile, entryId, onFork, forking, onNavigate, onEditContent }: {
   message: UserMessage;
+  turnTiming?: TurnTiming;
   cwd?: string;
   onOpenFile?: (filePath: string) => void;
   entryId?: string;
@@ -586,7 +591,8 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
               )}
             </div>
           )}
-          {time && <span style={{ fontSize: 10, color: "var(--text-dim)" }}>{time}</span>}
+          {turnTiming && <span style={{ flexShrink: 0, whiteSpace: "nowrap", fontSize: 10, color: "var(--text-dim)" }}><TurnDuration timing={turnTiming} /></span>}
+          {time && <span style={{ flexShrink: 0, whiteSpace: "nowrap", fontSize: 10, color: "var(--text-dim)" }}>{time}</span>}
         </div>
       )}
     </div>
@@ -594,6 +600,7 @@ function UserMessageView({ message, cwd, onOpenFile, entryId, onFork, forking, o
 }
 
 function AssistantMessageView({
+  turnTiming,
   message,
   isStreaming,
   toolResults,
@@ -609,6 +616,7 @@ function AssistantMessageView({
   writtenFiles,
 }: {
   message: AssistantMessage;
+  turnTiming?: TurnTiming;
   isStreaming?: boolean;
   toolResults?: Map<string, ToolResultMessage>;
   modelNames?: Record<string, string>;
@@ -765,11 +773,13 @@ function AssistantMessageView({
           display: "flex",
           alignItems: "center",
           gap: 6,
+          flexWrap: "wrap",
         }}
       >
         {message.provider && (
           <span>{getModelDisplayName(message.provider, message.model, modelNames)}</span>
         )}
+        {turnTiming && <span>{message.provider ? "· " : ""}<TurnDuration timing={turnTiming} live={isStreaming} /></span>}
         {isStreaming && (() => {
           const est = Math.round(estimatedTokens);
           return (
@@ -1435,7 +1445,7 @@ function PairedResult({ text, images, isEmpty, isError }: {
   );
 }
 
-function CompactionMessageView({ message }: { message: CustomMessage }) {
+function CompactionMessageView({ turnTiming, message }: { turnTiming?: TurnTiming; message: CustomMessage }) {
   const { t } = useI18n();
   const summary = getMessageText(message.content);
   const parsedSummary = useMemo(() => parseCompactionSummary(summary), [summary]);
@@ -1465,7 +1475,8 @@ function CompactionMessageView({ message }: { message: CustomMessage }) {
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, fontWeight: 650 }}>
             compaction
           </span>
-          {time && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
+          {turnTiming && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}><TurnDuration timing={turnTiming} /></span>}
+          {time && <span style={{ marginLeft: turnTiming ? 0 : "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
         </div>
 
         <div style={{ padding: "11px 13px 12px" }}>
@@ -1518,7 +1529,7 @@ function CompactionFileList({ title, files }: { title: string; files: string[] }
   );
 }
 
-function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessage; cwd?: string; onOpenFile?: (filePath: string) => void }) {
+function CustomMessageView({ turnTiming, message, cwd, onOpenFile }: { turnTiming?: TurnTiming; message: CustomMessage; cwd?: string; onOpenFile?: (filePath: string) => void }) {
   const { t } = useI18n();
   const isHiddenDisplay = message.display === false;
   const [contentExpanded, setContentExpanded] = useState(!isHiddenDisplay);
@@ -1565,7 +1576,8 @@ function CustomMessageView({ message, cwd, onOpenFile }: { message: CustomMessag
             {title}
           </span>
            {isHiddenDisplay && <span style={{ color: "var(--text-dim)", fontSize: 11 }}>{t("i18n.hiddenExtensionMessage")}</span>}
-          {time && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
+          {turnTiming && <span style={{ marginLeft: "auto", color: "var(--text-dim)", fontSize: 10 }}><TurnDuration timing={turnTiming} /></span>}
+          {time && <span style={{ marginLeft: turnTiming ? 0 : "auto", color: "var(--text-dim)", fontSize: 10 }}>{time}</span>}
         </div>
 
         {contentExpanded ? (

--- a/components/TurnDuration.test.mjs
+++ b/components/TurnDuration.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, { jsx: { runtime: "automatic" }, tsconfigPaths: true });
+const React = await jiti.import("react");
+const { renderToStaticMarkup } = await jiti.import("react-dom/server");
+const { I18nProvider } = await jiti.import("@/hooks/useI18n");
+const { TurnDuration, formatTurnDuration } = await jiti.import("./TurnDuration.tsx");
+const { mergeTurnTiming } = await jiti.import("@/lib/turn-timing");
+
+const render = (component, props) => renderToStaticMarkup(
+  React.createElement(I18nProvider, null, React.createElement(component, props)),
+);
+
+test("formats short, minute and hour durations without rounding across boundaries", () => {
+  for (const [ms, zh, en] of [
+    [0, "0秒", "0s"],
+    [59999, "59秒", "59s"],
+    [60000, "1分0秒", "1m 0s"],
+    [222000, "3分42秒", "3m 42s"],
+    [3600000, "1小时0分0秒", "1h 0m 0s"],
+  ]) {
+    assert.equal(formatTurnDuration(ms, "zh-CN"), zh);
+    assert.equal(formatTurnDuration(ms, "en"), en);
+  }
+  assert.equal(formatTurnDuration(-1000, "en"), "0s");
+  assert.equal(formatTurnDuration(3600000, "zh-TW"), "1小時0分0秒");
+});
+
+test("a refreshed live timer uses the server start, and completion freezes it", (t) => {
+  t.mock.method(Date, "now", () => 101000);
+  const timing = { id: "run", startedAt: 18000 };
+  assert.match(render(TurnDuration, { timing, live: true }), /Working · 1m 23s/);
+  const finished = { ...timing, endedAt: 60000 };
+  assert.match(render(TurnDuration, { timing: finished, live: true }), /Took 42s/);
+  assert.match(render(TurnDuration, { timing: finished }), /Took 42s/);
+  assert.equal(render(TurnDuration, { timing }), "");
+});
+
+test("late snapshots cannot restart a finished timer or overwrite a newer run", () => {
+  const started = { id: "first", startedAt: 1000 };
+  const finished = { ...started, endedAt: 5000 };
+  const next = { id: "second", startedAt: 6000 };
+  assert.equal(mergeTurnTiming(started, finished), finished);
+  assert.equal(mergeTurnTiming(finished, started), finished);
+  assert.equal(mergeTurnTiming(next, finished), next);
+  assert.equal(mergeTurnTiming(finished, next), next);
+  assert.equal(mergeTurnTiming(started, null), null);
+});

--- a/components/TurnDuration.tsx
+++ b/components/TurnDuration.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useI18n } from "@/hooks/useI18n";
+import type { TurnTiming } from "@/lib/turn-timing";
+
+export function formatTurnDuration(milliseconds: number, locale: string): string {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor(seconds % 3600 / 60);
+  const remainder = seconds % 60;
+  if (locale.startsWith("zh")) {
+    return `${hours ? `${hours}${locale === "zh-TW" ? "小時" : "小时"}` : ""}${minutes || hours ? `${minutes}分` : ""}${remainder}秒`;
+  }
+  return [hours ? `${hours}h` : "", minutes || hours ? `${minutes}m` : "", `${remainder}s`].filter(Boolean).join(" ");
+}
+
+/** Keep the ticking state local so long transcripts do not rerender every second. */
+export function TurnDuration({ timing, live = false, elapsedOnly = false }: { timing: TurnTiming; live?: boolean; elapsedOnly?: boolean }) {
+  const { t, locale } = useI18n();
+  const [now, setNow] = useState(() => Date.now());
+  const running = live && timing.endedAt === undefined;
+  useEffect(() => {
+    if (!running) return;
+    const update = () => setNow(Date.now());
+    update();
+    const timer = setInterval(update, 1000);
+    document.addEventListener("visibilitychange", update);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", update);
+    };
+  }, [running, timing.id]);
+
+  if (!running && timing.endedAt === undefined) return null;
+  const duration = formatTurnDuration((timing.endedAt ?? now) - timing.startedAt, locale);
+  return (
+    <span style={{ fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+      {elapsedOnly ? duration : t(running ? "chat.turnRunningDuration" : "chat.turnDuration", { duration })}
+    </span>
+  );
+}

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { checkExtensionDialogs, extensionSource } from "./extension-dialog.mjs";
 import { checkChatAppearance } from "./chat-appearance.mjs";
+import { checkTurnTiming, seedTurnTiming } from "./turn-timing.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const mode = process.env.E2E_SERVER_MODE || "dev";
@@ -57,6 +58,7 @@ process.once("SIGINT", interrupt);
 process.once("SIGTERM", interrupt);
 
 try {
+  const featureSessionIds = seedTurnTiming(writeSession, timestamp);
   // Seed before startup so the first catalogue scan sees every fixture.
   mkdirSync(join(agentDir, "extensions"));
   writeFileSync(join(agentDir, "extensions", "e2e-dialog.js"), extensionSource);
@@ -144,7 +146,7 @@ try {
     const response = await fetch(`${base}/api/sessions`, { signal: AbortSignal.timeout(5000) }).catch(() => null);
     if (response?.ok) {
       const { sessions } = await response.json();
-      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED].sort());
+      assert.deepEqual(sessions.map((session) => session.id).sort(), [LONG, BRANCH, RICH, COMPACTED, ...featureSessionIds].sort());
       break;
     }
     assert.ok(Date.now() < deadline, "Server readiness timed out; see server.log");
@@ -358,6 +360,7 @@ try {
       await page.locator(".markdown-code-block pre").waitFor();
       await checkChatAppearance(page);
     }
+    await checkTurnTiming({ page, base, artifacts, width: viewport.width });
     assert.deepEqual(errors, [], `Browser errors at width ${viewport.width}`);
     console.log(`PASS: ${viewport.width}px browser pagination, branch, markdown, code, tool call, and compaction navigation`);
     await context.tracing.stop();

--- a/e2e/turn-timing.mjs
+++ b/e2e/turn-timing.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+const PROCESS = "e2e-turn-timing-process";
+const PLAIN = "e2e-turn-timing-plain";
+const USER_ONLY = "e2e-turn-timing-user-only";
+const FAILURE = "e2e-turn-timing-failure";
+const ABORTED = "e2e-turn-timing-aborted";
+const PAGED = "e2e-turn-timing-paged";
+const LIVE = "e2e-turn-timing-live";
+const LEGACY = "e2e-turn-timing-legacy";
+
+function message(id, parentId, role, content, timestamp, extra = {}) {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: { role, content, timestamp: Date.parse(timestamp), ...extra },
+  };
+}
+
+function timing(id, parentId, anchorEntryId, startedAt) {
+  return {
+    type: "custom",
+    id: `${id}-timing`,
+    parentId,
+    timestamp: new Date(startedAt + 222_000).toISOString(),
+    customType: "pi-web:turn-timing",
+    data: {
+      version: 1,
+      id: `${id}-run`,
+      startedAt,
+      endedAt: startedAt + 222_000,
+      anchorEntryId,
+    },
+  };
+}
+
+export function seedTurnTiming(writeSession, timestamp) {
+  const startedAt = Date.parse(timestamp);
+  const prompt = (id, text = "Create a small offline bicycle animation") =>
+    message(`${id}-user`, null, "user", text, timestamp);
+  const answer = (id) => message(
+    `${id}-answer`,
+    `${id}-user`,
+    "assistant",
+    [{ type: "text", text: "The bicycle animation is ready." }],
+    timestamp,
+    { provider: "test", model: "timer" },
+  );
+
+  const processUser = prompt(PROCESS);
+  const processStep = message(
+    `${PROCESS}-step`,
+    processUser.id,
+    "assistant",
+    [{ type: "thinking", thinking: "Plan the motion path." }],
+    timestamp,
+    { provider: "test", model: "timer" },
+  );
+  const processAnswer = { ...answer(PROCESS), parentId: processStep.id };
+  writeSession(PROCESS, [
+    processUser,
+    processStep,
+    processAnswer,
+    timing(PROCESS, processAnswer.id, processAnswer.id, startedAt),
+  ]);
+
+  const plainUser = prompt(PLAIN);
+  const plainAnswer = answer(PLAIN);
+  writeSession(PLAIN, [plainUser, plainAnswer, timing(PLAIN, plainAnswer.id, plainAnswer.id, startedAt)]);
+
+  const userOnly = prompt(USER_ONLY, "Stop before the assistant replies");
+  writeSession(USER_ONLY, [userOnly, timing(USER_ONLY, userOnly.id, userOnly.id, startedAt)]);
+
+  const failureUser = prompt(FAILURE, "Trigger a provider failure");
+  const failureAnswer = message(
+    `${FAILURE}-answer`,
+    failureUser.id,
+    "assistant",
+    [],
+    timestamp,
+    { provider: "test", model: "timer", stopReason: "error", errorMessage: "Provider unavailable" },
+  );
+  writeSession(FAILURE, [failureUser, failureAnswer, timing(FAILURE, failureAnswer.id, failureAnswer.id, startedAt)]);
+
+  const abortedUser = prompt(ABORTED, "Stop before any response text");
+  const abortedAnswer = message(
+    `${ABORTED}-answer`,
+    abortedUser.id,
+    "assistant",
+    [],
+    timestamp,
+    { provider: "test", model: "timer", stopReason: "aborted" },
+  );
+  writeSession(ABORTED, [abortedUser, abortedAnswer, timing(ABORTED, abortedAnswer.id, abortedAnswer.id, startedAt)]);
+
+  const paged = [prompt(PAGED, "Prompt outside the first history page")];
+  for (let index = 0; index < 50; index += 1) {
+    const id = `${PAGED}-answer-${index}`;
+    paged.push(message(
+      id,
+      paged.at(-1).id,
+      "assistant",
+      [{ type: "text", text: `Paged assistant ${index}` }],
+      timestamp,
+      { provider: "test", model: "timer" },
+    ));
+  }
+  const pagedAnswer = paged.at(-1);
+  paged.push(timing(PAGED, pagedAnswer.id, pagedAnswer.id, startedAt));
+  writeSession(PAGED, paged);
+
+  writeSession(LIVE, [prompt(LIVE, "Show a running timer")]);
+  writeSession(LEGACY, [prompt(LEGACY), answer(LEGACY)]);
+  return [PROCESS, PLAIN, USER_ONLY, FAILURE, ABORTED, PAGED, LIVE, LEGACY];
+}
+
+export async function checkTurnTiming({ page, base, artifacts, width }) {
+  await page.setViewportSize({ width, height: width > 600 ? 800 : 844 });
+  const liveTiming = { id: `live-${width}`, startedAt: Date.now() - 83_000, anchorEntryId: `${LIVE}-user` };
+  const liveState = {
+    running: true,
+    state: { isStreaming: true, isPromptRunning: true, turnTiming: liveTiming },
+  };
+  const stateRoute = `**/api/sessions/${LIVE}/state`;
+  const agentRoute = `**/api/agent/${LIVE}`;
+  const eventsRoute = `**/api/agent/${LIVE}/events`;
+  await page.route(stateRoute, (route) => route.fulfill({ json: liveState }));
+  await page.route(agentRoute, (route) => route.fulfill({ json: liveState }));
+  await page.route(eventsRoute, (route) => route.fulfill({
+    contentType: "text/event-stream",
+    body: `data: ${JSON.stringify({ type: "connected", sessionId: LIVE, isStreaming: true, turnTiming: liveTiming })}\n\n`,
+  }));
+  await page.goto(`${base}/?session=${LIVE}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const running = page.getByText(/^Waiting for model.* · \d/);
+  await running.waitFor();
+  const before = await running.innerText();
+  await page.waitForFunction((text) => !document.body.innerText.includes(text), before);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  await page.screenshot({ path: join(artifacts, `turn-timing-running-${width}.png`) });
+  await page.goto("about:blank");
+  await page.unroute(eventsRoute);
+  await page.unroute(agentRoute);
+  await page.unroute(stateRoute);
+
+  await page.goto(`${base}/?session=${PROCESS}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const process = page.getByRole("button", { name: /^Process details · Took 3m 42s/ });
+  await process.waitFor();
+  assert.equal(await process.getAttribute("aria-expanded"), "false");
+  assert.equal(await page.getByText("Took 3m 42s", { exact: true }).count(), 1);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  await page.screenshot({ path: join(artifacts, `turn-timing-process-${width}.png`) });
+
+  await process.click();
+  assert.equal(await process.getAttribute("aria-expanded"), "true");
+  await page.getByText("Plan the motion path.", { exact: true }).waitFor();
+
+  await page.goto(`${base}/?session=${PLAIN}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const plainAnswer = page.locator(`[data-entry-id="${PLAIN}-answer"]`);
+  await plainAnswer.getByText("The bicycle animation is ready.", { exact: true }).waitFor();
+  await plainAnswer.getByText("Took 3m 42s", { exact: true }).waitFor();
+  assert.equal(await page.getByRole("button", { name: /^Process details/ }).count(), 0);
+  await page.reload();
+  await plainAnswer.getByText("Took 3m 42s", { exact: true }).waitFor();
+
+  await page.goto(`${base}/?session=${USER_ONLY}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const userOnly = page.locator(`[data-entry-id="${USER_ONLY}-user"]`);
+  await userOnly.getByText("Took 3m 42s", { exact: true }).waitFor();
+
+  await page.goto(`${base}/?session=${FAILURE}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const failureUser = page.locator(`[data-entry-id="${FAILURE}-user"]`);
+  const failureAnswer = page.locator(`[data-entry-id="${FAILURE}-answer"]`);
+  await failureAnswer.getByText("Provider unavailable", { exact: false }).waitFor();
+  await failureUser.getByText("Took 3m 42s", { exact: true }).waitFor();
+  assert.equal(await failureAnswer.getByText("Took 3m 42s", { exact: true }).count(), 0);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  await page.screenshot({ path: join(artifacts, `turn-timing-failure-${width}.png`) });
+
+  await page.goto(`${base}/?session=${ABORTED}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  const abortedUser = page.locator(`[data-entry-id="${ABORTED}-user"]`);
+  await abortedUser.getByText("Took 3m 42s", { exact: true }).waitFor();
+
+  await page.goto(`${base}/?session=${PAGED}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  assert.equal(await page.getByText("Prompt outside the first history page", { exact: true }).count(), 0);
+  const pagedAnswer = page.locator(`[data-entry-id="${PAGED}-answer-49"]`);
+  await pagedAnswer.getByText("Took 3m 42s", { exact: true }).waitFor();
+
+  await page.goto(`${base}/?session=${LEGACY}&sidebar=collapsed`, { waitUntil: "domcontentloaded" });
+  await page.getByText("The bicycle animation is ready.", { exact: true }).waitFor();
+  assert.equal(await page.getByText(/^Took /).count(), 0);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+  console.log(`PASS: ${width}px live, completed, process, failure, aborted, paged, user-only and legacy turn timing`);
+}

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -70,6 +70,33 @@ test("a rejected submission preserves a different run reported by the server", (
   assert.match(reconcileSource, /if \(!agentRunningRef\.current\) return;[\s\S]*?finishPromptWithoutStream/);
 });
 
+test("extension runs advance the same generation guard used by prompt reconciliation", () => {
+  const timingSource = source.slice(
+    source.indexOf("  const applyTurnTiming = useCallback"),
+    source.indexOf("  const resolveComposerDraftKey"),
+  );
+  const reconcileSource = source.slice(
+    source.indexOf("  const reconcileAgentState = useCallback"),
+    source.indexOf("  // Recovery net for missed SSE events"),
+  );
+  const eventSource = source.slice(
+    source.indexOf('case "turn_timing"'),
+    source.indexOf('case "agent_end"'),
+  );
+  const sendSource = source.slice(
+    source.indexOf("  const handleSend = useCallback"),
+    source.indexOf("  const executeBash = useCallback"),
+  );
+
+  assert.match(timingSource, /detectIndependentRun[\s\S]*?!rpcPromptPendingRef\.current[\s\S]*?!sdkAgentActiveRef\.current[\s\S]*?promptRunIdRef\.current \+= 1/);
+  assert.match(reconcileSource, /promptRunIdRef\.current !== runId/);
+  assert.match(reconcileSource, /currentTiming\.id !== timingId[\s\S]*?state\?\.turnTiming\?\.id !== currentTiming\.id/);
+  assert.match(reconcileSource, /applyTurnTiming\([\s\S]*?Boolean\(busy && state\?\.isStreaming\)/);
+  assert.match(eventSource, /applyTurnTiming\(incoming, incoming\?\.endedAt === undefined\)/);
+  assert.match(eventSource, /case "agent_start":[\s\S]*?promptRunIdRef\.current \+= 1/);
+  assert.match(sendSource, /if \(promptRunIdRef\.current === promptRunId\) promptRunIdRef\.current \+= 1;[\s\S]*?reconcileAgentState\(sentSessionId\)/);
+});
+
 test("opening System or Tools lazily starts a dormant session without sending a prompt", () => {
   const loadSystemInfoSource = source.slice(
     source.indexOf("  const loadSystemInfo = useCallback"),
@@ -295,7 +322,7 @@ test("delegates event stream readiness and hides an empty agent phase", () => {
   assert.match(ensureSource, /eventConnectionRef\.current!\.maintain\(sid\)/);
   assert.match(chatWindowSource, /const hasStreamingContent = Boolean\(streamState\.streamingMessage\?\.content\.length\)/);
   assert.match(chatWindowSource, /streamState\.isStreaming && hasStreamingContent && streamState\.streamingMessage/);
-  assert.match(chatWindowSource, /agentRunning && !hasStreamingContent && agentPhase/);
+  assert.match(chatWindowSource, /agentRunning && !hasStreamingContent && \(agentPhase \|\| turnTiming\)/);
   assert.match(chatWindowSource, /return null;/);
 });
 
@@ -407,7 +434,7 @@ test("reconnects active shell output to its streaming tool call", () => {
   assert.match(updateSource, /content,/);
   assert.match(endSource, /setActiveToolResults[\s\S]*next\.delete\(id\)/);
   assert.match(chatWindowSource, /const map = new Map\(activeToolResults\)/);
-  assert.match(chatWindowSource, /<MessageView message=\{streamState\.streamingMessage as AgentMessage\} toolResults=\{toolResultsMap\}/);
+  assert.match(chatWindowSource, /<MessageView turnTiming=\{turnTiming \?\? undefined\} message=\{streamState\.streamingMessage as AgentMessage\} toolResults=\{toolResultsMap\}/);
 });
 
 test("plays the enabled sound once for each extension dialog", () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -22,6 +22,7 @@ import type { SessionStatsInfo } from "@/lib/pi-types";
 import { mergeSessionStats, type SessionFileStats } from "@/lib/session-stats";
 import { userMessageKey } from "@/lib/prompt-recovery";
 import { AgentEventConnection } from "@/lib/agent-event-connection";
+import { mergeTurnTiming, type TurnTiming } from "@/lib/turn-timing";
 import { getToolExecutionProgress } from "@/lib/tool-execution-progress";
 import {
   CHAT_SCROLL_REATTACH_TOLERANCE,
@@ -42,6 +43,7 @@ export interface SessionData {
   leafId: string | null;
   toolNames?: string[];
   context: {
+    turnTimings?: TurnTiming[];
     messages: AgentMessage[];
     entryIds: string[];
     oldestEntryId: string | null;
@@ -68,6 +70,7 @@ interface LastAssistantTextResponse {
 }
 
 type AgentStateResponse = {
+  turnTiming?: TurnTiming | null;
   model?: { provider: string; id: string };
   contextUsage?: { percent: number | null; contextWindow: number; tokens: number | null } | null;
   systemPrompt?: string;
@@ -283,6 +286,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const isNew = session === null && newSessionCwd !== null;
 
   const [data, setData] = useState<SessionData | null>(null);
+  const [turnTiming, setTurnTiming] = useState<TurnTiming | null>(null);
   const [loading, setLoading] = useState(!isNew);
   const [error, setError] = useState<string | null>(null);
   const [activeLeafId, setActiveLeafId] = useState<string | null>(null);
@@ -354,6 +358,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const newSessionModelOverrideRef = useRef<SelectedModel | null>(null);
   const thinkingLevelOverrideRef = useRef<Exclude<ThinkingLevelOption, "auto"> | null>(null);
   const promptRunIdRef = useRef(0);
+  const turnTimingRef = useRef<TurnTiming | null>(null);
   const optimisticUserMessageKeyRef = useRef<string | null>(null);
   const modelSwitchPendingRef = useRef(false);
   const draftKeyAliasesRef = useRef(new Map<string, string>());
@@ -413,6 +418,23 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       : null);
   }, []);
 
+  const applyTurnTiming = useCallback((incoming: TurnTiming | null, detectIndependentRun = false) => {
+    const previous = turnTimingRef.current;
+    if (detectIndependentRun
+      && incoming
+      && incoming.endedAt === undefined
+      && incoming.id !== previous?.id
+      && !rpcPromptPendingRef.current
+      && !sdkAgentActiveRef.current) {
+      // Extension-triggered runs have no handleSend boundary. Advancing the
+      // same generation guard keeps an older state request from settling them.
+      promptRunIdRef.current += 1;
+    }
+    const next = mergeTurnTiming(previous, incoming);
+    turnTimingRef.current = next;
+    setTurnTiming(next);
+  }, []);
+
   const resolveComposerDraftKey = useCallback((key: string | undefined) => {
     if (!key) return undefined;
     let resolved = key;
@@ -468,6 +490,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   }, [messages, sessionStatsOverride, contextUsage, data?.context.messages, data?.filePath, data?.totalActiveMs, data?.stats, session?.id, session?.name]);
 
   const loadSession = useCallback(async (sid: string, showLoading = false, includeState = false) => {
+    const timingRunId = promptRunIdRef.current;
     let messagesLoaded = false;
     try {
       if (showLoading) setLoading(true);
@@ -513,6 +536,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         if (sessionIdRef.current !== sid) return null;
 
         const liveState = agentState.state;
+        if (promptRunIdRef.current === timingRunId) applyTurnTiming(
+          liveState?.turnTiming ?? null,
+          Boolean(agentState.running && liveState?.isStreaming),
+        );
         syncLiveModel(liveState);
         if (liveState) {
           if (liveState.contextUsage !== undefined) setContextUsage(liveState.contextUsage ?? null);
@@ -535,7 +562,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } finally {
       if (showLoading && !messagesLoaded) setLoading(false);
     }
-  }, [setToolPresetState, syncLiveModel]);
+  }, [applyTurnTiming, setToolPresetState, syncLiveModel]);
 
   const loadContext = useCallback(async (sid: string, leafId: string | null, before?: string | null, options?: { tail?: number; signal?: AbortSignal }) => {
     try {
@@ -558,6 +585,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           ...prev.context,
           messages: [...d.context.messages, ...prev.context.messages],
           entryIds: [...d.context.entryIds, ...prev.context.entryIds],
+          turnTimings: [...new Map([...(prev.context.turnTimings ?? []), ...(d.context.turnTimings ?? [])].map((timing) => [timing.id, timing])).values()],
           oldestEntryId: d.context.oldestEntryId,
           hasMore: d.context.hasMore,
         } : d.context;
@@ -916,6 +944,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       ) return;
 
       try {
+        const runId = promptRunIdRef.current;
         const res = await fetch(`/api/agent/${encodeURIComponent(sid)}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json() as { running?: boolean; state?: AgentStateResponse };
@@ -923,11 +952,16 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           generation !== eventStreamGraceGenerationRef.current
           || sessionIdRef.current !== sid
           || !eventStreamGraceActiveRef.current
+          || promptRunIdRef.current !== runId
         ) return;
 
         const state = data.state;
-        syncLiveModel(state);
         const promptActive = Boolean(data.running && state && (state.isStreaming || state.isPromptRunning));
+        if (state?.turnTiming !== undefined) applyTurnTiming(
+          state.turnTiming ?? null,
+          Boolean(promptActive && state.isStreaming),
+        );
+        syncLiveModel(state);
         if (promptActive) {
           eventStreamGraceActiveRef.current = false;
           eventStreamGraceTimerRef.current = null;
@@ -960,7 +994,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     };
 
     eventStreamGraceTimerRef.current = setTimeout(() => void checkServerIdle(), EVENT_STREAM_IDLE_GRACE_MS);
-  }, [cancelEventStreamGrace, closeEvents, syncLiveModel]);
+  }, [applyTurnTiming, cancelEventStreamGrace, closeEvents, syncLiveModel]);
 
   const finishPromptWithoutStream = useCallback(async (sid: string | null = sessionIdRef.current, runId = promptRunIdRef.current) => {
     // Bail out before loadSession too: a stale finish for a previous run
@@ -1046,6 +1080,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const reconcileAgentState = useCallback(async (sid: string) => {
     if (!agentRunningRef.current || sessionIdRef.current !== sid) return;
     const runId = promptRunIdRef.current;
+    const timingId = turnTimingRef.current?.id;
     try {
       const res = await fetch(`/api/agent/${encodeURIComponent(sid)}`);
       if (!res.ok) return;
@@ -1055,14 +1090,23 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       // flight) — everything in it is stale, drop it.
       if (sessionIdRef.current !== sid || promptRunIdRef.current !== runId) return;
       const state = data.state;
+      const currentTiming = turnTimingRef.current;
+      if (currentTiming
+        && currentTiming.endedAt === undefined
+        && currentTiming.id !== timingId
+        && state?.turnTiming?.id !== currentTiming.id) return;
+      const busy = data.running && state
+        && (state.isStreaming || state.isPromptRunning || state.isCompacting);
+      applyTurnTiming(
+        state?.turnTiming ?? null,
+        Boolean(busy && state?.isStreaming),
+      );
       syncLiveModel(state);
       // Mirror compaction state unconditionally: a missed compaction_end
       // would otherwise leave the "Stop compaction" UI stuck. No state
       // (wrapper destroyed) means nothing is compacting.
       setIsCompacting(state?.isCompacting ?? false);
       setQueuedMessages(normalizeQueuedMessages(state?.queuedMessages));
-      const busy = data.running && state
-        && (state.isStreaming || state.isPromptRunning || state.isCompacting);
       if (busy) {
         sdkAgentActiveRef.current = Boolean(state.isStreaming);
         rpcPromptPendingRef.current = Boolean(state.isPromptRunning);
@@ -1079,7 +1123,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } catch {
       // Network still down — the next poll / visibility / online tick retries.
     }
-  }, [finishPromptWithoutStream, syncLiveModel]);
+  }, [applyTurnTiming, finishPromptWithoutStream, syncLiveModel]);
 
   // Recovery net for missed SSE events: while the agent is running, verify
   // against the server periodically and whenever the tab returns to the
@@ -1111,9 +1155,23 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
   const handleAgentEvent = useCallback((event: AgentEvent) => {
     switch (event.type) {
+      case "turn_timing": {
+        const incoming = event.turnTiming as TurnTiming | null;
+        applyTurnTiming(incoming, incoming?.endedAt === undefined);
+        break;
+      }
       case "connected": {
+        if (event.turnTiming !== undefined) applyTurnTiming(
+          event.turnTiming as TurnTiming | null,
+          event.isStreaming === true,
+        );
         dispatch({ type: "end" });
         if (event.isStreaming === true) {
+          if (!rpcPromptPendingRef.current
+            && !sdkAgentActiveRef.current
+            && (!turnTimingRef.current || turnTimingRef.current.endedAt !== undefined)) {
+            promptRunIdRef.current += 1;
+          }
           cancelEventStreamGrace();
           sdkAgentActiveRef.current = true;
           agentRunningRef.current = true;
@@ -1123,6 +1181,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         break;
       }
       case "agent_start":
+        if (!rpcPromptPendingRef.current
+          && !sdkAgentActiveRef.current
+          && (!turnTimingRef.current || turnTimingRef.current.endedAt !== undefined)) {
+          promptRunIdRef.current += 1;
+        }
         cancelEventStreamGrace();
         sdkAgentActiveRef.current = true;
         agentRunningRef.current = true;
@@ -1363,7 +1426,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         setExtensionDialog((current) => current?.id === event.id ? null : current);
         break;
     }
-  }, [addNotice, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, scrollToBottom, settleUiStage, syncLiveModel]);
+  }, [addNotice, applyTurnTiming, cancelEventStreamGrace, handleExtensionUiRequest, loadSession, notifyPromptStage, onAgentEnd, scheduleEventStreamClose, scrollToBottom, settleUiStage, syncLiveModel]);
   handleAgentEventRef.current = handleAgentEvent;
 
   const handleSend = useCallback(async (message: string, images?: AttachedImage[]) => {
@@ -1402,6 +1465,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     setMessages((prev) => [...prev, userMsg]);
     optimisticUserMessageKeyRef.current = userMessageKey(userMsg);
     promptRunIdRef.current = promptRunId;
+    turnTimingRef.current = null;
+    setTurnTiming(null);
     agentRunningRef.current = true;
     setAgentRunning(true);
     setAgentPhase(isSlashCommandPrompt ? { kind: "running_command" } : { kind: "waiting_model" });
@@ -1461,6 +1526,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         return;
       }
       rpcPromptPendingRef.current = false;
+      if (promptRunIdRef.current === promptRunId) promptRunIdRef.current += 1;
       setMessages((prev) => {
         const optimisticIndex = prev.lastIndexOf(userMsg);
         return optimisticIndex === -1
@@ -2166,6 +2232,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   return {
     // State
     data, loading, error, activeLeafId, messages, activeToolResults, entryIds, historyCursor, hasEarlierMessages, streamState,
+    turnTiming, turnTimings: data?.context.turnTimings ?? [],
     agentRunning, modelNames, modelList, modelError, modelScopeWarnings, modelThinkingLevels, modelThinkingLevelMaps, newSessionModel, toolPreset, thinkingLevel,
     retryInfo, contextUsage, systemPrompt, forkingEntryId,
     isCompacting, compactError, compactResult, currentModel, displayModel, modelSwitching, sessionStats,

--- a/lib/agent-event-stream.test.mjs
+++ b/lib/agent-event-stream.test.mjs
@@ -51,12 +51,14 @@ test("opens the transport before a slow session is ready and snapshots after sub
   assert.equal(decoder.decode(transport.value), ":\n\n");
 
   const snapshot = { role: "assistant", content: [{ type: "text", text: "Hello" }] };
+  const turnTiming = { id: "run-1", startedAt: 1_000, anchorEntryId: "user-1" };
   let listener;
   let subscribeCount = 0;
   let unsubscribeCount = 0;
   startup.resolve({
     isStreaming: true,
     streamingMessage: snapshot,
+    turnTiming,
     onEvent(nextListener) {
       subscribeCount += 1;
       listener = nextListener;
@@ -78,6 +80,7 @@ test("opens the transport before a slow session is ready and snapshots after sub
     type: "connected",
     sessionId: "session-id",
     isStreaming: true,
+    turnTiming,
   });
   assert.deepEqual(messageStart, { type: "agent_start" });
   assert.deepEqual(replayedEvent, { type: "message_start", message: snapshot });

--- a/lib/agent-event-stream.ts
+++ b/lib/agent-event-stream.ts
@@ -4,10 +4,12 @@ import {
   type AgentEventLike,
 } from "./agent-event-wire";
 import { acquireSessionLivenessLease } from "./session-liveness";
+import type { TurnTiming } from "./turn-timing";
 
 export interface AgentEventStreamSession {
   readonly isStreaming: boolean;
   readonly streamingMessage: unknown;
+  readonly turnTiming?: TurnTiming | null;
   onEvent(listener: (event: AgentEventLike) => void): () => void;
 }
 
@@ -97,6 +99,7 @@ export function createAgentEventStream(
             type: "connected",
             sessionId,
             isStreaming: session.isStreaming,
+            turnTiming: session.turnTiming ?? null,
           });
           for (const event of bufferedEvents) forwardEvent(event, snapshot);
           if (snapshot !== undefined && snapshot !== null) {

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -307,6 +307,8 @@ export const enLocale: LocalePlugin = {
     "chat.runningCommand": "Running command...",
     "chat.thinking": "Thinking...",
     "chat.processDetails": "Process details",
+    "chat.turnDuration": "Took {duration}",
+    "chat.turnRunningDuration": "Working · {duration}",
     "chat.message": "message",
     "chat.messages": "messages",
     "chat.toolCall": "tool call",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -307,6 +307,8 @@ export const zhCNLocale: LocalePlugin = {
     "chat.runningCommand": "正在运行命令...",
     "chat.thinking": "正在思考...",
     "chat.processDetails": "处理详情",
+    "chat.turnDuration": "耗时 {duration}",
+    "chat.turnRunningDuration": "正在处理 · {duration}",
     "chat.message": "条消息",
     "chat.messages": "条消息",
     "chat.toolCall": "次工具调用",

--- a/lib/i18n/messages/zh-TW.ts
+++ b/lib/i18n/messages/zh-TW.ts
@@ -307,6 +307,8 @@ export const zhTWLocale: LocalePlugin = {
     "chat.runningCommand": "正在執行命令...",
     "chat.thinking": "正在思考...",
     "chat.processDetails": "處理詳細資料",
+    "chat.turnDuration": "耗時 {duration}",
+    "chat.turnRunningDuration": "正在處理 · {duration}",
     "chat.message": "則訊息",
     "chat.messages": "則訊息",
     "chat.toolCall": "次工具呼叫",

--- a/lib/rpc-manager-shutdown.test.mjs
+++ b/lib/rpc-manager-shutdown.test.mjs
@@ -222,7 +222,7 @@ test("prompt commands reject when SDK preflight fails", async (t) => {
   );
 
   assert.equal(wrapper.isRunning(), false);
-  assert.deepEqual(events, []);
+  assert.deepEqual(events.filter((event) => event.type !== "turn_timing"), []);
 });
 
 test("accepted prompt failures still finish through the event stream", async (t) => {
@@ -242,7 +242,7 @@ test("accepted prompt failures still finish through the event stream", async (t)
   failPrompt();
   await nextTurn();
 
-  assert.deepEqual(events.map((event) => event.type), ["prompt_error", "prompt_done"]);
+  assert.deepEqual(events.filter((event) => event.type !== "turn_timing").map((event) => event.type), ["prompt_error", "prompt_done"]);
 });
 
 test("queued prompt commands forward their streaming behavior and acknowledge acceptance", async (t) => {
@@ -267,7 +267,7 @@ test("queued prompt commands forward their streaming behavior and acknowledge ac
   assert.equal(receivedOptions.streamingBehavior, "followUp");
   assert.equal(receivedOptions.source, "rpc");
   assert.equal(wrapper.isRunning(), false);
-  assert.deepEqual(events, []);
+  assert.deepEqual(events.filter((event) => event.type !== "turn_timing"), []);
 });
 
 test("an exact system prompt is reapplied after SDK preflight resets it", async (t) => {
@@ -400,7 +400,7 @@ test("a failing event listener cannot reject prompt completion", async (t) => {
   await wrapper.send({ type: "prompt", message: "hello" });
   await nextTurn();
 
-  assert.deepEqual(delivered, ["prompt_done"]);
+  assert.deepEqual(delivered.filter((type) => type !== "turn_timing"), ["prompt_done"]);
   assert.equal(wrapper.isRunning(), false);
 });
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -17,6 +17,7 @@ import { getProjectTrustStatus, projectTrustReloadOptions } from "./project-trus
 import { persistExplicitStartupPreferences } from "./startup-preferences";
 import { notifySessionComplete } from "./web-push";
 import { hasActiveSessionLivenessProvider } from "./session-liveness";
+import { findTurnTimingAnchor, TURN_TIMING_CUSTOM_TYPE, type TurnTiming } from "./turn-timing";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { AgentSessionLike, ExtensionUiContextLike, ToolInfo } from "./pi-types";
 import type {
@@ -230,6 +231,8 @@ export class AgentSessionWrapper {
   private activeMutatingCommands = 0;
   private sessionReplacement: "fork" | "clone" | null = null;
   private agentRunNeedsCompletion = false;
+  private currentTurnTiming: TurnTiming | null = null;
+  private turnTimingStartIndex = 0;
   private promptAdmissionTail: Promise<void> = Promise.resolve();
   private extensionsBound = false;
   private extensionBindingPromise: Promise<void> | null = null;
@@ -278,6 +281,37 @@ export class AgentSessionWrapper {
     return this.inner.isStreaming;
   }
 
+  get turnTiming(): TurnTiming | null {
+    if (!this.currentTurnTiming || this.currentTurnTiming.endedAt !== undefined) return this.currentTurnTiming;
+    const entries = this.inner.sessionManager?.getEntries?.() as SessionEntry[] | undefined;
+    return {
+      ...this.currentTurnTiming,
+      anchorEntryId: findTurnTimingAnchor(entries ?? [], this.turnTimingStartIndex),
+    };
+  }
+
+  private beginTurnTiming(): void {
+    if (this.currentTurnTiming && this.currentTurnTiming.endedAt === undefined) return;
+    this.turnTimingStartIndex = this.inner.sessionManager?.getEntries?.().length ?? 0;
+    this.currentTurnTiming = { id: randomUUID(), startedAt: Date.now() };
+    this.emit({ type: "turn_timing", turnTiming: this.currentTurnTiming });
+  }
+
+  private finishTurnTiming(): void {
+    const timing = this.turnTiming;
+    if (!timing || timing.endedAt !== undefined) return;
+    const completed = { ...timing, endedAt: Math.max(timing.startedAt, Date.now()) };
+    this.currentTurnTiming = completed;
+    if (completed.anchorEntryId) {
+      try {
+        this.inner.sessionManager.appendCustomEntry(TURN_TIMING_CUSTOM_TYPE, { version: 1, ...completed });
+      } catch (error) {
+        console.error("[pi-web] failed to persist turn timing:", error instanceof Error ? error.message : error);
+      }
+    }
+    this.emit({ type: "turn_timing", turnTiming: completed });
+  }
+
   isAlive(): boolean {
     return this._alive;
   }
@@ -296,7 +330,10 @@ export class AgentSessionWrapper {
 
   start(): void {
     this.unsubscribe = this.inner.subscribe((event: AgentEvent) => {
-      if (event.type === "agent_start") this.agentRunNeedsCompletion = true;
+      if (event.type === "agent_start") {
+        this.agentRunNeedsCompletion = true;
+        this.beginTurnTiming();
+      }
       if (event.type === "agent_end") {
         invalidateSessionListCache();
       }
@@ -318,6 +355,7 @@ export class AgentSessionWrapper {
   private notifyAgentRunCompleteIfIdle(): void {
     if (!this.agentRunNeedsCompletion || this.isRunning()) return;
     this.agentRunNeedsCompletion = false;
+    this.finishTurnTiming();
     if (this.suppressCompletionNotifications) return;
     try {
       this.onAgentRunComplete?.(this.sessionId);
@@ -593,12 +631,21 @@ export class AgentSessionWrapper {
           let preflightAccepted = false;
           let preflightSettled = false;
           let promptSettled = false;
-          let acceptPreflight!: () => void;
+          let acceptPreflight!: (startTiming?: boolean) => void;
           let rejectPreflight!: (error: unknown) => void;
           const preflight = new Promise<void>((resolve, reject) => {
-            acceptPreflight = () => {
-              preflightAccepted = true;
-              this.agentRunNeedsCompletion = true;
+            acceptPreflight = (startTiming = true) => {
+              if (!preflightAccepted) {
+                preflightAccepted = true;
+                this.agentRunNeedsCompletion = true;
+                // The SDK callback is the exact point where validation and
+                // extension preflight accept the submission. Exclude time
+                // spent waiting for that decision from the turn duration.
+                if (startTiming && !this.inner.isStreaming
+                  && (!this.currentTurnTiming || this.currentTurnTiming.endedAt !== undefined)) {
+                  this.beginTurnTiming();
+                }
+              }
               if (preflightSettled) return;
               preflightSettled = true;
               resolve();
@@ -640,8 +687,9 @@ export class AgentSessionWrapper {
 
           void prompt.then(() => {
             // Compatibility fallback if a future SDK resolves without invoking
-            // the internal callback. This waits for the run, but never acks early.
-            acceptPreflight();
+            // the internal callback. Agent events own timing in that case, so
+            // resolving after the run cannot accidentally start a new timer.
+            acceptPreflight(false);
             finishPrompt();
             if (!streamingBehavior) this.emit({ type: "prompt_done" });
           }, (error) => {
@@ -690,6 +738,7 @@ export class AgentSessionWrapper {
           sessionFile: this.inner.sessionFile ?? "",
           isStreaming: this.inner.isStreaming,
           isPromptRunning: this.pendingPromptCount > 0,
+          turnTiming: this.turnTiming,
           isBashRunning: this.inner.isBashRunning,
           isCompacting: this.inner.isCompacting,
           autoCompactionEnabled: this.inner.autoCompactionEnabled,

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -14,6 +14,7 @@ import { MAX_TOOL_RESULT_IMAGE_BYTES, TOOL_RESULT_IMAGE_MIMES } from "./tool-res
 import { resolveProject, type ProjectInfo } from "./worktree";
 import { readSubagentRun, SUBAGENT_META_TYPE } from "./subagents";
 import { listSessionsIncremental } from "./session-list-scanner";
+import { readTurnTimings } from "./turn-timing";
 
 export { getAgentDir };
 
@@ -481,6 +482,7 @@ export function buildSessionContext(
   return {
     messages,
     entryIds,
+    turnTimings: readTurnTimings(entries, entryIds),
     oldestEntryId: sliced[0]?.id ?? null,
     hasMore,
     ...getSessionSettings(entries, leafId),

--- a/lib/turn-timing.test.mjs
+++ b/lib/turn-timing.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
+const { buildSessionContext } = await jiti.import("./session-reader.ts");
+const { readTurnTimings, TURN_TIMING_CUSTOM_TYPE } = await jiti.import("./turn-timing.ts");
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
+const message = (role, text) => ({ role, content: [{ type: "text", text }], timestamp: Date.now() });
+
+function fixture(t, manager = SessionManager.inMemory()) {
+  let listener;
+  let resolvePrompt;
+  let rejectPrompt;
+  const events = [];
+  const inner = {
+    sessionId: manager.getSessionId(), sessionManager: manager,
+    isStreaming: false, isCompacting: false, isBashRunning: false,
+    agent: { state: {} }, extensionRunner: {},
+    getContextUsage: () => null, getSteeringMessages: () => [], getFollowUpMessages: () => [],
+    subscribe(callback) { listener = callback; return () => {}; },
+    prompt(text, options) {
+      if (inner.isStreaming) { options.preflightResult(true); return Promise.resolve(); }
+      options.preflightResult(true);
+      inner.isStreaming = true;
+      listener({ type: "agent_start" });
+      manager.appendMessage(message("user", text));
+      return new Promise((resolve, reject) => { resolvePrompt = resolve; rejectPrompt = reject; });
+    },
+    async abort() {
+      manager.appendMessage({ ...message("assistant", "stopped"), stopReason: "aborted" });
+      inner.isStreaming = false;
+      listener({ type: "agent_settled" });
+      resolvePrompt();
+    },
+    dispose() {},
+  };
+  const wrapper = new AgentSessionWrapper(inner);
+  wrapper.start();
+  wrapper.onEvent((event) => events.push(event));
+  t.after(() => wrapper.destroy());
+  return {
+    wrapper, inner, manager, events,
+    emit: (event) => listener(event),
+    finish: () => resolvePrompt(),
+    fail: () => rejectPrompt(new Error("provider failed")),
+  };
+}
+
+test("one timing spans retries, compaction and queued prompts and survives disk reload", async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-web-turn-timing-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const run = fixture(t, SessionManager.create(directory, directory));
+  await run.wrapper.send({ type: "prompt", message: "first" });
+  const started = run.wrapper.turnTiming;
+  assert.equal(typeof started.startedAt, "number");
+  assert.equal(started.endedAt, undefined);
+  const firstUserId = started.anchorEntryId;
+  assert.ok(firstUserId);
+  assert.deepEqual((await run.wrapper.send({ type: "get_state" })).turnTiming, started);
+
+  run.manager.appendMessage(message("assistant", "retry error"));
+  run.emit({ type: "agent_end" });
+  run.emit({ type: "auto_retry_start" });
+  run.emit({ type: "agent_start" });
+  assert.equal(run.wrapper.turnTiming.id, started.id);
+  assert.equal(run.wrapper.turnTiming.endedAt, undefined);
+  run.inner.isCompacting = true;
+  run.emit({ type: "compaction_start" });
+  run.manager.appendCompaction("summary", firstUserId, 1000);
+  run.inner.isCompacting = false;
+  run.emit({ type: "compaction_end" });
+  await run.wrapper.send({ type: "prompt", message: "queued", streamingBehavior: "followUp" });
+  run.manager.appendMessage(message("user", "queued"));
+  run.manager.appendMessage(message("assistant", "final"));
+  const finalEntryId = run.manager.getLeafId();
+  run.inner.isStreaming = false;
+  run.emit({ type: "agent_settled" });
+  assert.equal(run.wrapper.turnTiming.endedAt, undefined, "pending prompt still owns completion");
+  run.finish();
+  await nextTurn();
+  const completed = run.wrapper.turnTiming;
+  assert.equal(completed.id, started.id);
+  assert.equal(completed.startedAt, started.startedAt);
+  assert.ok(completed.endedAt >= started.startedAt);
+  assert.equal(completed.anchorEntryId, finalEntryId);
+  run.emit({ type: "agent_settled" });
+  assert.equal(run.manager.getEntries().filter((entry) => entry.customType === TURN_TIMING_CUSTOM_TYPE).length, 1);
+  assert.equal(run.events.filter((event) => event.type === "turn_timing").length, 2);
+
+  const restored = SessionManager.open(run.manager.getSessionFile());
+  assert.deepEqual(buildSessionContext(restored.getEntries()).turnTimings, [completed]);
+  assert.deepEqual(buildSessionContext(restored.getEntries(), finalEntryId, { tail: 1 }).turnTimings, [completed]);
+  assert.deepEqual(buildSessionContext(restored.getEntries(), firstUserId).turnTimings, []);
+});
+
+test("accepted failures and Stop freeze timing and persist their visible anchor", async (t) => {
+  for (const action of ["fail", "abort"]) {
+    const run = fixture(t);
+    await run.wrapper.send({ type: "prompt", message: action });
+    if (action === "abort") await run.wrapper.send({ type: "abort" });
+    else { run.inner.isStreaming = false; run.fail(); }
+    await nextTurn();
+    assert.equal(typeof run.wrapper.turnTiming.endedAt, "number");
+    assert.deepEqual(buildSessionContext(run.manager.getEntries()).turnTimings, [run.wrapper.turnTiming]);
+  }
+});
+
+test("rejected preflight never starts live or historical timing", async (t) => {
+  const run = fixture(t);
+  run.inner.prompt = async (_text, options) => { options.preflightResult(false); throw new Error("no key"); };
+  await assert.rejects(run.wrapper.send({ type: "prompt", message: "rejected" }), /no key/);
+  assert.equal(run.wrapper.turnTiming, null);
+  assert.deepEqual(run.manager.getEntries(), []);
+  assert.equal(run.events.some((event) => event.type === "turn_timing"), false);
+});
+
+test("timing starts at accepted preflight rather than submission", async (t) => {
+  const run = fixture(t);
+  const realNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  t.after(() => { Date.now = realNow; });
+  run.inner.prompt = (text, options) => {
+    now = 5_000;
+    options.preflightResult(true);
+    run.inner.isStreaming = true;
+    run.emit({ type: "agent_start" });
+    run.manager.appendMessage(message("user", text));
+    return new Promise(() => {});
+  };
+
+  await run.wrapper.send({ type: "prompt", message: "accepted" });
+  assert.equal(run.wrapper.turnTiming.startedAt, 5_000);
+});
+
+test("extension runs get their own timing and finish only once idle", (t) => {
+  const run = fixture(t);
+  run.inner.isStreaming = true;
+  run.emit({ type: "agent_start" });
+  run.manager.appendMessage(message("assistant", "extension result"));
+  run.emit({ type: "agent_end" });
+  assert.equal(run.wrapper.turnTiming.endedAt, undefined);
+  run.inner.isStreaming = false;
+  run.emit({ type: "agent_settled" });
+  assert.equal(typeof run.wrapper.turnTiming.endedAt, "number");
+});
+
+test("a rejected submission during a non-streaming gap preserves the active prompt timing", async (t) => {
+  const run = fixture(t);
+  await run.wrapper.send({ type: "prompt", message: "accepted" });
+  const originalTiming = run.wrapper.turnTiming;
+  run.inner.isStreaming = false;
+  run.inner.isCompacting = true;
+  run.inner.prompt = async (_text, options) => {
+    options.preflightResult(false);
+    throw new Error("compaction in progress");
+  };
+
+  await assert.rejects(run.wrapper.send({ type: "prompt", message: "rejected" }), /compaction in progress/);
+  assert.deepEqual(run.wrapper.turnTiming, originalTiming);
+  assert.equal(run.wrapper.isRunning(), true);
+  assert.equal(run.events.filter((event) => event.type === "turn_timing").length, 1);
+
+  run.inner.isCompacting = false;
+  run.manager.appendMessage(message("assistant", "accepted run completed"));
+  run.finish();
+  await nextTurn();
+  assert.equal(run.wrapper.turnTiming.id, originalTiming.id);
+  assert.equal(run.wrapper.turnTiming.startedAt, originalTiming.startedAt);
+  assert.equal(typeof run.wrapper.turnTiming.endedAt, "number");
+  assert.deepEqual(buildSessionContext(run.manager.getEntries()).turnTimings, [run.wrapper.turnTiming]);
+});
+
+test("timing metadata follows only the selected branch and visible history page", () => {
+  const manager = SessionManager.inMemory();
+  manager.appendMessage(message("user", "root"));
+  const rootId = manager.getLeafId();
+  manager.appendMessage(message("assistant", "a"));
+  const aId = manager.getLeafId();
+  const a = { version: 1, id: "run-a", startedAt: 1000, endedAt: 2000, anchorEntryId: aId };
+  manager.appendCustomEntry(TURN_TIMING_CUSTOM_TYPE, a);
+  manager.branch(rootId);
+  manager.appendMessage(message("assistant", "b"));
+  const bId = manager.getLeafId();
+  const b = { version: 1, id: "run-b", startedAt: 3000, endedAt: 5000, anchorEntryId: bId };
+  manager.appendCustomEntry(TURN_TIMING_CUSTOM_TYPE, b);
+  assert.deepEqual(buildSessionContext(manager.getEntries(), aId).turnTimings.map((timing) => timing.id), ["run-a"]);
+  assert.deepEqual(buildSessionContext(manager.getEntries(), bId).turnTimings.map((timing) => timing.id), ["run-b"]);
+  assert.deepEqual(buildSessionContext(manager.getEntries(), bId, { tail: 1, excludeLeaf: true }).turnTimings, []);
+});
+
+test("legacy and malformed timing metadata produce no invented duration", () => {
+  const manager = SessionManager.inMemory();
+  manager.appendMessage(message("assistant", "legacy"));
+  const anchorEntryId = manager.getLeafId();
+  for (const data of [null, {}, { version: 1, id: "bad", startedAt: 2, endedAt: 1, anchorEntryId }]) {
+    manager.appendCustomEntry(TURN_TIMING_CUSTOM_TYPE, data);
+  }
+  assert.deepEqual(readTurnTimings(manager.getEntries(), [anchorEntryId]), []);
+});

--- a/lib/turn-timing.ts
+++ b/lib/turn-timing.ts
@@ -1,0 +1,53 @@
+import type { SessionEntry } from "./types";
+
+export const TURN_TIMING_CUSTOM_TYPE = "pi-web:turn-timing";
+
+/** One server-side logical run, including retries, tools and auto-compaction. */
+export interface TurnTiming {
+  id: string;
+  startedAt: number;
+  endedAt?: number;
+  /** Last visible entry produced by this run; follows queued user messages. */
+  anchorEntryId?: string;
+}
+
+/** A late snapshot must not restart a finished run or replace a newer one. */
+export function mergeTurnTiming(previous: TurnTiming | null, incoming: TurnTiming | null): TurnTiming | null {
+  if (!incoming) return null;
+  if (previous && (previous.startedAt > incoming.startedAt
+    || (previous.id === incoming.id && previous.endedAt !== undefined && incoming.endedAt === undefined))) return previous;
+  return incoming;
+}
+
+export function findTurnTimingAnchor(entries: readonly SessionEntry[], startIndex = 0): string | undefined {
+  for (let index = entries.length - 1; index >= startIndex; index -= 1) {
+    const entry = entries[index];
+    if (entry.type === "message" || entry.type === "compaction"
+      || entry.type === "branch_summary" || entry.type === "custom_message") return entry.id;
+  }
+  return undefined;
+}
+
+/** Metadata may follow the selected leaf or page, so search all entries by anchor. */
+export function readTurnTimings(entries: readonly SessionEntry[], visibleEntryIds: readonly string[]): TurnTiming[] {
+  const visible = new Set(visibleEntryIds);
+  const timings = new Map<string, TurnTiming>();
+  for (const entry of entries) {
+    if (entry.type !== "custom" || entry.customType !== TURN_TIMING_CUSTOM_TYPE) continue;
+    const data = entry.data;
+    if (typeof data !== "object" || data === null || Array.isArray(data)) continue;
+    const timing = data as Record<string, unknown>;
+    if (timing.version !== 1 || typeof timing.id !== "string"
+      || typeof timing.startedAt !== "number" || !Number.isFinite(timing.startedAt)
+      || typeof timing.endedAt !== "number" || !Number.isFinite(timing.endedAt)
+      || timing.endedAt < timing.startedAt
+      || typeof timing.anchorEntryId !== "string" || !visible.has(timing.anchorEntryId)) continue;
+    timings.set(timing.id, {
+      id: timing.id,
+      startedAt: timing.startedAt,
+      endedAt: timing.endedAt,
+      anchorEntryId: timing.anchorEntryId,
+    });
+  }
+  return [...timings.values()];
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -348,6 +348,7 @@ export interface SessionInfo {
 }
 
 export interface SessionContext {
+  turnTimings?: import("./turn-timing").TurnTiming[];
   messages: AgentMessage[];
   entryIds: string[]; // parallel to messages — the session entry id for each message
   oldestEntryId: string | null;


### PR DESCRIPTION
Long turns provide no durable indication of how long the full run took. This measures from accepted prompt to logical idle across retries, tools, queued follow-ups, and compaction, persists a versioned record, and renders only the total duration in existing phase/process/message metadata rows. It intentionally adds no TTFT, token-rate metrics, or extra summary row.

Validation:

- `npm test` (1032 passed)
- `npm run lint`
- `node_modules/.bin/tsc --noEmit --incremental false`
- Playwright at 1280px and 390px: live ticking, completed/process turns, provider errors, empty Stop, pagination, and legacy sessions
