### PR TITLE
fix(cli): disable Wasm lazy compilation on RISC-V

### DIFF
--- a/bin/pi-web-node-args.js
+++ b/bin/pi-web-node-args.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function getNextNodeArgs(nextBin, nextArgs, arch = process.arch) {
+  if (arch === "riscv64") {
+    return ["--no-wasm-lazy-compilation", nextBin, ...nextArgs];
+  }
+
+  return [nextBin, ...nextArgs];
+}
+
+module.exports = { getNextNodeArgs };

--- a/bin/pi-web.js
+++ b/bin/pi-web.js
@@ -18,6 +18,8 @@ const fs = require("fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { getHelpText, parseLaunchOptions } = require("./pi-web-options");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const { getNextNodeArgs } = require("./pi-web-node-args");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { wireChildProcessLifecycle } = require("./process-lifecycle");
 
 let launchOptions;
@@ -81,7 +83,7 @@ nextArgs.push("-H", hostname);
 
 // Always run next's JS entry with node directly — avoids .bin symlink issues
 // and path-with-spaces problems on Windows when shell: true is used.
-const child = spawn(process.execPath, [nextBin, ...nextArgs], {
+const child = spawn(process.execPath, getNextNodeArgs(nextBin, nextArgs), {
   cwd: pkgDir,
   stdio: ["inherit", "pipe", "inherit"],
   env: { ...process.env, PI_WEB_HOSTNAME: hostname },

--- a/lib/pi-web-node-args.test.mjs
+++ b/lib/pi-web-node-args.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { getNextNodeArgs } = require("../bin/pi-web-node-args.js");
+
+test("passes the no-wasm-lazy-compilation flag to Node on RISC-V", () => {
+  assert.deepEqual(getNextNodeArgs("next-bin", ["start", "-p", "30141"], "riscv64"), [
+    "--no-wasm-lazy-compilation",
+    "next-bin",
+    "start",
+    "-p",
+    "30141",
+  ]);
+});
+
+test("keeps the existing Node arguments on other architectures", () => {
+  for (const arch of ["x64", "arm64"]) {
+    assert.deepEqual(getNextNodeArgs("next-bin", ["start"], arch), ["next-bin", "start"]);
+  }
+});
+
+test("does not mutate the caller's Next.js arguments", () => {
+  const nextArgs = ["start", "-H", "127.0.0.1"];
+
+  getNextNodeArgs("next-bin", nextArgs, "riscv64");
+
+  assert.deepEqual(nextArgs, ["start", "-H", "127.0.0.1"]);
+});


### PR DESCRIPTION
## Summary

- start the packaged Next server with `--no-wasm-lazy-compilation` on `riscv64`
- preserve the existing Node argv on other architectures
- cover the architecture branch and caller-owned argument behavior with dependency-free tests

Closes #685

## Why

Node/V8 flags must appear before the Next CLI entrypoint. Scoping the workaround to `process.arch === "riscv64"` avoids changing compilation behavior for x64 and arm64 installs. A small argv helper keeps the architecture branch directly testable without changing the CLI's cwd, environment, stdio, browser launch, or child-process lifecycle.

## Testing

- `env PI_CODING_AGENT_DIR=/private/tmp/pi-web-685-agent npm test` — 1,023 passed
- `npm run lint`
- `node_modules/.bin/tsc --noEmit`
- `node --test lib/pi-web-node-args.test.mjs lib/pi-web-options.test.mjs lib/node-version.test.mjs lib/process-lifecycle.test.mjs` — 26 passed
- `node --check bin/pi-web.js`
- `node --check bin/pi-web-node-args.js`
- `NPM_CONFIG_CACHE=/private/tmp/pi-web-685-npm-cache npm pack --dry-run --ignore-scripts` — packaged helper confirmed
- `git diff --check`

## Evidence boundary

The argv behavior is covered by red/green tests and Node accepts the V8 flag locally. I do not have RISC-V hardware, so the reported target-device `SIGILL` still needs confirmation by the reporter or CI.
